### PR TITLE
Add ai-firstify plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,7 +18,6 @@
         "name": "TechWolf",
         "url": "https://techwolf.ai"
       }
-    }
     },
     {
       "name": "ai-firstify",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,7 +27,7 @@
       "category": "productivity",
       "author": {
         "name": "Jeroen Van Hautte",
-        "url": "https://techwolf.com"
+        "url": "https://techwolf.ai"
       }
     }
   ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -19,5 +19,16 @@
         "url": "https://techwolf.ai"
       }
     }
+    },
+    {
+      "name": "ai-firstify",
+      "description": "AI-first project auditor and re-engineer based on the 9 design principles and 7 design patterns from the TechWolf AI-First Bootcamp",
+      "source": "./plugins/ai-firstify",
+      "category": "productivity",
+      "author": {
+        "name": "Jeroen Van Hautte",
+        "url": "https://techwolf.com"
+      }
+    }
   ]
 }

--- a/plugins/ai-firstify/.claude-plugin/plugin.json
+++ b/plugins/ai-firstify/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "ai-firstify",
+  "version": "1.0.0",
+  "description": "AI-first project auditor and re-engineer based on the 9 design principles and 7 design patterns from the TechWolf AI-First Bootcamp",
+  "author": { "name": "Jeroen Van Hautte", "email": "jeroen@techwolf.ai" },
+  "keywords": ["ai-first", "audit", "principles", "patterns", "bootcamp"]
+}

