### PR TITLE
Add Codex support, install script, and community files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# TechWolf AI-First Toolkit
+
+This repository publishes TechWolf AI-first plugins and skills for both Claude Code and Codex.
+
+## Repository Purpose
+
+- `plugins/<plugin>/` is the source of truth for each plugin.
+- Claude-specific plugin metadata lives in `.claude-plugin/`.
+- Codex-compatible skills live in each plugin's `skills/` directory.
+- Codex installs are managed via `./install.sh`.
+
+## Working Conventions
+
+- Preserve the mapping between a plugin and its Codex-installed skills.
+- When changing a plugin, update both Claude-facing and Codex-facing docs if behavior changes.
+- If Codex install behavior changes, update `README.md`, plugin READMEs, and `CHANGELOG.md`.
+- Prefer adding Codex guidance under `plugins/<plugin>/codex/AGENTS.md` when plugin-specific instructions are needed.
+
+## Codex Install Notes
+
+- `./install.sh` installs skills into `~/.codex/skills` by default.
+- The installer also manages plugin metadata, verification, and uninstall state under `~/.codex/skills/.techwolf-ai-first/`.
+- `content-studio` has a plugin-level Codex entry skill in addition to its specialized skills.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on Keep a Changelog and this project follows Semantic Versioning.
+
+## [1.1.0] - 2026-03-10
+
+### Added
+
+- Codex support via `./install.sh` for installing plugin skills into Codex skill directories.
+- Managed Codex install lifecycle commands for install, update, verify, uninstall, and list.
+- Codex install metadata and plugin guidance files.
+- A plugin-level `content-studio` Codex entry skill.
+
+### Changed
+
+- Documentation now explains both Claude Code and Codex installation flows.
+
+## [1.0.0] - 2026-03-09
+
+### Added
+
+- Initial public release of the TechWolf AI-First Toolkit plugin marketplace.
+- `ai-firstify` plugin.
+- `content-studio` plugin.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,35 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers at **lennert.demey@techwolf.ai**. All complaints will be reviewed and investigated promptly and fairly.
+
+Project maintainers are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Contributing
+
+Thanks for your interest in contributing to the TechWolf AI-First Toolkit!
+
+## Getting Started
+
+1. Fork the repository
+2. Clone your fork locally
+3. Create a branch for your change
+
+## What You Can Contribute
+
+- **New skills** -- Add skills to existing plugins or propose new plugins
+- **Bug fixes** -- Fix issues in existing skills, scripts, or docs
+- **Documentation** -- Improve READMEs, add examples, fix typos
+- **Ideas** -- Open an issue to discuss new plugins or improvements
+
+## Project Structure
+
+```
+plugins/
+  <plugin-name>/
+    .claude-plugin/     # Plugin manifest
+    skills/
+      <skill-name>/
+        SKILL.md        # Skill definition (agentskills.io spec)
+        references/     # Supporting docs the skill can read
+        scripts/        # Helper scripts the skill can run
+```
+
+## Adding a New Skill
+
+1. Create a directory under `plugins/<plugin>/skills/<skill-name>/`
+2. Add a `SKILL.md` following the [agentskills.io](https://agentskills.io) spec
+3. Add any supporting files in `references/` and `scripts/`
+4. Update the plugin's README with the new skill
+
+## Submitting Changes
+
+1. Keep PRs focused -- one feature or fix per PR
+2. Update relevant READMEs if your change affects usage
+3. Test your skills with Claude Code (and Codex via `./install.sh` if possible)
+4. Open a PR against `main` with a clear description of what and why
+
+## Code Style
+
+- Keep skills concise and self-contained
+- No unnecessary comments or boilerplate
+- Shell scripts should use `set -euo pipefail`
+
+## Questions?
+
+Open an issue or start a discussion on GitHub.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,42 @@ claude plugin update ai-firstify@techwolf-ai-first
 claude plugin update content-studio@techwolf-ai-first
 ```
 
+### Codex
+
+The skills in this repo follow the [agentskills.io](https://agentskills.io) spec, so they work with any compatible agent, including [Codex](https://github.com/openai/codex).
+
+Install plugins into Codex's skill directory:
+
+```bash
+./install.sh                         # install all plugins
+./install.sh ai-firstify            # install one plugin
+./install.sh content-studio
+./install.sh --target ~/custom/     # install to a custom directory
+```
+
+Manage the install lifecycle:
+
+```bash
+./install.sh list
+./install.sh verify
+./install.sh update content-studio
+./install.sh uninstall ai-firstify
+```
+
+What the Codex installer does:
+
+- Installs each skill under `~/.codex/skills/<skill-name>/`
+- Adds per-skill metadata so installs can be traced back to the source plugin and version
+- Verifies that required files are present after install
+- Copies plugin guidance into `~/.codex/skills/.techwolf-ai-first/plugins/<plugin>/AGENTS.md`
+
+Codex-specific plugin entry points:
+
+- `ai-firstify` installs as the `ai-firstify` skill
+- `content-studio` installs a plugin-level `content-studio` skill plus the specialized writing, brainstorming, setup, and analysis skills
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).
+
+See [CHANGELOG.md](CHANGELOG.md) for release history.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it responsibly.
+
+**Do not open a public issue.**
+
+Instead, email **lennert.demey@techwolf.ai** with:
+
+- A description of the vulnerability
+- Steps to reproduce
+- Potential impact
+
+We will review your report and work with you to understand and address the issue.
+
+## Scope
+
+This project contains AI agent skills and scripts. Security concerns may include:
+
+- Scripts that execute unsafe commands
+- Skills that could leak sensitive data from a user's environment
+- Supply chain risks in dependencies
+
+## Supported Versions
+
+Only the latest version on `main` is actively maintained.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,374 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET="${HOME}/.codex/skills"
+ACTION="install"
+PLUGIN=""
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+STATE_DIR_NAME=".techwolf-ai-first"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./install.sh [install|update|uninstall|verify|list] [plugin] [--target <dir>]
+
+Examples:
+  ./install.sh
+  ./install.sh content-studio
+  ./install.sh install ai-firstify
+  ./install.sh update content-studio
+  ./install.sh uninstall content-studio
+  ./install.sh verify
+  ./install.sh --target /tmp/codex-skills
+EOF
+}
+
+list_plugins() {
+  for plugin_dir in "${SCRIPT_DIR}"/plugins/*/; do
+    [[ -d "${plugin_dir}/skills" ]] || continue
+    basename "${plugin_dir}"
+  done
+}
+
+plugin_exists() {
+  local plugin_name="$1"
+  [[ -d "${SCRIPT_DIR}/plugins/${plugin_name}/skills" ]]
+}
+
+plugin_version() {
+  local plugin_name="$1"
+  local manifest="${SCRIPT_DIR}/plugins/${plugin_name}/.claude-plugin/plugin.json"
+
+  if [[ -f "$manifest" ]]; then
+    sed -n 's/.*"version":[[:space:]]*"\([^"]*\)".*/\1/p' "$manifest" | head -n 1
+  else
+    echo "unknown"
+  fi
+}
+
+plugin_guide_src() {
+  local plugin_name="$1"
+  echo "${SCRIPT_DIR}/plugins/${plugin_name}/codex/AGENTS.md"
+}
+
+plugin_state_dir() {
+  local plugin_name="$1"
+  echo "${TARGET}/${STATE_DIR_NAME}/plugins/${plugin_name}"
+}
+
+skill_source_dir() {
+  local plugin_name="$1"
+  echo "${SCRIPT_DIR}/plugins/${plugin_name}/skills"
+}
+
+skill_names_for_plugin() {
+  local plugin_name="$1"
+  local skills_dir
+  skills_dir="$(skill_source_dir "$plugin_name")"
+
+  for skill_dir in "${skills_dir}"/*/; do
+    [[ -d "$skill_dir" ]] || continue
+    basename "$skill_dir"
+  done
+}
+
+json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  printf '%s' "$s"
+}
+
+write_skill_metadata() {
+  local dest="$1"
+  local plugin_name="$2"
+  local version="$3"
+  local skill_name="$4"
+  local source_dir="$5"
+
+  cat > "${dest}/.techwolf-plugin.json" <<EOF
+{
+  "plugin": "$(json_escape "$plugin_name")",
+  "version": "$(json_escape "$version")",
+  "skill": "$(json_escape "$skill_name")",
+  "source": "$(json_escape "$source_dir")"
+}
+EOF
+}
+
+write_plugin_manifest() {
+  local plugin_name="$1"
+  local version="$2"
+  local state_dir
+  state_dir="$(plugin_state_dir "$plugin_name")"
+
+  mkdir -p "$state_dir"
+  {
+    echo "plugin=${plugin_name}"
+    echo "version=${version}"
+    for skill_name in $(skill_names_for_plugin "$plugin_name"); do
+      echo "skill=${skill_name}"
+    done
+  } > "${state_dir}/manifest.txt"
+}
+
+install_plugin_guide() {
+  local plugin_name="$1"
+  local guide_src
+  local guide_dest_dir
+
+  guide_src="$(plugin_guide_src "$plugin_name")"
+  guide_dest_dir="$(plugin_state_dir "$plugin_name")"
+
+  if [[ -f "$guide_src" ]]; then
+    mkdir -p "$guide_dest_dir"
+    cp "$guide_src" "${guide_dest_dir}/AGENTS.md"
+    echo "  Installed guide ${plugin_name} -> ${guide_dest_dir}/AGENTS.md"
+  fi
+}
+
+installed_version() {
+  local plugin_name="$1"
+  local state_dir
+  state_dir="$(plugin_state_dir "$plugin_name")"
+  if [[ -f "${state_dir}/manifest.txt" ]]; then
+    grep -F 'version=' "${state_dir}/manifest.txt" | head -1 | cut -d= -f2
+  fi
+}
+
+install_plugin() {
+  local plugin_name="$1"
+  local version
+  local skills_dir
+  local installed_count=0
+
+  if ! plugin_exists "$plugin_name"; then
+    echo "Error: plugin '${plugin_name}' not found" >&2
+    exit 1
+  fi
+
+  version="$(plugin_version "$plugin_name")"
+  skills_dir="$(skill_source_dir "$plugin_name")"
+
+  echo "Installing ${plugin_name} v${version} to ${TARGET}"
+  mkdir -p "$TARGET"
+
+  # Write manifest first so interrupted installs can be cleaned up
+  write_plugin_manifest "$plugin_name" "$version"
+
+  for skill_dir in "${skills_dir}"/*/; do
+    [[ -d "$skill_dir" ]] || continue
+
+    local skill_name
+    local dest
+    skill_name="$(basename "$skill_dir")"
+    dest="${TARGET}/${skill_name}"
+
+    # Check for ownership conflict with another plugin
+    if [[ -f "${dest}/.techwolf-plugin.json" ]]; then
+      local existing_owner
+      existing_owner="$(grep -F '"plugin":' "${dest}/.techwolf-plugin.json" | sed 's/.*"plugin":[[:space:]]*"\([^"]*\)".*/\1/' || true)"
+      if [[ -n "$existing_owner" && "$existing_owner" != "$plugin_name" ]]; then
+        echo "  Error: skill '${skill_name}' already installed by plugin '${existing_owner}'" >&2
+        echo "  Uninstall '${existing_owner}' first or use a different target directory" >&2
+        exit 1
+      fi
+    fi
+
+    rm -rf "$dest"
+    mkdir -p "$dest"
+    cp -R "${skill_dir}/." "$dest/"
+    write_skill_metadata "$dest" "$plugin_name" "$version" "$skill_name" "$skill_dir"
+
+    echo "  Installed ${plugin_name}/${skill_name} -> ${dest}"
+    installed_count=$((installed_count + 1))
+  done
+  install_plugin_guide "$plugin_name"
+
+  echo "  Installed ${installed_count} skill(s) for ${plugin_name}"
+}
+
+verify_plugin() {
+  local plugin_name="$1"
+  local version
+  local failures=0
+  local checked=0
+
+  if ! plugin_exists "$plugin_name"; then
+    echo "Error: plugin '${plugin_name}' not found" >&2
+    exit 1
+  fi
+
+  version="$(plugin_version "$plugin_name")"
+
+  for skill_name in $(skill_names_for_plugin "$plugin_name"); do
+    local dest="${TARGET}/${skill_name}"
+    checked=$((checked + 1))
+
+    if [[ ! -f "${dest}/SKILL.md" ]]; then
+      echo "  Missing SKILL.md for ${plugin_name}/${skill_name} at ${dest}"
+      failures=$((failures + 1))
+      continue
+    fi
+
+    if [[ ! -f "${dest}/.techwolf-plugin.json" ]]; then
+      echo "  Missing metadata for ${plugin_name}/${skill_name} at ${dest}"
+      failures=$((failures + 1))
+      continue
+    fi
+
+    if ! grep -Fq "\"plugin\": \"${plugin_name}\"" "${dest}/.techwolf-plugin.json"; then
+      echo "  Metadata plugin mismatch for ${plugin_name}/${skill_name} at ${dest}"
+      failures=$((failures + 1))
+      continue
+    fi
+
+    if ! grep -Fq "\"version\": \"${version}\"" "${dest}/.techwolf-plugin.json"; then
+      echo "  Metadata version mismatch for ${plugin_name}/${skill_name} at ${dest}"
+      failures=$((failures + 1))
+    fi
+  done
+
+  local guide_src
+  guide_src="$(plugin_guide_src "$plugin_name")"
+  if [[ -f "$guide_src" ]]; then
+    local installed_guide
+    installed_guide="$(plugin_state_dir "$plugin_name")/AGENTS.md"
+    if [[ ! -f "$installed_guide" ]]; then
+      echo "  Missing guide for ${plugin_name} at ${installed_guide}"
+      failures=$((failures + 1))
+    fi
+  fi
+
+  if [[ $failures -eq 0 ]]; then
+    echo "Verified ${plugin_name}: ${checked} skill(s) OK"
+  else
+    echo "Verification failed for ${plugin_name}: ${failures} issue(s)"
+    return 1
+  fi
+}
+
+uninstall_plugin() {
+  local plugin_name="$1"
+  local state_dir
+
+  state_dir="$(plugin_state_dir "$plugin_name")"
+  if [[ ! -f "${state_dir}/manifest.txt" ]]; then
+    echo "No install manifest found for ${plugin_name} under ${state_dir}"
+    return 1
+  fi
+
+  echo "Uninstalling ${plugin_name} from ${TARGET}"
+
+  while IFS= read -r line; do
+    [[ "$line" == skill=* ]] || continue
+    local skill_name="${line#skill=}"
+    local dest="${TARGET}/${skill_name}"
+
+    if [[ -f "${dest}/.techwolf-plugin.json" ]] && grep -Fq "\"plugin\": \"${plugin_name}\"" "${dest}/.techwolf-plugin.json"; then
+      rm -rf "$dest"
+      echo "  Removed ${dest}"
+    else
+      echo "  Skipped ${dest} (missing or not owned by ${plugin_name})"
+    fi
+  done < "${state_dir}/manifest.txt"
+
+  rm -rf "$state_dir"
+  echo "Removed plugin state ${state_dir}"
+}
+
+run_for_selected_plugins() {
+  local selected_plugins=()
+  local had_failures=0
+
+  if [[ -n "$PLUGIN" ]]; then
+    selected_plugins=("$PLUGIN")
+  else
+    while IFS= read -r plugin_name; do
+      selected_plugins+=("$plugin_name")
+    done < <(list_plugins)
+  fi
+
+  if [[ ${#selected_plugins[@]} -eq 0 ]]; then
+    echo "No plugins found."
+    exit 1
+  fi
+
+  for plugin_name in "${selected_plugins[@]}"; do
+    case "$ACTION" in
+      install)
+        install_plugin "$plugin_name"
+        ;;
+      update)
+        local old_ver
+        old_ver="$(installed_version "$plugin_name" || true)"
+        local new_ver
+        new_ver="$(plugin_version "$plugin_name")"
+        if [[ -n "$old_ver" && "$old_ver" == "$new_ver" ]]; then
+          echo "${plugin_name} is already at v${new_ver}"
+        else
+          [[ -n "$old_ver" ]] && echo "Updating ${plugin_name}: v${old_ver} -> v${new_ver}"
+          install_plugin "$plugin_name"
+        fi
+        ;;
+      uninstall)
+        uninstall_plugin "$plugin_name" || had_failures=1
+        ;;
+      verify)
+        verify_plugin "$plugin_name" || had_failures=1
+        ;;
+      list)
+        printf "%s v%s:" "$plugin_name" "$(plugin_version "$plugin_name")"
+        for skill_name in $(skill_names_for_plugin "$plugin_name"); do
+          printf " %s" "$skill_name"
+        done
+        printf "\n"
+        ;;
+      *)
+        echo "Unknown action: ${ACTION}" >&2
+        usage
+        exit 1
+        ;;
+    esac
+  done
+
+  [[ $had_failures -eq 0 ]] || return 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    install|update|uninstall|verify|list)
+      ACTION="$1"
+      shift
+      ;;
+    --target)
+      if [[ $# -lt 2 ]]; then
+        echo "Error: --target requires a value" >&2
+        usage
+        exit 1
+      fi
+      TARGET="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      if [[ -n "$PLUGIN" ]]; then
+        echo "Error: unexpected argument '$1'" >&2
+        usage
+        exit 1
+      fi
+      PLUGIN="$1"
+      shift
+      ;;
+  esac
+done
+
+run_for_selected_plugins
+
+if [[ "$ACTION" == "install" || "$ACTION" == "update" ]]; then
+  ACTION="verify"
+  run_for_selected_plugins
+fi

--- a/plugins/ai-firstify/README.md
+++ b/plugins/ai-firstify/README.md
@@ -12,6 +12,26 @@ claude plugin marketplace add techwolf-ai/ai-first-toolkit
 claude plugin install ai-firstify@techwolf-ai-first
 ```
 
+### Codex
+
+```bash
+./install.sh ai-firstify
+```
+
+Update, uninstall, or verify:
+
+```bash
+./install.sh update ai-firstify
+./install.sh uninstall ai-firstify
+./install.sh verify ai-firstify
+```
+
+For Codex, this plugin installs:
+
+- `ai-firstify`
+
+The installer also writes plugin metadata into the installed skill directory and copies a Codex guidance file into `~/.codex/skills/.techwolf-ai-first/plugins/ai-firstify/`.
+
 ## Usage
 
 The skill triggers automatically when you ask Claude Code to:

--- a/plugins/ai-firstify/codex/AGENTS.md
+++ b/plugins/ai-firstify/codex/AGENTS.md
@@ -1,0 +1,10 @@
+# TechWolf ai-firstify for Codex
+
+Use the `ai-firstify` skill when the user wants to audit, improve, re-engineer, or bootstrap a project with the TechWolf AI-first methodology.
+
+Prefer these modes:
+- Audit: read-only review with scores and recommendations.
+- Re-engineer: audit first, then make concrete improvements.
+- Bootstrap: guide a new project from discovery to initial structure.
+
+Load only the reference files needed for the current mode or analysis dimension.

--- a/plugins/content-studio/README.md
+++ b/plugins/content-studio/README.md
@@ -32,6 +32,35 @@ claude plugin marketplace add techwolf-ai/ai-first-toolkit
 claude plugin install content-studio@techwolf-ai-first
 ```
 
+### Codex
+
+From the repository root:
+
+```bash
+./install.sh content-studio
+```
+
+Update, uninstall, or verify:
+
+```bash
+./install.sh update content-studio
+./install.sh uninstall content-studio
+./install.sh verify content-studio
+```
+
+For Codex, this plugin installs:
+
+- `content-studio` as the plugin-level entry point
+- `setup-content-studio`
+- `write-linkedin-post`
+- `write-blog-post`
+- `write-opinion`
+- `brainstorm-linkedin`
+- `brainstorm-opinion`
+- `analyze-performance`
+
+The installer also writes plugin metadata into each installed skill directory and copies a Codex guidance file into `~/.codex/skills/.techwolf-ai-first/plugins/content-studio/`.
+
 ### 2. Set Up for a Person
 
 Run the setup skill to create a personalized content studio:

--- a/plugins/content-studio/codex/AGENTS.md
+++ b/plugins/content-studio/codex/AGENTS.md
@@ -1,0 +1,11 @@
+# TechWolf content-studio for Codex
+
+Use `content-studio` as the plugin-level entry point.
+
+Typical flow:
+- New person or new repository: use `setup-content-studio` first.
+- Existing content studio repository: route to the most specific writing, brainstorming, or analysis skill.
+
+Repository-local expectations:
+- Writing and analysis skills assume `guidelines/`, `references/`, `content/posts/`, and `scripts/` exist in the current repository.
+- If they do not exist yet, do not improvise around that state; set up the content studio first.

--- a/plugins/content-studio/skills/content-studio/SKILL.md
+++ b/plugins/content-studio/skills/content-studio/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: content-studio
+description: Entry point for the TechWolf content-studio plugin. Use to understand the workflow, pick the right content skill, or start setup for a new author/repository.
+---
+
+# Content Studio
+
+Use this skill as the plugin-level entry point for the TechWolf content-studio workflow in Codex.
+
+## Start Here
+
+- If the user wants a new content studio for a person, use `setup-content-studio` first.
+- If the repository is already configured, route to the most specific skill:
+  - `write-linkedin-post`
+  - `write-blog-post`
+  - `write-opinion`
+  - `brainstorm-linkedin`
+  - `brainstorm-opinion`
+  - `analyze-performance`
+
+## Workflow
+
+1. Confirm whether the current repository is already a configured content studio.
+2. If not, use `setup-content-studio` to create or adapt one from the template.
+3. Before writing or brainstorming, read the existing published content and author guidance required by the target skill.
+4. Use the repository scripts for search/list/print operations when the selected skill expects them.
+
+## Repository Expectations
+
+- Most content skills assume they are being run inside a configured content studio repository.
+- Those skills rely on repo-local files such as `guidelines/`, `references/`, `content/posts/`, and `scripts/`.
+- If those files are missing, stop and either run `setup-content-studio` or explain what is missing.


### PR DESCRIPTION
## Summary

- Add `install.sh` for Codex skill installation with full lifecycle management (install, update, uninstall, verify, list), ownership conflict detection, JSON-safe metadata, and manifest-first writes for interrupted install recovery
- Add community files: AGENTS.md, CHANGELOG.md, CODE_OF_CONDUCT.md, CONTRIBUTING.md, SECURITY.md
- Add Codex-specific AGENTS.md and SKILL.md entry points for both plugins
- Update all READMEs with Codex installation sections

## Test plan

- [x] `bash install.sh list` shows both plugins with correct versions and skills
- [x] `bash install.sh install ai-firstify --target /tmp/test` installs and verifies
- [x] `bash install.sh update ai-firstify --target /tmp/test` reports "already at vX.Y.Z"
- [x] `bash install.sh uninstall ai-firstify --target /tmp/test` cleans up correctly
- [x] Full content-studio lifecycle (install/verify/update/uninstall) passes
- [x] Reinstalling same plugin succeeds (no false ownership conflict)
- [x] `bash -n install.sh` syntax check passes
- [x] Verify agentskills.io link resolves publicly

🤖 Generated with [Claude Code](https://claude.com/claude-code)