### PR TITLE
Overhaul README and GitHub metadata for adoption

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,98 +1,122 @@
 # TechWolf AI-First Toolkit
 
-Open-source AI skills and plugins from [TechWolf](https://techwolf.ai)'s [AI-First Bootcamp](https://ai-first.techwolf.ai).
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![v1.1.0](https://img.shields.io/badge/version-1.1.0-green.svg)](CHANGELOG.md)
+[![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-blueviolet.svg)](https://docs.anthropic.com/en/docs/claude-code)
+[![Codex](https://img.shields.io/badge/Codex-compatible-orange.svg)](https://github.com/openai/codex)
+[![agentskills.io](https://img.shields.io/badge/agentskills.io-spec-lightgrey.svg)](https://agentskills.io)
 
-This repository is a **plugin marketplace** for [Claude Code](https://docs.anthropic.com/en/docs/claude-code). Each plugin bundles skills, agents, hooks, and other resources that extend Claude Code with domain-specific capabilities.
+Production-tested Claude Code plugins and Codex skills from [TechWolf](https://techwolf.ai)'s engineering team. Battle-tested across 200+ engineers in the [AI-First Bootcamp](https://ai-first.techwolf.ai).
 
-## Available Plugins
+<!-- TODO: Add hero GIF showing ai-firstify audit in action -->
 
-| Plugin | Description | Status |
-|--------|-------------|--------|
-| [ai-firstify](plugins/ai-firstify/) | AI-first project auditor and re-engineer based on the 9 design principles and 7 design patterns from the TechWolf AI-First Bootcamp | Available |
-| [content-studio](plugins/content-studio/) | Content studio for thought leadership (LinkedIn, blog, opinion) with visual editor and Claude Code skills | Available |
+## What's inside
 
-## Repository Structure
+### ai-firstify — AI-First Project Auditor
+
+Audits any codebase against 9 AI-first design principles and 7 design patterns. Three modes:
+
+- **Audit** — deep analysis across 7 dimensions with a scored report
+- **Re-engineer** — actively restructures your project to be AI-first
+- **Bootstrap** — guides new project setup with discovery questions
 
 ```
-ai-first-toolkit/
-├── .claude-plugin/
-│   └── marketplace.json        # Marketplace manifest (registers all plugins)
-├── plugins/
-│   ├── ai-firstify/            # Plugin: AI-first auditor & re-engineer
-│   │   ├── .claude-plugin/     #   Plugin manifest
-│   │   └── skills/             #   SKILL.md files + reference docs
-│   └── content-studio/         # Plugin: Content studio
-│       ├── .claude-plugin/     #   Plugin manifest
-│       ├── skills/             #   SKILL.md files per content type
-│       ├── hooks/              #   Event handlers
-│       ├── templates/          #   Guidelines & reference templates
-│       ├── content/            #   Content storage (posts, drafts)
-│       ├── content-studio/     #   Next.js visual editor app
-│       └── scripts/            #   Utility scripts
-├── LICENSE
-└── README.md
+> /ai-firstify audit
+
+Scanning project structure...
+Analyzing 7 dimensions: foundation, agents, skills, complexity, context, safety, workflows
+
+AI-First Assessment Report
+==========================
+Overall Score: 6.2 / 10
+
+  Foundation & Structure    ████████░░  8/10
+  De-agentification         ███░░░░░░░  3/10
+  Skill Architecture        ██████░░░░  6/10
+  Complexity Management     ████████░░  8/10
+  Context Hygiene           █████░░░░░  5/10
+  Safety & Guardrails       ███████░░░  7/10
+  Workflow Optimization     ██████░░░░  6/10
+
+Top recommendations:
+1. Extract inline agent logic into standalone skills (SKILL.md)
+2. Add validation gates to your content pipeline
+3. Reduce context window pollution — move reference docs to load-on-demand
 ```
 
-Each plugin lives in `plugins/<plugin-name>/` and contains at minimum a `.claude-plugin/` manifest directory and a `skills/` directory with one or more `SKILL.md` files. Plugins can optionally include hooks, templates, scripts, and companion apps.
+### content-studio — Thought Leadership Pipeline
 
-## Installation
+Full content pipeline for LinkedIn posts, blog posts, and opinion pieces. Includes 8 specialized skills, a visual Kanban editor, and hooks that auto-start the companion app.
+
+- **Write** — LinkedIn posts, blog posts, opinion pieces with voice-matched style
+- **Brainstorm** — generate ideas from URLs, files, or recent posts
+- **Analyze** — engagement pattern analysis across published content
+- **Setup** — interactive onboarding that learns your voice and creates a personalized content repo
+
+## Quick start
 
 ### Claude Code
 
-Install a plugin directly from this marketplace:
-
 ```bash
-# Add the TechWolf marketplace (once)
+# Add the marketplace (once)
 claude plugin marketplace add techwolf-ai/ai-first-toolkit
 
-# Install a specific plugin
+# Install plugins
 claude plugin install ai-firstify@techwolf-ai-first
 claude plugin install content-studio@techwolf-ai-first
 ```
 
-Update to the latest version:
-
-```bash
-claude plugin update ai-firstify@techwolf-ai-first
-claude plugin update content-studio@techwolf-ai-first
-```
-
 ### Codex
 
-The skills in this repo follow the [agentskills.io](https://agentskills.io) spec, so they work with any compatible agent, including [Codex](https://github.com/openai/codex).
-
-Install plugins into Codex's skill directory:
+Skills follow the [agentskills.io](https://agentskills.io) spec:
 
 ```bash
-./install.sh                         # install all plugins
-./install.sh ai-firstify            # install one plugin
+./install.sh                    # install all plugins
+./install.sh ai-firstify       # install one plugin
 ./install.sh content-studio
-./install.sh --target ~/custom/     # install to a custom directory
 ```
 
-Manage the install lifecycle:
+<details>
+<summary>More install commands</summary>
 
 ```bash
-./install.sh list
-./install.sh verify
-./install.sh update content-studio
+./install.sh list               # list installed skills
+./install.sh verify             # check installation
+./install.sh update ai-firstify # update a plugin
 ./install.sh uninstall ai-firstify
+./install.sh --target ~/custom/ # custom install directory
 ```
 
-What the Codex installer does:
-
+**What the installer does:**
 - Installs each skill under `~/.codex/skills/<skill-name>/`
-- Adds per-skill metadata so installs can be traced back to the source plugin and version
-- Verifies that required files are present after install
+- Adds per-skill metadata for traceability back to the source plugin and version
+- Verifies required files are present after install
 - Copies plugin guidance into `~/.codex/skills/.techwolf-ai-first/plugins/<plugin>/AGENTS.md`
 
-Codex-specific plugin entry points:
+</details>
 
-- `ai-firstify` installs as the `ai-firstify` skill
-- `content-studio` installs a plugin-level `content-studio` skill plus the specialized writing, brainstorming, setup, and analysis skills
+## Repository structure
+
+```
+ai-first-toolkit/
+├── .claude-plugin/
+│   └── marketplace.json        # Marketplace manifest
+├── plugins/
+│   ├── ai-firstify/            # Auditor & re-engineer (1 skill, 9 reference docs)
+│   └── content-studio/         # Content pipeline (8 skills, visual editor, hooks)
+├── install.sh                  # Codex skill installer
+└── README.md
+```
+
+Each plugin lives in `plugins/<name>/` with a `.claude-plugin/` manifest and `skills/` directory containing `SKILL.md` files. See individual plugin READMEs for details:
+
+- [ai-firstify README](plugins/ai-firstify/README.md)
+- [content-studio README](plugins/content-studio/README.md)
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## License
 
-This project is licensed under the [MIT License](LICENSE).
-
-See [CHANGELOG.md](CHANGELOG.md) for release history.
+[MIT](LICENSE) — see [CHANGELOG.md](CHANGELOG.md) for release history.

--- a/README.md
+++ b/README.md
@@ -1,48 +1,20 @@
 # TechWolf AI-First Toolkit
 
-[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![v1.1.0](https://img.shields.io/badge/version-1.1.0-green.svg)](CHANGELOG.md)
-[![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-blueviolet.svg)](https://docs.anthropic.com/en/docs/claude-code)
-[![Codex](https://img.shields.io/badge/Codex-compatible-orange.svg)](https://github.com/openai/codex)
-[![agentskills.io](https://img.shields.io/badge/agentskills.io-spec-lightgrey.svg)](https://agentskills.io)
+![MIT License](https://img.shields.io/badge/license-MIT-blue.svg) ![v1.1.0](https://img.shields.io/badge/version-1.1.0-green.svg) ![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-blueviolet.svg) ![Codex](https://img.shields.io/badge/Codex-compatible-orange.svg) ![agentskills.io](https://img.shields.io/badge/agentskills.io-spec-lightgrey.svg)
 
-Production-tested Claude Code plugins and Codex skills from [TechWolf](https://techwolf.ai)'s engineering team. Battle-tested across 200+ engineers in the [AI-First Bootcamp](https://ai-first.techwolf.ai).
+Open-source Claude Code skills and Codex skills from [TechWolf](https://techwolf.ai)'s [AI-First Bootcamp](https://ai-first.techwolf.ai).
 
-<!-- TODO: Add hero GIF showing ai-firstify audit in action -->
+<!-- TODO: Replace with hero GIF showing ai-firstify audit in action -->
 
 ## What's inside
 
-### ai-firstify — AI-First Project Auditor
+### ai-firstify — AI-First Skill
 
-Audits any codebase against 9 AI-first design principles and 7 design patterns. Three modes:
+Audit, re-engineer, or bootstrap any codebase to align with 9 AI-first design principles and 7 design patterns. Three modes:
 
 - **Audit** — deep analysis across 7 dimensions with a scored report
 - **Re-engineer** — actively restructures your project to be AI-first
 - **Bootstrap** — guides new project setup with discovery questions
-
-```
-> /ai-firstify audit
-
-Scanning project structure...
-Analyzing 7 dimensions: foundation, agents, skills, complexity, context, safety, workflows
-
-AI-First Assessment Report
-==========================
-Overall Score: 6.2 / 10
-
-  Foundation & Structure    ████████░░  8/10
-  De-agentification         ███░░░░░░░  3/10
-  Skill Architecture        ██████░░░░  6/10
-  Complexity Management     ████████░░  8/10
-  Context Hygiene           █████░░░░░  5/10
-  Safety & Guardrails       ███████░░░  7/10
-  Workflow Optimization     ██████░░░░  6/10
-
-Top recommendations:
-1. Extract inline agent logic into standalone skills (SKILL.md)
-2. Add validation gates to your content pipeline
-3. Reduce context window pollution — move reference docs to load-on-demand
-```
 
 ### content-studio — Thought Leadership Pipeline
 
@@ -58,10 +30,7 @@ Full content pipeline for LinkedIn posts, blog posts, and opinion pieces. Includ
 ### Claude Code
 
 ```bash
-# Add the marketplace (once)
 claude plugin marketplace add techwolf-ai/ai-first-toolkit
-
-# Install plugins
 claude plugin install ai-firstify@techwolf-ai-first
 claude plugin install content-studio@techwolf-ai-first
 ```
@@ -71,8 +40,8 @@ claude plugin install content-studio@techwolf-ai-first
 Skills follow the [agentskills.io](https://agentskills.io) spec:
 
 ```bash
-./install.sh                    # install all plugins
-./install.sh ai-firstify       # install one plugin
+./install.sh
+./install.sh ai-firstify
 ./install.sh content-studio
 ```
 
@@ -80,11 +49,11 @@ Skills follow the [agentskills.io](https://agentskills.io) spec:
 <summary>More install commands</summary>
 
 ```bash
-./install.sh list               # list installed skills
-./install.sh verify             # check installation
-./install.sh update ai-firstify # update a plugin
+./install.sh list
+./install.sh verify
+./install.sh update ai-firstify
 ./install.sh uninstall ai-firstify
-./install.sh --target ~/custom/ # custom install directory
+./install.sh --target ~/custom/
 ```
 
 **What the installer does:**


### PR DESCRIPTION
## Summary
- Overhaul README: badges, sample ai-firstify output, quick start, collapsible details
- GitHub topics set (11 topics including claude-code, ai-first, codex, etc.)
- Repo description and homepage updated

## Note
GitHub metadata (topics, description, homepage) is already live — only the README needs merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)