--- a/plugins/ai-firstify/README.md
+++ b/plugins/ai-firstify/README.md
@@ -1,0 +1,37 @@
+# ai-firstify
+
+AI-first project auditor and re-engineer based on the 9 design principles and 7 design patterns from the [TechWolf AI-First Bootcamp](https://ai-first.techwolf.ai).
+
+## Install
+
+```bash
+# Add the TechWolf marketplace (once)
+/plugin marketplace add techwolf-ai/ai-first-toolkit
+
+# Install the plugin
+/plugin install ai-firstify@techwolf-ai-first
+```
+
+## Usage
+
+The skill triggers automatically when you ask Claude Code to:
+
+- **Audit** a project: "review", "audit", "analyze", "assess"
+- **Re-Engineer** a project: "ai-firstify", "fix", "improve", "transform"
+- **Bootstrap** a new project: "start", "new project", "bootstrap", "build from scratch"
+
+Or invoke directly:
+
+```
+/ai-firstify
+```
+
+## Modes
+
+1. **Audit** -- Read-only analysis across 7 dimensions with a scored report
+2. **Re-Engineer** -- Full audit followed by active fixes in 7 phases
+3. **Bootstrap** -- Interactive new project setup with discovery questions
+
+## Author
+
+Jeroen Van Hautte ([TechWolf](https://techwolf.ai))

--- a/plugins/ai-firstify/skills/ai-firstify/SKILL.md
+++ b/plugins/ai-firstify/skills/ai-firstify/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: ai-firstify
+description: "Analyze, re-engineer, or bootstrap projects to align with AI-first design principles. Use when asked to review, audit, improve, 'ai-firstify', or start a new project. Performs deep analysis across 7 dimensions, actively restructures existing projects, or guides new project setup through discovery questions. Based on the 9 design principles and 7 design patterns from the TechWolf AI-First Bootcamp."
+---
+
+# AI-Firstify
+
+Analyze and re-engineer projects to align with AI-first design principles.
+
+## Trigger
+
+Use this skill when asked to:
+- **Audit mode** (read-only): "review", "audit", "analyze", "check", "assess"
+- **Re-engineer mode** (active changes): "ai-firstify", "fix", "improve", "re-engineer", "transform"
+- **Bootstrap mode** (new project): "start", "new project", "bootstrap", "set up", "build from scratch"
+
+## Mode 1: Audit (Read-Only Analysis)
+
+Perform a comprehensive read-only analysis across 7 dimensions. Output a scored report with recommendations. Do NOT modify any files.
+
+Read **references/mode-audit.md** for the full audit procedure and dimension checklist.
+
+## Mode 2: Re-Engineer (Active Transformation)
+
+First, perform the full audit (Mode 1). Then actively fix issues in 7 phases: foundation, de-agentification, skill extraction, complexity reduction, context hygiene, safety hardening, workflow optimization.
+
+Read **references/mode-reengineer.md** for the full re-engineering procedure.
+
+## Mode 3: Bootstrap (New Project Setup)
+
+Guide the user through setting up a new AI-first project from scratch. Interactive -- ask discovery questions, recommend architecture, scaffold, and test.
+
+Read **references/mode-bootstrap.md** for the full bootstrap procedure.
+
+## Reference Files
+
+Domain knowledge (load on demand per dimension):
+
+- **references/principles.md** -- All 9 AI-first design principles in depth
+- **references/patterns.md** -- All 7 design patterns with implementation guidance
+- **references/anti-patterns.md** -- Common mistakes with detection patterns and fixes
+- **references/skill-architecture.md** -- How to structure skills, sub-agents, and workflows
+- **references/project-structure.md** -- Ideal project layouts, CLAUDE.md templates, .gitignore
+- **references/assessment-rubric.md** -- Scoring criteria and report template
+
+Load the relevant reference file for the dimension you are currently analyzing. Do not load all references at once -- use progressive disclosure.

--- a/plugins/ai-firstify/skills/ai-firstify/SKILL.md
+++ b/plugins/ai-firstify/skills/ai-firstify/SKILL.md
@@ -11,7 +11,7 @@ Analyze and re-engineer projects to align with AI-first design principles.
 
 Use this skill when asked to:
 - **Audit mode** (read-only): "review", "audit", "analyze", "check", "assess"
-- **Re-engineer mode** (active changes): "ai-firstify", "fix", "improve", "re-engineer", "transform"
+- **Re-Engineer mode** (active changes): "ai-firstify", "fix", "improve", "re-engineer", "transform"
 - **Bootstrap mode** (new project): "start", "new project", "bootstrap", "set up", "build from scratch"
 
 ## Mode 1: Audit (Read-Only Analysis)

--- a/plugins/ai-firstify/skills/ai-firstify/references/anti-patterns.md
+++ b/plugins/ai-firstify/skills/ai-firstify/references/anti-patterns.md
@@ -1,0 +1,284 @@
+# Anti-Patterns: Common Mistakes and How to Fix Them
+
+## Architecture Anti-Patterns
+
+### Building an Agent in a Web App
+**Severity:** RED
+
+**Description:** Deploying an LLM-powered agent inside a web application (chatbot, conversational UI, or API-driven agent). Result: "Nobody used it because it was too complex and had too little context." Switched to Claude Code skills and it worked "10 times better."
+
+**How to detect:**
+- grep for: `openai`, `anthropic`, `langchain`, `llamaindex`, `autogen`, `crewai`
+- Look for: `/api/chat`, `/api/agent`, streaming response handlers
+- Check for: prompt template files, chain/pipeline definitions
+- Scan dependencies: `package.json` or `requirements.txt` for LLM libraries
+
+**Fix procedure:**
+1. Identify what the embedded agent does (list its capabilities)
+2. Convert each capability to a Claude Code skill
+3. Create SKILL.md with prescriptive instructions
+4. Remove the agent infrastructure code
+5. Test the skills via slash commands
+
+**Relevant principles:** #5 (Don't Build Your Own Agent), #3 (Build for Yourself First)
+
+---
+
+### Over-Investing in Frontend UI
+**Severity:** YELLOW
+
+**Description:** Building React dashboards, polished UIs, or complex frontend applications for tools that are primarily used by the builder. Terminal output or a simple file is sufficient for most personal tools.
+
+**How to detect:**
+- Look for: React, Vue, Angular, Svelte in dependencies
+- Check for: multiple CSS files, component directories, UI frameworks
+- Scan for: authentication/login pages in personal tools
+- Count frontend files vs. core logic files
+
+**Fix procedure:**
+1. Identify the core functionality (what does the tool actually DO?)
+2. Replace frontend with terminal output or file output
+3. If visual output is needed, use simple HTML files (no framework)
+4. Remove frontend framework dependencies
+5. Keep the UI only if non-technical stakeholders need it
+
+**Relevant principles:** #2 (Narrow Scope), #3 (Build for Yourself First)
+
+---
+
+### Building Custom Agent Frameworks
+**Severity:** RED
+
+**Description:** Creating custom tool-calling, prompt chaining, or agent orchestration systems instead of using Claude Code's built-in capabilities.
+
+**How to detect:**
+- grep for: `tool_call`, `function_calling`, `chain`, `pipeline`, `orchestrat`
+- Look for: custom prompt template systems
+- Check for: agent state management code
+- Scan for: retry/fallback logic for LLM calls
+
+**Fix procedure:**
+1. Map custom agent capabilities to Claude Code features
+2. Replace custom tool-calling with Claude Code tools (scripts/)
+3. Replace custom chaining with skill step-by-step instructions
+4. Replace custom orchestration with sub-agents
+5. Delete the framework code
+
+**Relevant principles:** #5 (Don't Build Your Own Agent)
+
+---
+
+### Unnecessary Deployment
+**Severity:** YELLOW
+
+**Description:** Deploying applications (Docker, cloud hosting, CI/CD) for tools that could be skills. The default answer to "should I deploy?" is no.
+
+**How to detect:**
+- Look for: Dockerfile, docker-compose.yml, .github/workflows/, .gitlab-ci.yml
+- Check for: cloud configuration (AWS, GCP, Azure files)
+- Scan for: deployment scripts, infrastructure-as-code
+- Ask: does this NEED to run without a human present?
+
+**Fix procedure:**
+1. Ask: Can this be a skill instead?
+2. Ask: Can this be a static HTML page on GitLab Pages?
+3. Ask: Does this need to run without a human present?
+4. If all "no" answers: convert to a skill
+5. Remove deployment infrastructure
+
+**Relevant principles:** #3 (Build for Yourself First), #2 (Narrow Scope)
+
+---
+
+### Building Without Version Control
+**Severity:** RED
+
+**Description:** No git repository, no commits, no history. One bad prompt can destroy hours of work.
+
+**How to detect:**
+- Check for: `.git` directory (if missing, this is the anti-pattern)
+- Check for: `.gitignore` (if missing, partial anti-pattern)
+- Check git log: are there regular commits?
+
+**Fix procedure:**
+1. `git init`
+2. Create appropriate `.gitignore`
+3. `git add . && git commit -m "Initial commit"`
+4. Set up remote on GitLab
+5. Commit after every significant change
+
+**Relevant principles:** #1 (You Are Responsible)
+
+---
+
+## Workflow Anti-Patterns
+
+### Single Monolithic Prompt
+**Severity:** YELLOW
+
+**Description:** One huge prompt that tries to accomplish everything at once instead of a prescriptive skill with clear steps.
+
+**How to detect:**
+- SKILL.md with one giant paragraph of instructions
+- No numbered steps or phases
+- Mixing research, creation, and validation in one instruction
+
+**Fix procedure:**
+1. Break the prompt into distinct phases
+2. Number each step clearly
+3. Add validation checkpoints between phases
+4. Create separate sub-skills if phases are complex
+5. Test each phase independently
+
+**Relevant principles:** #2 (Narrow Scope), #4 (Start with a Plan)
+
+---
+
+### No Context Separation
+**Severity:** YELLOW
+
+**Description:** Everything in CLAUDE.md instead of using skills and references. All context loaded at once instead of progressively.
+
+**How to detect:**
+- CLAUDE.md over 500 lines
+- No .claude/skills/ directory
+- No references/ subdirectories in skills
+- SKILL.md files with inline reference material
+
+**Fix procedure:**
+1. Identify distinct workflows in CLAUDE.md
+2. Extract each into a separate skill
+3. Move reference material to references/ directories
+4. Keep CLAUDE.md as a project overview only
+5. Use progressive disclosure
+
+**Relevant principles:** #6 (Stick to the Point), #2 (Narrow Scope)
+
+---
+
+### Author Reviews Own Work
+**Severity:** YELLOW
+
+**Description:** The same agent instance that created content also reviews it. Without context isolation, the "reviewer" is biased by the creation context.
+
+**How to detect:**
+- Skills that include "review your work" as a final step without spawning a separate agent
+- No use of sub-agents for critique
+- Self-review without context isolation
+
+**Fix procedure:**
+1. Add a sub-agent review step (use Task tool)
+2. Give the reviewer a different perspective/criteria
+3. The reviewer should NOT see the creation instructions
+4. Aggregate reviewer feedback before finalizing
+
+**Relevant principles:** #3 (Feedback Loop pattern)
+
+---
+
+### No Validation
+**Severity:** YELLOW
+
+**Description:** No tools, scripts, or checks to validate output. Relying purely on hope that the LLM gets it right.
+
+**How to detect:**
+- No scripts/ directory in skills
+- No test files
+- No validation commands in SKILL.md
+- No error checking steps
+
+**Fix procedure:**
+1. Identify what "correct" looks like (rules, constraints, format)
+2. Write validation scripts for checkable rules
+3. Add validation steps to SKILL.md
+4. Use sub-agents for subjective validation
+5. Add error handling for common failures
+
+**Relevant principles:** #5 (Tools pattern), #3 (Feedback Loop pattern)
+
+---
+
+### Building for Others First
+**Severity:** YELLOW
+
+**Description:** Building multi-user tools, shared platforms, or team features before the tool works for the builder. Adding unnecessary complexity for hypothetical users.
+
+**How to detect:**
+- User management code
+- Multi-tenant database schemas
+- Role-based access control
+- "Admin panel" features
+- User onboarding flows
+
+**Fix procedure:**
+1. Strip all multi-user features
+2. Build for yourself only
+3. Use for a week
+4. Share as a skill (copy folder) if it works
+5. Only add multi-user features if there's proven demand
+
+**Relevant principles:** #3 (Build for Yourself First)
+
+---
+
+## Scope Anti-Patterns
+
+### Too Many Data Sources at Once
+**Severity:** YELLOW
+
+**Description:** Trying to integrate 50 data sources from day one instead of starting with 1-2 and expanding.
+
+**How to detect:**
+- Multiple API integrations in initial version
+- Data source configuration files with many entries
+- Complex data merging/normalization code
+
+**Fix procedure:**
+1. Identify the single most valuable data source
+2. Build the full workflow for that one source
+3. Validate it works end-to-end
+4. Add one more source at a time
+5. Refactor shared patterns as they emerge
+
+**Relevant principles:** #2 (Narrow Scope), #3 (Build for Yourself First)
+
+---
+
+### Feature Creep from Vibe Coding
+**Severity:** YELLOW
+
+**Description:** Adding features spontaneously because "it's easy" rather than because they're needed. The vibe coding trap: building is so easy that you build things nobody asked for.
+
+**How to detect:**
+- Features mentioned in code but not in CLAUDE.md or any plan
+- UI elements that serve no clear workflow
+- Code paths that aren't tested or documented
+- Multiple half-finished features
+
+**Fix procedure:**
+1. List all features in the project
+2. For each: "did someone ask for this?" and "have I used this?"
+3. Remove unused features
+4. Focus on completing one feature fully before starting the next
+
+**Relevant principles:** #2 (Narrow Scope), #4 (Start with a Plan)
+
+---
+
+### Not Using /clear
+**Severity:** YELLOW
+
+**Description:** Never clearing context, leading to stale information, confused responses, and wasted tokens.
+
+**How to detect:**
+- No evidence of task separation in git history
+- Commits that mix unrelated changes
+- Responses referencing outdated context
+
+**Fix procedure:**
+1. Use /clear when switching tasks
+2. Document key learnings in CLAUDE.md before clearing
+3. Use /compact when context is large but still relevant
+4. Start significant new tasks in empty folders
+
+**Relevant principles:** #8 (Start with a Clean Slate)

--- a/plugins/ai-firstify/skills/ai-firstify/references/assessment-rubric.md
+++ b/plugins/ai-firstify/skills/ai-firstify/references/assessment-rubric.md
@@ -93,6 +93,10 @@ find .claude/skills -name "SKILL.md" 2>/dev/null
 ls -R .claude/skills/ 2>/dev/null
 # Check skill length
 wc -l .claude/skills/*/SKILL.md 2>/dev/null
+# Check skill prescriptiveness (should have numbered steps)
+grep -c "^[0-9]" .claude/skills/*/SKILL.md 2>/dev/null
+# Check for progressive disclosure (references/ dirs)
+find .claude/skills -name "references" -type d 2>/dev/null
 ```
 
 ---
@@ -225,7 +229,7 @@ git log --oneline --since="1 week ago" 2>/dev/null | wc -l
 ## Report Template
 
 ```markdown
-# Jeroenify Assessment Report
+# AI-Firstify Assessment Report
 
 **Project:** [project name]
 **Date:** [date]

--- a/plugins/ai-firstify/skills/ai-firstify/references/assessment-rubric.md
+++ b/plugins/ai-firstify/skills/ai-firstify/references/assessment-rubric.md
@@ -1,0 +1,283 @@
+# Assessment Rubric
+
+## Scoring Criteria
+
+Each dimension is scored as GREEN (good), YELLOW (needs improvement), or RED (critical issue).
+
+---
+
+### Dimension 1: Project Structure
+
+**GREEN:**
+- CLAUDE.md exists and is well-structured (under 200 lines)
+- .gitignore exists and excludes sensitive files
+- Git is initialized with regular commits
+- Files are organized logically
+
+**YELLOW:**
+- CLAUDE.md exists but is too long or unfocused
+- .gitignore exists but is incomplete
+- Git exists but commits are infrequent
+- Some organizational issues
+
+**RED:**
+- No CLAUDE.md
+- No .gitignore
+- No git
+- Files are disorganized (50+ files in root)
+
+**Detection commands:**
+```bash
+# Check CLAUDE.md
+test -f CLAUDE.md && wc -l CLAUDE.md
+# Check .gitignore
+test -f .gitignore && cat .gitignore
+# Check git
+test -d .git && git log --oneline -5
+# Count root files
+ls -1 | wc -l
+```
+
+---
+
+### Dimension 2: Agent Architecture
+
+**GREEN:**
+- No embedded agents (no LLM API calls in app code)
+- Sub-agents used appropriately via Claude Code
+- No custom agent frameworks
+
+**YELLOW:**
+- Some LLM API calls but for valid reasons (e.g., batch processing via API)
+- Partial migration from embedded agent to skills
+
+**RED:**
+- Full embedded agent in a web app
+- Custom agent framework
+- LLM API calls for core functionality
+
+**Detection commands:**
+```bash
+# Check for LLM libraries
+grep -r "openai\|anthropic\|langchain\|llamaindex\|autogen\|crewai" --include="*.py" --include="*.js" --include="*.ts" -l
+# Check for API keys
+grep -r "OPENAI_API_KEY\|ANTHROPIC_API_KEY\|api_key" --include="*.py" --include="*.js" --include="*.env" -l
+# Check for agent patterns
+grep -r "chat/completions\|messages.create\|AgentExecutor\|ChatOpenAI" --include="*.py" --include="*.js" -l
+```
+
+---
+
+### Dimension 3: Skill Usage
+
+**GREEN:**
+- Skills exist in .claude/skills/
+- Skills are well-structured (SKILL.md + references/ + scripts/)
+- Skills are prescriptive (step-by-step)
+- Progressive disclosure used
+
+**YELLOW:**
+- Some skills exist but are poorly structured
+- Skills are vague (not prescriptive)
+- No references/ or scripts/
+
+**RED:**
+- No skills despite repeated workflows
+- No .claude/ directory
+
+**Detection commands:**
+```bash
+# Check for skills
+find .claude/skills -name "SKILL.md" 2>/dev/null
+# Check skill structure
+ls -R .claude/skills/ 2>/dev/null
+# Check skill length
+wc -l .claude/skills/*/SKILL.md 2>/dev/null
+```
+
+---
+
+### Dimension 4: Scope & Complexity
+
+**GREEN:**
+- Project does one thing well
+- No unnecessary frontend (or frontend is warranted)
+- No over-engineered infrastructure
+- Clear, focused CLAUDE.md
+
+**YELLOW:**
+- Some scope creep (2-3 extra features)
+- Frontend exists but may not be necessary
+- Some unnecessary complexity
+
+**RED:**
+- Project tries to do too many things
+- Full React/Vue/Angular app for a personal tool
+- Unnecessary databases, auth, deployment pipelines
+- Features nobody asked for
+
+**Detection commands:**
+```bash
+# Check for heavy frontend frameworks
+grep -r "react\|vue\|angular\|svelte" package.json 2>/dev/null
+# Check for databases
+grep -r "mongoose\|sequelize\|prisma\|typeorm\|sqlite3\|pg " package.json requirements.txt 2>/dev/null
+# Check for auth
+grep -r "passport\|jwt\|bcrypt\|auth0\|firebase-auth" package.json requirements.txt 2>/dev/null
+# Count files (complexity indicator)
+find . -type f -not -path './.git/*' -not -path './node_modules/*' | wc -l
+```
+
+---
+
+### Dimension 5: Context Hygiene
+
+**GREEN:**
+- CLAUDE.md under 200 lines and well-organized
+- Skills use progressive disclosure
+- Reference material in references/ directories
+- No context pollution
+
+**YELLOW:**
+- CLAUDE.md is 200-500 lines
+- Some inline reference material in SKILL.md
+- Minor organizational issues
+
+**RED:**
+- CLAUDE.md over 500 lines
+- All context in one file
+- No progressive disclosure
+- Context pollution (unrelated concerns mixed)
+
+**Detection commands:**
+```bash
+# CLAUDE.md length
+wc -l CLAUDE.md 2>/dev/null
+# SKILL.md lengths
+wc -l .claude/skills/*/SKILL.md 2>/dev/null
+# Check for references directories
+find .claude -name "references" -type d 2>/dev/null
+```
+
+---
+
+### Dimension 6: Safety
+
+**GREEN:**
+- No credentials in code
+- .gitignore excludes sensitive files
+- Read-only access where possible
+- Human-in-the-loop for external actions
+
+**YELLOW:**
+- .gitignore exists but may miss some sensitive files
+- Some external actions without explicit approval
+
+**RED:**
+- Credentials in code or config files
+- No .gitignore
+- Write access to production systems without approval
+- Automated external actions without human review
+
+**Detection commands:**
+```bash
+# Check for hardcoded secrets
+grep -r "password\|secret\|token\|api_key" --include="*.py" --include="*.js" --include="*.ts" --include="*.json" -l 2>/dev/null | grep -v node_modules | grep -v package-lock
+# Check for .env files in git
+git ls-files | grep -i "\.env"
+# Check .gitignore for common exclusions
+grep -c "\.env\|credentials\|\.pem\|api_key" .gitignore 2>/dev/null
+```
+
+---
+
+### Dimension 7: Workflow Design
+
+**GREEN:**
+- Workflows are prescriptive (step-by-step in skills)
+- Sub-agents used for review/critique
+- Validation tools/scripts exist
+- Proper git commit discipline
+
+**YELLOW:**
+- Some workflows are prescriptive
+- No sub-agent review but manual review exists
+- Partial validation
+
+**RED:**
+- No prescriptive workflows
+- No review process
+- No validation
+- No git discipline
+
+**Detection commands:**
+```bash
+# Check for validation scripts
+find . -name "validate*" -o -name "check*" -o -name "test*" 2>/dev/null | grep -v node_modules
+# Check SKILL.md for numbered steps
+grep -c "^[0-9]" .claude/skills/*/SKILL.md 2>/dev/null
+# Check git commit frequency
+git log --oneline --since="1 week ago" 2>/dev/null | wc -l
+```
+
+---
+
+## Report Template
+
+```markdown
+# Jeroenify Assessment Report
+
+**Project:** [project name]
+**Date:** [date]
+**Mode:** [Audit / Re-engineer]
+
+## Overall Score
+
+| Dimension | Score | Summary |
+|-----------|-------|---------|
+| 1. Project Structure | [GREEN/YELLOW/RED] | [one-line summary] |
+| 2. Agent Architecture | [GREEN/YELLOW/RED] | [one-line summary] |
+| 3. Skill Usage | [GREEN/YELLOW/RED] | [one-line summary] |
+| 4. Scope & Complexity | [GREEN/YELLOW/RED] | [one-line summary] |
+| 5. Context Hygiene | [GREEN/YELLOW/RED] | [one-line summary] |
+| 6. Safety | [GREEN/YELLOW/RED] | [one-line summary] |
+| 7. Workflow Design | [GREEN/YELLOW/RED] | [one-line summary] |
+
+## Priority Recommendations
+
+1. **[HIGH]** [recommendation] -- [estimated effort]
+2. **[HIGH]** [recommendation] -- [estimated effort]
+3. **[MEDIUM]** [recommendation] -- [estimated effort]
+4. **[LOW]** [recommendation] -- [estimated effort]
+
+## Detailed Findings
+
+### Dimension 1: Project Structure
+[Detailed findings, specific files, what's good, what needs work]
+
+### Dimension 2: Agent Architecture
+[Detailed findings...]
+
+[...continue for all 7 dimensions...]
+
+## Changes Made (Re-engineer mode only)
+
+| Action | File | Description |
+|--------|------|-------------|
+| Created | CLAUDE.md | Project context file |
+| Created | .gitignore | Standard exclusions |
+| Created | .claude/skills/[name]/SKILL.md | Extracted workflow |
+| Deleted | src/agent/ | Removed embedded agent |
+| Modified | package.json | Removed LLM dependencies |
+
+## Still Needs Human Decision
+
+- [ ] [Decision needed about X]
+- [ ] [Decision needed about Y]
+
+## Recommended Next Steps
+
+1. [Next step]
+2. [Next step]
+3. [Next step]
+```

--- a/plugins/ai-firstify/skills/ai-firstify/references/mode-audit.md
+++ b/plugins/ai-firstify/skills/ai-firstify/references/mode-audit.md
@@ -1,0 +1,57 @@
+# Mode 1: Audit (Read-Only Analysis)
+
+Perform a comprehensive analysis across 7 dimensions. Output a detailed report with scores and recommendations. Do NOT modify any files.
+
+## Step 1: Scan the project
+- Read CLAUDE.md (if it exists)
+- List all files and directories
+- Check for .git, .gitignore, .claude/skills/
+- Identify the tech stack, languages, and frameworks
+
+## Step 2: Analyze each dimension
+
+**Dimension 1: Project Structure**
+- Does CLAUDE.md exist? Is it well-structured and under 500 lines?
+- Is there a .gitignore? Does it exclude sensitive files?
+- Is git initialized with recent commits?
+- Is the project organized as a monorepository (code + data + skills together)?
+
+**Dimension 2: Agent Architecture**
+- Are there embedded agents? (Look for: LLM API calls, custom agent frameworks, deployed chatbots, prompt chaining libraries)
+- Read references/anti-patterns.md for detection patterns
+- Are sub-agents used appropriately within Claude Code?
+
+**Dimension 3: Skill Usage**
+- Do skills exist in .claude/skills/?
+- Are they well-structured? (SKILL.md with frontmatter, references/, scripts/)
+- Are repeated workflows captured as skills?
+- Read references/skill-architecture.md for best practices
+
+**Dimension 4: Scope & Complexity**
+- Is there unnecessary UI/frontend? (Terminal-first check)
+- Are there over-engineered systems? (Unnecessary databases, auth, deployment pipelines)
+- Does the project try to do too many things at once?
+
+**Dimension 5: Context Hygiene**
+- Is CLAUDE.md focused and well-structured?
+- Are large reference documents in separate files (not inlined in CLAUDE.md)?
+- Do skills use progressive disclosure (SKILL.md links to references/)?
+- Is there context pollution (too many unrelated things in one folder)?
+
+**Dimension 6: Safety**
+- Are there credentials in code, config, or environment files?
+- Does .gitignore exclude .env, credentials, API keys?
+- For data tools: is access read-only where possible?
+- Is there human-in-the-loop before external actions?
+
+**Dimension 7: Workflow Design**
+- Are workflows prescriptive (step-by-step)?
+- Is there separation between creation and review (sub-agent reviewers)?
+- Are there validation tools/scripts for critical operations?
+- Is git commit discipline in place?
+
+## Step 3: Generate report
+Read references/assessment-rubric.md for scoring criteria and report template. Output a structured report with:
+- Overall score (green/yellow/red for each dimension)
+- Priority-ordered recommendations
+- Specific files/patterns that need attention

--- a/plugins/ai-firstify/skills/ai-firstify/references/mode-bootstrap.md
+++ b/plugins/ai-firstify/skills/ai-firstify/references/mode-bootstrap.md
@@ -1,0 +1,105 @@
+# Mode 3: Bootstrap (New Project Setup)
+
+Guide the user through setting up a new AI-first project from scratch. This mode is interactive -- ask questions, do discovery, and build the right foundation.
+
+## Phase 1: Discovery (Ask Questions)
+
+Ask the user these questions one at a time. Don't overwhelm -- ask 2-3, then follow up based on answers.
+
+**Problem definition:**
+1. What specific problem are you trying to solve? (One sentence)
+2. Who benefits? (Start with "me" -- build for yourself first)
+3. What does "done" look like? What's the concrete output?
+4. How will you measure impact? (Time saved, quality improved, tasks completed)
+
+**Scope narrowing:**
+5. Have you done this task manually before? How many times? (Three Times Rule check)
+6. What data sources do you need? (Start with 1-2, not all of them)
+7. Do you need a UI, or is terminal/file output sufficient? (Terminal-first check)
+8. Should this be a skill, a content studio, or a standalone tool?
+
+**Architecture decisions:**
+9. Does this need to run without you present? (Deployment check -- if no, make it a skill)
+10. Do you need to search external systems? (MCP connections: Slack, Notion, Atlassian?)
+11. Will this involve multiple phases? (Research -> create -> review = sub-agent opportunity)
+12. Are there quality criteria that can be checked automatically? (Validation tools)
+
+## Phase 2: Architecture Recommendation
+
+Based on the answers, recommend one of these architectures:
+
+**Simple Skill** (most common -- default to this)
+- Single SKILL.md with step-by-step instructions
+- Optional references/ for domain knowledge
+- Optional scripts/ for validation
+- Lives in .claude/skills/ of an existing project or ~/.claude/skills/ for cross-project
+
+**Multi-Skill Workflow**
+- Multiple skills that chain together (research -> create -> review)
+- Sub-agents for review/critique
+- Shared references/ across skills
+- Lives in a dedicated project folder
+
+**Content Studio**
+- Express.js backend + HTML frontend + content/ folder
+- Skill for content creation with style guide
+- Validation tools
+- Best for: ongoing content creation in a specific domain
+
+**Data/Analysis Tool**
+- Skill with MCP connections (Slack, databases, APIs)
+- Read-only data access where possible
+- Output to files or terminal
+- Best for: investigation, search, aggregation tasks
+
+Present the recommendation with reasoning. Wait for user approval before building.
+
+## Phase 3: Scaffold the Project
+
+After the user approves the architecture:
+
+1. **Create the project folder** (if not already in one)
+   - Ask the user where they want to create it, or use the current directory
+
+2. **Initialize git**
+   ```bash
+   git init
+   ```
+
+3. **Create .gitignore** (read references/project-structure.md for templates)
+
+4. **Create CLAUDE.md** using the template from references/project-structure.md, filled with the user's answers from Phase 1
+
+5. **Create the skill structure**
+   ```
+   .claude/skills/[skill-name]/
+   ├── SKILL.md
+   ├── references/
+   └── scripts/
+   ```
+
+6. **Write SKILL.md** with prescriptive step-by-step instructions based on the user's workflow description
+
+7. **Add validation** if quality criteria were identified in Phase 1
+
+8. **Initial commit**
+   ```bash
+   git add . && git commit -m "Initial project setup with CLAUDE.md and [skill-name] skill"
+   ```
+
+## Phase 4: First Run
+
+After scaffolding:
+1. Run the skill via its slash command to test it
+2. Review the output with the user
+3. Iterate on the SKILL.md based on what worked and what didn't
+4. Commit improvements
+5. Suggest next steps (add references, add more validation, expand scope gradually)
+
+## Key Principles to Apply During Bootstrap
+
+- **Narrow Scope:** Start with the smallest useful version. One feature, one data source.
+- **Build for Yourself:** No auth, no multi-user, no deployment. Build for localhost/terminal.
+- **Terminal-First:** Default to file/terminal output. Only add UI if the user specifically needs it.
+- **Plan Before Build:** The discovery phase IS the plan. Don't skip it.
+- **Three Times Rule:** If they haven't done it manually at least twice, they might not know what they actually need. Suggest doing it manually first and documenting the steps.

--- a/plugins/ai-firstify/skills/ai-firstify/references/mode-reengineer.md
+++ b/plugins/ai-firstify/skills/ai-firstify/references/mode-reengineer.md
@@ -1,0 +1,55 @@
+# Mode 2: Re-Engineer (Active Transformation)
+
+First, perform the full audit (read references/mode-audit.md). Then execute fixes in phases:
+
+## Phase 1: Foundation
+- Create or rewrite CLAUDE.md (read references/project-structure.md for template)
+- Create .gitignore if missing (read references/project-structure.md for templates)
+- Initialize git if not present (`git init` + initial commit)
+- Restructure into monorepository if code/content/skills are scattered
+
+## Phase 2: De-agentification
+- Scan for embedded agent patterns (read references/anti-patterns.md for detection)
+- For each found: propose replacement with Claude Code skills + sub-agents
+- After user approval, remove agent infrastructure code
+- Remember: "deployed an agent in a web app that nobody used because it was too complex and had too little context -- switched to Claude Code and it worked 10 times better"
+
+## Phase 3: Skill Extraction
+- Identify repeated workflows (scripts run multiple times, similar prompt patterns, recurring data transformations)
+- Extract each into a proper skill in `.claude/skills/`
+- Create SKILL.md with prescriptive step-by-step instructions
+- Add validation tools (scripts/) where deterministic behavior is needed
+- Add reference files where domain knowledge is needed
+- Check if Anthropic pre-built skills could replace custom code
+
+## Phase 4: Complexity Reduction
+- Identify unnecessary UI/frontend (terminal-first check)
+- Flag over-engineered infrastructure
+- Propose simplifications: flat files over databases, skills over web apps, HTML output over React dashboards
+- Remove features nobody asked for
+
+## Phase 5: Context Hygiene
+- Audit CLAUDE.md: is it focused? Under 500 lines? Well-structured?
+- Move large reference documents from CLAUDE.md to separate files
+- Ensure skills use progressive disclosure
+- Check for context pollution
+
+## Phase 6: Safety Hardening
+- Scan for credentials in code, config, or environment files
+- Check .gitignore excludes sensitive files
+- For data tools: verify read-only access where possible
+- Check for human-in-the-loop before external actions
+- Add validation scripts for critical operations
+
+## Phase 7: Workflow Optimization
+- Make workflows prescriptive (step-by-step instructions in skills)
+- Add sub-agents for review/critique tasks
+- Add feedback loops: validation tools, test scripts, self-checking
+- Set up proper git commit discipline
+
+## Final: Generate Summary Report
+After re-engineering, output:
+- What was found (per dimension, with scores)
+- What was changed (specific files created/modified/deleted)
+- What still needs human decision (architectural choices, scope questions)
+- Recommended next steps

--- a/plugins/ai-firstify/skills/ai-firstify/references/patterns.md
+++ b/plugins/ai-firstify/skills/ai-firstify/references/patterns.md
@@ -1,0 +1,219 @@
+# The 7 AI-First Design Patterns
+
+## Pattern 1: One-Shotting
+
+**Summary:** Minimal prompt, maximum freedom. Good for inspiration and gauging difficulty.
+
+**Description:** Give a minimal prompt and let the AI run freely. No constraints, no detailed specifications -- just an idea and maximum creative freedom. One-shotting also works as a difficulty gauge: if the AI nails it in one shot, the task was straightforward. If it struggles, you need more specificity.
+
+**When to use:**
+- Inspiration and exploration
+- Prototyping and proof of concepts
+- Gauging task difficulty before investing in detailed specs
+- Creative work where surprise is welcome
+
+**When NOT to use:**
+- Production work requiring specific outcomes
+- Workflows that need consistency across runs
+- Tasks with strict format/quality requirements
+
+**Implementation checklist:**
+- [ ] Single prompt, no multi-step instructions
+- [ ] Let the agent choose its own approach
+- [ ] Review output as a difficulty gauge
+- [ ] If good: task is simple, might not need a skill
+- [ ] If poor: task needs more structure, consider a skill
+
+---
+
+## Pattern 2: Monorepository
+
+**Summary:** Code + data + skills in one Git repo. The agent sees everything.
+
+**Description:** Keep all related code, data, skills, and configuration in a single Git repository. The AI works best when everything is in one place -- it can see the full picture and make changes that span code and content.
+
+**When to use:**
+- Any project with code AND content/data
+- Content studios
+- Projects with skills and tools
+- Any setup where the agent needs to see the full picture
+
+**When NOT to use:**
+- Truly independent projects that share nothing
+- Massive repositories where context window would overflow
+
+**Implementation checklist:**
+- [ ] Single git repo for code + content + skills
+- [ ] CLAUDE.md at the root describing the project
+- [ ] .claude/skills/ for project-specific skills
+- [ ] Content/data files alongside code
+- [ ] .gitignore for node_modules, .env, etc.
+
+**Example structure:**
+```
+my-project/
+├── CLAUDE.md
+├── .gitignore
+├── package.json
+├── src/                  # Application code
+├── content/              # Content/data files
+├── .claude/
+│   └── skills/
+│       └── my-skill/
+│           ├── SKILL.md
+│           ├── references/
+│           └── scripts/
+└── docs/                 # Documentation
+```
+
+---
+
+## Pattern 3: Feedback Loop
+
+**Summary:** Agent tests its own work: unit tests, sub-agent critique, self-testing.
+
+**Description:** Set up mechanisms for the agent to test its own work and iterate. Three types: unit tests (agent writes tests then code to pass them), sub-agent critique (one agent creates, another reviews), and self-testing (agent runs its output and checks for errors).
+
+**When to use:**
+- Content generation requiring quality control
+- Code that needs validation
+- Any workflow where output quality varies
+- Multi-step processes where early errors compound
+
+**When NOT to use:**
+- Simple one-shot tasks
+- Tasks where human review is the feedback loop
+- Trivial operations that can't really fail
+
+**Implementation checklist:**
+- [ ] Validation script in scripts/ (for deterministic checks)
+- [ ] Sub-agent reviewer for subjective quality (use Task tool)
+- [ ] Test suite for code outputs
+- [ ] Self-checking step at end of skill workflow
+- [ ] Error handling that retries with modified approach
+
+---
+
+## Pattern 4: Content Plus Form
+
+**Summary:** Known template + custom content. Template provides structure, content provides uniqueness.
+
+**Description:** Use a known format or template and fill it with custom content. This is how the Flappy Bird demo worked: the "form" is a Flappy Bird game (well-known template), the "content" is a PDF about TechWolf. Result: a themed Flappy Bird game.
+
+**When to use:**
+- Creating content in a known format (emails, reports, memos)
+- Building apps with well-known UI patterns (dashboards, landing pages)
+- Gamification of existing content
+- Any time you have a template + unique data
+
+**When NOT to use:**
+- Truly novel creations without precedent
+- Tasks where the format itself needs to be designed
+
+**Implementation checklist:**
+- [ ] Identify the "form" (template, known format, existing design)
+- [ ] Identify the "content" (unique data, custom information)
+- [ ] Provide the form as a reference file or example
+- [ ] Provide the content as input or from a data source
+- [ ] Let the agent combine them
+
+---
+
+## Pattern 5: Tools
+
+**Summary:** Deterministic scripts. Use when you need exact, repeatable behavior.
+
+**Description:** Give the agent access to deterministic scripts it can run. While the LLM is probabilistic (slightly different output each time), a tool always does exactly the same thing. Create tools not because the agent can't do it, but because you want it done in one specific way.
+
+**When to use:**
+- Getting current date/time
+- Reading existing content for consistency
+- Validation against rules
+- Data transformations that must be exact
+- File format conversions
+
+**When NOT to use:**
+- Creative tasks requiring flexibility
+- Tasks where the approach should vary
+- Simple operations the agent handles natively
+
+**Implementation checklist:**
+- [ ] Script in scripts/ directory (bash or Python)
+- [ ] Script is executable (chmod +x)
+- [ ] Script has clear input/output contract
+- [ ] Script is referenced in SKILL.md
+- [ ] Script handles errors gracefully
+
+**Example:**
+```bash
+#!/bin/bash
+# scripts/validate.sh -- Validates content against rules
+FILE="$1"
+if [ -z "$FILE" ]; then echo "Usage: validate.sh <file>"; exit 1; fi
+# Check specific rules...
+echo "PASS: Content is valid"
+```
+
+---
+
+## Pattern 6: Agent Skills
+
+**Summary:** Instruction files in .claude/skills/. Loaded on demand via slash commands.
+
+**Description:** Skills are text files that load contextual instructions into the agent on demand. They live in .claude/skills/ and are activated via slash commands. A skill typically contains: a description, instructions, reference examples, and tools.
+
+**When to use:**
+- Repeated workflows (the Three Times Rule)
+- Domain-specific knowledge needed on demand
+- Complex multi-step procedures
+- Workflows that need consistency across runs
+
+**When NOT to use:**
+- One-time tasks
+- Simple operations that don't need instructions
+- Tasks where every run should be different
+
+**Implementation checklist:**
+- [ ] SKILL.md with frontmatter (name, description)
+- [ ] Step-by-step prescriptive instructions
+- [ ] references/ for domain knowledge and examples
+- [ ] scripts/ for deterministic tools
+- [ ] Progressive disclosure (SKILL.md links to references/)
+
+**Skill anatomy:**
+```
+.claude/skills/my-skill/
+├── SKILL.md              # Main instructions (lean, prescriptive)
+├── references/           # Domain knowledge, examples, templates
+│   ├── style-guide.md
+│   └── examples.md
+└── scripts/              # Deterministic tools
+    ├── validate.sh
+    └── read-all.sh
+```
+
+---
+
+## Pattern 7: Sub-Agents
+
+**Summary:** Parallel, independent workers. Great for batch processing.
+
+**Description:** Break large tasks into parallel, independent workers. Each sub-agent gets a specific prompt and isolated context, works independently, and reports back. Sub-agents can use skills and spawn their own sub-agents (but don't nest too deep).
+
+**When to use:**
+- Batch processing (same task, different inputs)
+- Research tasks (isolated investigation, produce report)
+- Review/critique (separate instance reviews, fresh perspective)
+- Parallel data processing
+
+**When NOT to use:**
+- Tasks requiring shared state between workers
+- Sequential workflows where order matters
+- Simple tasks that don't benefit from parallelism
+
+**Implementation checklist:**
+- [ ] Clear, self-contained prompt for each sub-agent
+- [ ] Isolated context (sub-agent doesn't see main conversation)
+- [ ] Defined output format for results
+- [ ] Aggregation strategy for combining results
+- [ ] Read-only or read-write settings as appropriate

--- a/plugins/ai-firstify/skills/ai-firstify/references/principles.md
+++ b/plugins/ai-firstify/skills/ai-firstify/references/principles.md
@@ -114,7 +114,9 @@
 
 **Summary:** Use Claude Code. It improves automatically. Your custom agent won't.
 
-**Description:** You already have an agent with tools, research, and coding abilities. Building agent infrastructure in your applications is almost never the right choice. Your custom agent will never be as smart, bulletproof, or flexible as maintained agents like Claude Code. As models improve, Claude Code improves automatically -- your custom agent stays stuck in time. Important clarification: sub-agents WITHIN Claude Code are fine and encouraged. "When we say don't build your own agent, we mean don't build a web app with an agent in it."
+**Description:** You already have an agent with tools, research, and coding abilities. Building agent infrastructure in your applications is almost never the right choice. Your custom agent will never be as smart, bulletproof, or flexible as maintained agents like Claude Code. As models improve, Claude Code improves automatically -- your custom agent stays stuck in time.
+
+> **Important:** Sub-agents WITHIN Claude Code (e.g., using the Agent tool, TeamCreate, or sub-agent patterns in skills) are fine and encouraged. "Don't build your own agent" means don't build a web app or deployed service with an embedded LLM agent. Using Claude Code's built-in multi-agent capabilities is the recommended approach.
 
 **When it applies:** Whenever you're tempted to add LLM API calls to your application. When designing system architecture. When choosing between skills and deployed agents.
 
@@ -187,7 +189,7 @@
 - No examples provided in skill instructions
 
 **How to fix:**
-- Use Voice Ink for richer, more detailed prompts
+- Use VoiceInk for richer, more detailed prompts
 - Add reference files with examples and style guides
 - Include step-by-step procedures in skills
 - Provide context about why, not just what

--- a/plugins/ai-firstify/skills/ai-firstify/references/principles.md
+++ b/plugins/ai-firstify/skills/ai-firstify/references/principles.md
@@ -1,0 +1,245 @@
+# The 9 AI-First Design Principles
+
+## Principle 1: You Are Responsible
+
+**Summary:** You are the pilot. AI is your co-pilot. Your name is on everything it produces.
+
+**Description:** Think of yourself as a pilot. The AI is your autopilot -- it handles a lot of the flying, but you are always responsible for the plane and everyone on it. Whether the AI wrote the email, generated the report, or built the tool -- your name is on it. This applies especially to automated systems. If you build something that runs unattended and it makes mistakes, that is on you -- even if the AI caused the error.
+
+**When it applies:** Always. Every interaction with AI tools. Especially when outputs are shared with others or when automated systems run without human oversight.
+
+**Common violations:**
+- Sharing AI-generated content without reviewing it
+- Building automated pipelines without human review steps
+- Blaming AI for mistakes in outputs you distributed
+- Running unattended agents that post to Slack, send emails, or modify data
+
+**How to detect in code:**
+- Look for automated posting/sending without approval gates
+- Check for scheduled/cron AI tasks without review checkpoints
+- Scan for API calls that write to external systems without confirmation
+
+**How to fix:**
+- Add human-in-the-loop review before any external action
+- Add approval gates before automated distribution
+- Log all AI-generated outputs for audit trail
+- Review all outputs before sharing
+
+---
+
+## Principle 2: Narrow Scope
+
+**Summary:** Define narrow goals. Avoid complexity creep from vibe coding. One task at a time.
+
+**Description:** LLMs perform worse when given too many tasks at once. They are like a brilliant but easily distracted junior colleague -- give them one clear task and they will excel. Pile on five things and quality drops everywhere. The empty folder approach: start each significant task in a fresh, empty folder.
+
+**When it applies:** Every time you give instructions to an agent. When designing skills. When scoping projects.
+
+**Common violations:**
+- Skills that try to do 10 things at once
+- CLAUDE.md files that describe the entire organization
+- Prompts that ask for multiple unrelated outputs
+- Projects that mix too many concerns in one folder
+
+**How to detect in code:**
+- CLAUDE.md longer than 500 lines
+- Skills with more than 15 steps
+- Folders with more than 50 files at the same level
+- Single prompts/skills that mention multiple unrelated domains
+
+**How to fix:**
+- Split multi-concern skills into focused single-purpose skills
+- Use the empty folder approach for new tasks
+- Keep CLAUDE.md under 200 lines (ideally under 100)
+- One skill = one workflow
+
+---
+
+## Principle 3: Build for Yourself First
+
+**Summary:** Build for yourself before others. Use it daily. Then share what works.
+
+**Description:** Do not build tools for others until you have built them for yourself. When you use your own tool daily, you discover what actually matters and what is unnecessary fluff. Usage is not a good metric for impact -- a Pokemon game has lots of usage but doesn't solve a business problem.
+
+**When it applies:** Starting any new project. Deciding whether to share a tool. Prioritizing features.
+
+**Common violations:**
+- Building multi-user apps before using the tool yourself
+- Adding login/auth systems for a personal tool
+- Building deployment pipelines before the tool works locally
+- Designing for "the team" before solving your own problem
+
+**How to detect in code:**
+- Auth/login systems in personal tools
+- Multi-user database schemas
+- Deployment configurations (Docker, k8s, CI/CD) for tools nobody uses yet
+- User management features
+
+**How to fix:**
+- Strip auth and multi-user features
+- Build for localhost first
+- Use for a week yourself before considering sharing
+- Share as a skill (copy the folder) rather than deploying
+
+---
+
+## Principle 4: Start with a Plan
+
+**Summary:** Shift+Tab before building. Planning is cheaper than rebuilding.
+
+**Description:** Before building anything substantial, enter plan mode. Claude Code will research, ask clarifying questions, propose a file structure and approach, and wait for your approval before writing code. You can iterate on the plan before a single line of code is written.
+
+**When it applies:** Any non-trivial task. New projects. Feature additions. Refactoring.
+
+**Common violations:**
+- Jumping straight into coding without planning
+- Not using plan mode for multi-file changes
+- Building before understanding the requirements
+- Skipping the design phase for skills
+
+**How to detect in code:**
+- No CLAUDE.md (suggests no planning phase)
+- Messy file structure (suggests organic growth without planning)
+- Multiple failed attempts visible in git history
+- Skills without clear step-by-step instructions
+
+**How to fix:**
+- Always use Shift+Tab or /plan before building
+- Write a brief plan in CLAUDE.md before starting
+- Invest 15-30 minutes in planning before any build session
+
+---
+
+## Principle 5: Don't Build Your Own Agent
+
+**Summary:** Use Claude Code. It improves automatically. Your custom agent won't.
+
+**Description:** You already have an agent with tools, research, and coding abilities. Building agent infrastructure in your applications is almost never the right choice. Your custom agent will never be as smart, bulletproof, or flexible as maintained agents like Claude Code. As models improve, Claude Code improves automatically -- your custom agent stays stuck in time. Important clarification: sub-agents WITHIN Claude Code are fine and encouraged. "When we say don't build your own agent, we mean don't build a web app with an agent in it."
+
+**When it applies:** Whenever you're tempted to add LLM API calls to your application. When designing system architecture. When choosing between skills and deployed agents.
+
+**Common violations:**
+- LLM API calls (OpenAI, Anthropic, etc.) in application code
+- Custom agent frameworks or prompt chaining libraries
+- Deployed chatbots or conversational UIs with embedded AI
+- Custom tool-calling implementations
+
+**How to detect in code:**
+- grep for: `openai`, `anthropic`, `langchain`, `llamaindex`, `autogen`, `crewai`
+- Look for: API key environment variables for LLM providers
+- Check for: prompt template files, chain definitions, agent configurations
+- Scan for: streaming response handlers, tool/function calling implementations
+
+**How to fix:**
+- Replace embedded agents with Claude Code skills
+- Convert agent workflows to skill + sub-agent patterns
+- Remove LLM API dependencies
+- Use Claude Code's built-in sub-agent capabilities instead
+
+---
+
+## Principle 6: Stick to the Point
+
+**Summary:** Keep context relevant. Use skills and tools for on-demand context. Keep CLAUDE.md clean.
+
+**Description:** Agents work much better when their context is limited to what is relevant in the moment. Use separate files, tools, skills, and sub-agents to provide context when relevant. Keep CLAUDE.md clean and focused.
+
+**When it applies:** Structuring CLAUDE.md. Designing skills. Organizing project files.
+
+**Common violations:**
+- CLAUDE.md that's an encyclopedia (500+ lines)
+- All reference material inlined in SKILL.md instead of in references/
+- Too many unrelated files in one directory
+- Loading all context at once instead of progressively
+
+**How to detect in code:**
+- CLAUDE.md file size (should be under 200 lines)
+- SKILL.md files larger than 100 lines without references/ directory
+- Flat folder structures with 50+ files
+- No .claude/skills/ directory despite complex workflows
+
+**How to fix:**
+- Move reference material to references/ subdirectories
+- Use progressive disclosure: SKILL.md links to references/
+- Organize files into logical subdirectories
+- Keep CLAUDE.md focused on project overview and conventions
+
+---
+
+## Principle 7: Don't Be Stingy on the Input
+
+**Summary:** Use voice. Be generous with context. Detailed prompts beat short ones.
+
+**Description:** Removing ambiguity and giving more depth to your prompts works wonders. Provide ample documentation, additional links, etc. Use voice transcription to give complete and nuanced input. The times of over-engineering prompts are over -- just be clear and detailed.
+
+**When it applies:** Writing prompts. Creating skills. Describing requirements.
+
+**Common violations:**
+- Vague one-line prompts for complex tasks
+- Skills without detailed step-by-step instructions
+- Missing context in CLAUDE.md
+- Not providing examples or reference material
+
+**How to detect in code:**
+- SKILL.md files with fewer than 10 lines of instructions
+- Skills without any reference files
+- CLAUDE.md that's too sparse (under 10 lines)
+- No examples provided in skill instructions
+
+**How to fix:**
+- Use Voice Ink for richer, more detailed prompts
+- Add reference files with examples and style guides
+- Include step-by-step procedures in skills
+- Provide context about why, not just what
+
+---
+
+## Principle 8: Start with a Clean Slate
+
+**Summary:** /clear before new tasks. Fresh folders. Document learnings first.
+
+**Description:** Start with a fresh folder as context and bring in exactly what you need. During big sessions, clearing context dramatically improves performance. Before clearing: document useful insights in CLAUDE.md so they persist.
+
+**When it applies:** Starting a new task. Switching between different work. After long sessions.
+
+**Common violations:**
+- Never using /clear (stale context accumulates)
+- Not documenting learnings before clearing
+- Mixing unrelated tasks in one session
+- Keeping old project files when starting fresh
+
+**How to detect in code:**
+- No CLAUDE.md (suggests no documentation of learnings)
+- Large, cluttered project folders with mixed concerns
+- No evidence of task separation
+
+**How to fix:**
+- Use /clear when switching tasks
+- Document key learnings in CLAUDE.md before clearing
+- Use separate folders for separate concerns
+- Start significant new tasks in empty folders
+
+---
+
+## Principle 9: Speak the Right Language
+
+**Summary:** Text + images are what models understand. Provide screenshots for visual work.
+
+**Description:** AI understands text and images. It struggles with spatial layout, proprietary binary formats, and physical-world reasoning. For visual work, provide screenshots alongside code so the agent can compare visual output with the code and make informed adjustments.
+
+**When it applies:** Working with visual outputs (slides, UIs, layouts). Providing feedback on design. Working with binary formats.
+
+**Common violations:**
+- Asking the agent to "make it look nice" without a screenshot
+- Expecting the agent to understand spatial layouts from code alone
+- Not providing visual references when working on UI
+
+**How to detect in code:**
+- Visual output generation without screenshot-based feedback loops
+- Slide/presentation generation without visual validation
+- UI work without reference images
+
+**How to fix:**
+- Always provide screenshots when working on visual output
+- Use the screenshot-comparison workflow for iterative visual work
+- Include reference images in skill reference files

--- a/plugins/ai-firstify/skills/ai-firstify/references/project-structure.md
+++ b/plugins/ai-firstify/skills/ai-firstify/references/project-structure.md
@@ -1,0 +1,206 @@
+# Project Structure Guide
+
+## CLAUDE.md Template
+
+```markdown
+# CLAUDE.md
+
+## Project
+[One sentence: what this project does and who it's for]
+
+## Tech Stack
+- Backend: [Express.js / Flask / etc.]
+- Frontend: [HTML+CSS / React / etc.]
+- Data: [Markdown with YAML frontmatter / SQLite / etc.]
+
+## Key Files
+- [filename] -- [what it does]
+- [filename] -- [what it does]
+
+## Conventions
+- [File naming convention]
+- [Code style preferences]
+- [Content format requirements]
+
+## Constraints
+- [What NOT to do]
+- [Size limits, performance requirements]
+- [Data handling rules]
+
+## Skills
+- /[skill-name] -- [what it does]
+
+## Tone
+- [Writing style for generated content]
+```
+
+### CLAUDE.md Guidelines
+
+- **Under 200 lines** (ideally under 100)
+- Focus on what the agent needs to know RIGHT NOW
+- Reference external documents instead of inlining
+- Update after significant changes
+- Include key file paths so the agent knows where things are
+
+---
+
+## Minimal Project Structure (Simple Tool)
+
+```
+my-tool/
+├── CLAUDE.md                # Project context
+├── .gitignore               # Exclude sensitive files
+├── .claude/
+│   └── skills/
+│       └── my-skill/
+│           ├── SKILL.md     # Skill instructions
+│           └── scripts/
+│               └── validate.sh
+└── output/                  # Generated output files
+```
+
+---
+
+## Content Studio Structure
+
+```
+my-content-studio/
+├── CLAUDE.md
+├── .gitignore
+├── package.json
+├── server.js
+├── public/
+│   ├── index.html
+│   └── style.css
+├── content/
+│   ├── post-1.md
+│   └── post-2.md
+└── .claude/
+    └── skills/
+        └── content-writer/
+            ├── SKILL.md
+            ├── references/
+            │   └── style-guide.md
+            └── scripts/
+                ├── read-all.sh
+                └── validate.sh
+```
+
+---
+
+## Skill-Heavy Project Structure
+
+```
+my-workflow-project/
+├── CLAUDE.md
+├── .gitignore
+├── data/                          # Input data
+│   ├── templates/
+│   └── sources/
+├── output/                        # Generated output
+└── .claude/
+    └── skills/
+        ├── research/
+        │   ├── SKILL.md
+        │   ├── references/
+        │   │   └── research-methodology.md
+        │   └── scripts/
+        │       └── search-sources.sh
+        ├── writing/
+        │   ├── SKILL.md
+        │   ├── references/
+        │   │   ├── style-guide.md
+        │   │   └── examples/
+        │   └── scripts/
+        │       └── validate.sh
+        └── review/
+            ├── SKILL.md
+            └── references/
+                └── review-criteria.md
+```
+
+---
+
+## .gitignore Templates
+
+### General (all projects)
+
+```
+# Dependencies
+node_modules/
+
+# Environment
+.env
+.env.local
+.env.*.local
+
+# Credentials
+*.pem
+*.key
+credentials.json
+service-account.json
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# IDE
+.vscode/
+.idea/
+
+# Build output
+dist/
+build/
+```
+
+### Python projects (add to general)
+
+```
+__pycache__/
+*.pyc
+.venv/
+venv/
+*.egg-info/
+```
+
+### Node.js projects (add to general)
+
+```
+node_modules/
+package-lock.json
+```
+
+---
+
+## Git Commit Discipline
+
+### When to Commit
+
+- After completing a feature or fix
+- Before switching tasks
+- Before running risky operations
+- After significant refactoring
+- At least once per hour during active work
+
+### Commit Message Style
+
+```
+Add customer signal search skill
+Fix validation script for empty inputs
+Update CLAUDE.md with new conventions
+Remove unused frontend code
+```
+
+Keep messages short (under 72 characters), action-oriented ("Add", "Fix", "Update", "Remove"), and focused on what changed.
+
+### Git Workflow
+
+```bash
+# The basic flow
+git add .
+git commit -m "Add search skill with Slack integration"
+git push
+
+# Let Claude handle it
+"Commit and push my changes with a meaningful message"
+```

--- a/plugins/ai-firstify/skills/ai-firstify/references/skill-architecture.md
+++ b/plugins/ai-firstify/skills/ai-firstify/references/skill-architecture.md
@@ -1,0 +1,197 @@
+# Skill Architecture Guide
+
+## SKILL.md Anatomy and Best Practices
+
+### Structure
+
+```markdown
+---
+name: skill-name
+description: "Brief description for the slash command menu"
+---
+
+# Skill Name
+
+## Instructions
+Step-by-step prescriptive workflow:
+1. First, do this specific thing
+2. Then, do this next thing
+3. Read references/specific-file.md for detailed guidance
+4. Run scripts/validate.sh to check the output
+5. Save the result to [specific location]
+
+## References
+- references/style-guide.md -- detailed style rules
+- references/examples.md -- example outputs
+
+## Tools
+- scripts/validate.sh -- validates output against rules
+- scripts/read-all.sh -- reads existing content for context
+```
+
+### Best Practices
+
+- **Keep SKILL.md lean** -- under 100 lines. Put detailed guidance in references/
+- **Be prescriptive** -- numbered steps, specific actions, clear outputs
+- **Use progressive disclosure** -- SKILL.md links to references/ for depth
+- **Name skills clearly** -- the name becomes the slash command
+- **Include frontmatter** -- name and description are required for slash command registration
+
+### When to Create scripts/ vs references/
+
+- **scripts/** -- Deterministic operations: validation, data reading, formatting, date/time
+- **references/** -- Knowledge: style guides, examples, templates, domain context
+- **Neither** -- Simple instructions that the agent handles natively
+
+---
+
+## Progressive Disclosure Pattern
+
+```
+SKILL.md (lean, ~50-100 lines)
+  └── "Read references/style-guide.md for detailed style rules"
+       └── references/style-guide.md (detailed, 200+ lines)
+  └── "Read references/examples.md for output examples"
+       └── references/examples.md (detailed, with full examples)
+```
+
+The agent loads SKILL.md first (cheap). Only loads reference files when needed for the current step (on-demand). This saves tokens and keeps context focused.
+
+---
+
+## Project-Level vs User-Level Decision Guide
+
+| Factor | Project-Level (.claude/skills/) | User-Level (~/.claude/skills/) |
+|--------|----------------------------------|-------------------------------|
+| Scope | One specific project | All your projects |
+| Sharing | Shared via git repo | Personal only |
+| Examples | Content studio writer, project-specific validator | Memo writer, jeroenify, code review |
+| When to promote | After proving useful across 3+ projects | -- |
+
+**Start project-level.** Promote to user-level when the skill is proven useful across multiple projects.
+
+---
+
+## The Three Times Rule
+
+If you have done something three times manually:
+1. Document what you did (the steps, the inputs, the outputs)
+2. Create a skill from those documented steps
+3. Test the skill on the fourth occurrence
+4. Refine based on real usage
+
+Don't create skills speculatively. Wait for the pattern to emerge.
+
+---
+
+## Sharing and Packaging Skills
+
+Skills are just folders with text files. To share:
+1. **Zip the folder** -- `zip -r my-skill.zip .claude/skills/my-skill/`
+2. **Push to GitLab** -- include .claude/skills/ in your repo
+3. **Copy directly** -- recipients paste into their .claude/skills/
+
+Treat shared skills as deployed products:
+- Version them (track changes in git)
+- Document them (clear SKILL.md with examples)
+- Maintain them (update when workflows change)
+
+---
+
+## Sub-Agent Patterns
+
+### Research Agent
+
+Collects information, produces a report. Context is isolated and discarded afterward.
+
+```
+Main agent --> spawns research sub-agent -->
+  Sub-agent reads files, searches, analyzes -->
+  Sub-agent produces report -->
+  Main agent receives report, continues work
+```
+
+**Use for:** Investigation, data gathering, literature review, competitive analysis
+
+### Review Agent
+
+Critiques work in isolation. Doesn't share context with the creator.
+
+```
+Main agent --> creates content -->
+  Spawns review sub-agent -->
+  Reviewer critiques with fresh eyes -->
+  Main agent receives feedback, revises
+```
+
+**Use for:** Content quality review, code review, proposal review
+
+### Parallel Batch Agent
+
+Same task, different inputs. All sub-agents run simultaneously.
+
+```
+Main agent --> splits 50 items into groups of 10 -->
+  Spawns 5 sub-agents (one per group) -->
+  All run in parallel -->
+  Main agent aggregates results
+```
+
+**Use for:** RFP answers, bulk data processing, mass content generation
+
+### Nested Agents
+
+Agent spawns agent spawns agent. Use sparingly -- one level of nesting covers most cases.
+
+```
+Main agent --> spawns research agent -->
+  Research agent --> spawns analysis sub-agent -->
+  Results bubble up
+```
+
+**Use for:** Complex multi-phase research where phases are independent
+
+### Read-Only vs Read-Write
+
+- **Read-only sub-agents:** Use for research, analysis, review. Safe, no side effects.
+- **Read-write sub-agents:** Use for batch processing where output is needed. Add validation.
+
+---
+
+## Workflow Composition
+
+### Multi-Skill Workflows
+
+Skills can be combined in sequence:
+
+```
+/research-skill --> produces research report -->
+/writing-skill --> uses report as input, produces draft -->
+/review-skill --> critiques draft, produces feedback -->
+Human reviews feedback --> approves or requests changes
+```
+
+### Skills + MCP Connections
+
+Skills become more powerful with MCP integrations:
+- **Slack MCP + research skill** = search Slack for insights, produce report
+- **Notion MCP + writing skill** = create Notion pages from generated content
+- **Atlassian MCP + tracking skill** = create Jira issues from analysis
+
+### Human-in-the-Loop Checkpoints
+
+Add explicit checkpoints where human review is required:
+
+```
+Step 3: Present findings to the user and wait for approval before proceeding
+Step 6: Save draft to Google Docs for human review. Import comments before continuing.
+```
+
+### Document Feedback Loop
+
+A particularly effective pattern:
+1. Agent generates content
+2. Export to Google Docs
+3. Human adds comments in Google Docs
+4. Agent reads comments and revises
+5. Repeat until approved

--- a/plugins/ai-firstify/skills/ai-firstify/references/skill-architecture.md
+++ b/plugins/ai-firstify/skills/ai-firstify/references/skill-architecture.md
@@ -20,7 +20,7 @@ Step-by-step prescriptive workflow:
 4. Run scripts/validate.sh to check the output
 5. Save the result to [specific location]
 
-## References
+## References (example -- adapt to your skill)
 - references/style-guide.md -- detailed style rules
 - references/examples.md -- example outputs
 
@@ -55,6 +55,8 @@ SKILL.md (lean, ~50-100 lines)
        └── references/examples.md (detailed, with full examples)
 ```
 
+> **Note:** The file names above (style-guide.md, examples.md) are illustrative. Name your reference files to match your skill's domain -- e.g., references/assessment-rubric.md, references/api-docs.md, etc.
+
 The agent loads SKILL.md first (cheap). Only loads reference files when needed for the current step (on-demand). This saves tokens and keeps context focused.
 
 ---
@@ -65,7 +67,7 @@ The agent loads SKILL.md first (cheap). Only loads reference files when needed f
 |--------|----------------------------------|-------------------------------|
 | Scope | One specific project | All your projects |
 | Sharing | Shared via git repo | Personal only |
-| Examples | Content studio writer, project-specific validator | Memo writer, jeroenify, code review |
+| Examples | Content studio writer, project-specific validator | Memo writer, ai-firstify, code review |
 | When to promote | After proving useful across 3+ projects | -- |
 
 **Start project-level.** Promote to user-level when the skill is proven useful across multiple projects.

--- a/plugins/content-studio/.claude-plugin/plugin.json
+++ b/plugins/content-studio/.claude-plugin/plugin.json
@@ -5,6 +5,6 @@
   "author": {
     "name": "TechWolf",
     "email": "lennert.demey@techwolf.ai",
-    "url": "https://techwolf.com"
+    "url": "https://techwolf.ai"
   }
 }


### PR DESCRIPTION
## Summary
- Add ai-firstify plugin: AI-first project auditor and re-engineer based on TechWolf AI-First Bootcamp
- Fix naming remnants (Jeroenify -> AI-Firstify), typos, and clarify examples as illustrative
- Add detection commands to assessment rubric
- Add README with marketplace install instructions

## Test plan
- [x] Skill references verified (all referenced files exist)
- [x] Plugin JSON valid
- [x] Marketplace JSON valid with both plugins listed

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>