### PR TITLE
Add people-management plugin

### DIFF
--- a/plugins/people-management/.claude-plugin/plugin.json
+++ b/plugins/people-management/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "people-management",
+  "version": "0.1.0",
+  "description": "AI-augmented management tooling for people managers. Surfaces the right context at the right time — before meetings, during 1:1 prep, when triaging messages, or reviewing customer status. Grounded in a performance framework (Impact + Growth) and AI-first design principles. Augments managers, never automates.",
+  "keywords": ["management", "1:1", "performance", "team-health", "meeting-prep"]
+}

--- a/plugins/people-management/.claude-plugin/plugin.json
+++ b/plugins/people-management/.claude-plugin/plugin.json
@@ -1,6 +1,7 @@
 {
   "name": "people-management",
   "version": "0.1.0",
-  "description": "AI-augmented management tooling for people managers. Surfaces the right context at the right time — before meetings, during 1:1 prep, when triaging messages, or reviewing customer status. Grounded in a performance framework (Impact + Growth) and AI-first design principles. Augments managers, never automates.",
+  "description": "AI-augmented management tooling for people managers. Surfaces the right context at the right time — before meetings, during 1:1 prep, when triaging messages, or reviewing customer status. Adapts to your org's performance and management frameworks. Augments managers, never automates.",
+  "author": { "name": "TechWolf" },
   "keywords": ["management", "1:1", "performance", "team-health", "meeting-prep"]
 }

--- a/plugins/people-management/.gitignore
+++ b/plugins/people-management/.gitignore
@@ -1,0 +1,12 @@
+# Runtime context (contains sensitive personal/performance data)
+manager-context/
+
+# Skill outputs (contain personal prep notes, triage, evidence)
+outputs/
+
+# OS and editor noise
+.DS_Store
+.idea/
+.vscode/
+*.swp
+*~

--- a/plugins/people-management/.mcp.json
+++ b/plugins/people-management/.mcp.json
@@ -1,0 +1,24 @@
+{
+  "mcpServers": {
+    "slack": {
+      "type": "http",
+      "url": "https://mcp.slack.com/mcp"
+    },
+    "notion": {
+      "type": "http",
+      "url": "https://mcp.notion.com/mcp"
+    },
+    "google-drive": {
+      "type": "http",
+      "url": "https://gdrive.mcp.claude.com/mcp"
+    },
+    "gmail": {
+      "type": "http",
+      "url": "https://gmail.mcp.claude.com/mcp"
+    },
+    "google-calendar": {
+      "type": "http",
+      "url": "https://gcal.mcp.claude.com/mcp"
+    }
+  }
+}

--- a/plugins/people-management/CLAUDE.md
+++ b/plugins/people-management/CLAUDE.md
@@ -18,8 +18,8 @@ AI-augmented management tooling. See `README.md` for philosophy and details.
 ## Key References
 
 - `references/operating-principles.md` -- shared principles all skills follow
-- `references/performance-framework.md` -- default performance dimensions (customised during setup)
-- `references/management-framework.md` -- default management dimensions (customised during setup)
+- `references/performance-framework.md` -- how skills use the performance framework (configured during setup)
+- `references/management-framework.md` -- how skills use the management framework (configured during setup)
 - `references/values-guide.md` -- how org values are used across skills
 
 ## Runtime Data

--- a/plugins/people-management/CLAUDE.md
+++ b/plugins/people-management/CLAUDE.md
@@ -1,0 +1,28 @@
+# People Manager Plugin
+
+AI-augmented management tooling. See `README.md` for philosophy and details.
+
+## Skills
+
+| Command | What it does |
+|---------|--------------|
+| `/setup` | Interactive onboarding -- run this first |
+| `/meeting-prep` | Pre-meeting briefing from all sources |
+| `/one-on-one-prep` | Deep 1:1 preparation (org's performance framework) |
+| `/triage-messages` | Batch message triage by urgency |
+| `/customer-status` | Account health overview |
+| `/priority-planner` | Highest-leverage actions for the day/week |
+| `/team-health` | Periodic team dynamics check |
+| `/performance-cycle` | Evidence gathering for review cycles |
+
+## Key References
+
+- `references/operating-principles.md` -- shared principles all skills follow
+- `references/performance-framework.md` -- default performance dimensions (customised during setup)
+- `references/management-framework.md` -- default management dimensions (customised during setup)
+- `references/values-guide.md` -- how org values are used across skills
+
+## Runtime Data
+
+- `manager-context/` -- persisted team context (created by `/setup`, gitignored)
+- `outputs/` -- skill outputs (gitignored)

--- a/plugins/people-management/README.md
+++ b/plugins/people-management/README.md
@@ -4,20 +4,20 @@ AI-augmented management tooling for people managers.
 
 ## Philosophy
 
-**Augment, never automate.** This plugin surfaces context so managers can make better decisions — it never acts on their behalf. Every output is a draft for human review. Management is about human judgment, trust, and relationships. AI provides leverage on information-gathering so managers spend more energy on the human side.
+**Augment, never automate.** This plugin surfaces context so managers can make better decisions -- it never acts on their behalf. Every output is a draft for human review. Management is about human judgment, trust, and relationships. AI provides leverage on information-gathering so managers spend more energy on the human side.
 
 ## Skills
 
 | Skill | What it does |
 |-------|--------------|
-| **Setup** | Interactive onboarding (9 phases): discovers team, terminology, goals, values, ways of working. Configures output preferences, triage rules, review calendar, and skill rhythm. Run this first. |
-| **Meeting Prep** | Gathers all relevant context before any meeting — attendees, topics, previous notes, action items |
+| **Setup** | Interactive onboarding (10 phases): discovers team, frameworks, terminology, goals, values, ways of working. Configures output preferences, triage rules, review calendar, and skill rhythm. Run this first. |
+| **Meeting Prep** | Gathers all relevant context before any meeting -- attendees, topics, previous notes, action items |
 | **Triage Messages** | Batch-processes Slack and email, categorises by urgency using your custom triage rules (VIPs, hot channels) |
-| **1:1 Prep** | Deep-dive preparation for 1:1s with direct reports, anchored in the performance framework (Impact + Growth) |
+| **1:1 Prep** | Deep-dive preparation for 1:1s with direct reports, anchored in your org's performance framework |
 | **Customer Status** | Synthesised view of account health and activity for customer-facing teams |
-| **Priority Planner** | Identifies highest-leverage actions for the day/week with goal alignment reflection — maps activities against OKRs, surfaces drift |
+| **Priority Planner** | Identifies highest-leverage actions for the day/week with goal alignment reflection -- maps activities against OKRs, surfaces drift |
 | **Team Health** | Periodic check through two lenses: development (growth, goals, performance) and wellbeing (energy, connection, celebration) |
-| **Performance Cycle** | Evidence gathering for bi-annual review cycles, organised along Impact and Growth dimensions |
+| **Performance Cycle** | Evidence gathering for review cycles, organised along your org's performance framework dimensions |
 
 ## Setup Flow
 
@@ -25,28 +25,28 @@ AI-augmented management tooling for people managers.
 2. Connect required MCP sources
 3. Run `/setup` to begin interactive onboarding
 
-Setup covers 9 phases:
-1. **Team discovery** — team structure, terminology, goals, ways of working, customers
-2. **Organizational values** — your org's core values and what signals to look for
-3. **Output preferences** — language, tone, file format, folder structure, naming
-4. **Manager's own context** — your OKRs, who you report to, upward priorities
-5. **Triage rules** — VIP people, hot channels, deprioritise list, privacy boundaries
-6. **Review calendar** — cycle dates, calibration, promotion windows
-7. **Skill preferences** — 1:1 style, suggested rhythm for all skills
-8. **Staleness check** — flags stale data for validation
-9. **Persist & wrap up** — saves all context, summary, suggested first skills
+Setup covers 10 phases:
+1. **Team discovery** -- team structure, terminology, goals, ways of working, customers
+2. **Performance & management frameworks** -- your org's performance dimensions, rating scale, management competencies
+3. **Organizational values** -- your org's core values and what signals to look for
+4. **Output preferences** -- language, tone, file format, folder structure, naming
+5. **Manager's own context** -- your OKRs, who you report to, upward priorities
+6. **Triage rules** -- VIP people, hot channels, deprioritise list, privacy boundaries
+7. **Review calendar** -- cycle dates, calibration, promotion windows
+8. **Skill preferences** -- 1:1 style, suggested rhythm for all skills
+9. **Staleness check** -- flags stale data for validation
+10. **Persist & wrap up** -- saves all context, summary, suggested first skills
 
 ## Required Connectors
 
-- **Slack** — message search, channel reading, user profiles
-- **Notion** — performance docs, goals, OKRs, team pages
-- **Google Drive** — meeting notes, 1:1 docs, strategy docs
-- **Gmail** — email context and triage
-- **Google Calendar** — upcoming meetings, attendee lists
+- **Slack** -- message search, channel reading, user profiles
+- **Notion** -- performance docs, goals, OKRs, team pages
+- **Google Drive** -- meeting notes, 1:1 docs, strategy docs
+- **Gmail** -- email context and triage
+- **Google Calendar** -- upcoming meetings, attendee lists
 
 ## Grounded In
 
-- **Your organization's values** — configured during setup, used as a lens across 1:1 prep, team health, and performance reviews
-- **Management framework** (Deliver Excellence + Develop People)
-- **Performance framework** (Impact + Growth, ratings, promotion readiness)
-- **AI-first design principles**
+- **Your organization's frameworks** -- performance and management frameworks configured during setup, with sensible defaults if your org doesn't have formal ones
+- **Your organization's values** -- configured during setup, used as a lens across 1:1 prep, team health, and performance reviews
+- **AI-first design principles** -- narrow scope, human-in-the-loop, progressive disclosure

--- a/plugins/people-management/README.md
+++ b/plugins/people-management/README.md
@@ -1,0 +1,52 @@
+# People Manager
+
+AI-augmented management tooling for people managers.
+
+## Philosophy
+
+**Augment, never automate.** This plugin surfaces context so managers can make better decisions — it never acts on their behalf. Every output is a draft for human review. Management is about human judgment, trust, and relationships. AI provides leverage on information-gathering so managers spend more energy on the human side.
+
+## Skills
+
+| Skill | What it does |
+|-------|--------------|
+| **Setup** | Interactive onboarding (9 phases): discovers team, terminology, goals, values, ways of working. Configures output preferences, triage rules, review calendar, and skill rhythm. Run this first. |
+| **Meeting Prep** | Gathers all relevant context before any meeting — attendees, topics, previous notes, action items |
+| **Triage Messages** | Batch-processes Slack and email, categorises by urgency using your custom triage rules (VIPs, hot channels) |
+| **1:1 Prep** | Deep-dive preparation for 1:1s with direct reports, anchored in the performance framework (Impact + Growth) |
+| **Customer Status** | Synthesised view of account health and activity for customer-facing teams |
+| **Priority Planner** | Identifies highest-leverage actions for the day/week with goal alignment reflection — maps activities against OKRs, surfaces drift |
+| **Team Health** | Periodic check through two lenses: development (growth, goals, performance) and wellbeing (energy, connection, celebration) |
+| **Performance Cycle** | Evidence gathering for bi-annual review cycles, organised along Impact and Growth dimensions |
+
+## Setup Flow
+
+1. Install the plugin
+2. Connect required MCP sources
+3. Run `/setup` to begin interactive onboarding
+
+Setup covers 9 phases:
+1. **Team discovery** — team structure, terminology, goals, ways of working, customers
+2. **Organizational values** — your org's core values and what signals to look for
+3. **Output preferences** — language, tone, file format, folder structure, naming
+4. **Manager's own context** — your OKRs, who you report to, upward priorities
+5. **Triage rules** — VIP people, hot channels, deprioritise list, privacy boundaries
+6. **Review calendar** — cycle dates, calibration, promotion windows
+7. **Skill preferences** — 1:1 style, suggested rhythm for all skills
+8. **Staleness check** — flags stale data for validation
+9. **Persist & wrap up** — saves all context, summary, suggested first skills
+
+## Required Connectors
+
+- **Slack** — message search, channel reading, user profiles
+- **Notion** — performance docs, goals, OKRs, team pages
+- **Google Drive** — meeting notes, 1:1 docs, strategy docs
+- **Gmail** — email context and triage
+- **Google Calendar** — upcoming meetings, attendee lists
+
+## Grounded In
+
+- **Your organization's values** — configured during setup, used as a lens across 1:1 prep, team health, and performance reviews
+- **Management framework** (Deliver Excellence + Develop People)
+- **Performance framework** (Impact + Growth, ratings, promotion readiness)
+- **AI-first design principles**

--- a/plugins/people-management/references/ai-first-principles.md
+++ b/plugins/people-management/references/ai-first-principles.md
@@ -1,0 +1,46 @@
+# AI-First Design Principles
+
+These principles guide how every skill in this plugin is designed.
+
+## Core Principles
+
+### 1. You Are Responsible
+The human is always accountable. AI surfaces information and proposes — it never decides or acts autonomously. Every output is a draft for human review. In management context: the manager makes the call, the tool provides leverage.
+
+### 2. Narrow Scope
+Each skill does ONE thing well. No "do everything" commands. A meeting prep skill preps meetings. A triage skill triages. Users invoke what they need, when they need it. Resist the temptation to combine skills into mega-prompts.
+
+### 3. Build for Yourself First
+Design skills for real workflows, tested by real managers. If a skill doesn't save YOU time, it won't save anyone else time either. Start with what you actually do, not what sounds impressive.
+
+### 4. Start with a Plan
+Before building, map out: what inputs are available, what output is needed, what success looks like. Every skill has a clear trigger, clear sources, and a clear output format.
+
+### 5. Don't Build Your Own Agent
+Use the platform's capabilities. The platform provides MCP connectors, skill architecture, and context management. Don't reinvent these. Compose existing tools rather than building from scratch.
+
+### 6. Stick to the Point
+Don't let the AI ramble. Skills should produce focused, actionable output. A meeting prep should be scannable in 2 minutes. A triage should categorise, not narrate. Brevity is a feature.
+
+### 7. Don't Be Stingy on the Input
+Give the AI rich context. The setup skill exists to build a deep understanding of the manager's world. Reference files embed framework knowledge. The more context the AI has, the less generic the output.
+
+### 8. Start with a Clean Slate
+Each invocation should work independently. Don't assume the AI "remembers" a previous run. Load context explicitly from files (manager-context/). This makes skills reliable and debuggable.
+
+### 9. Speak the Right Language
+Use the manager's terminology, not generic business jargon. The setup skill builds a terminology map specifically so other skills can decode and use internal language. "CS" instead of "Customer Success", "the pod" instead of "the cross-functional team."
+
+## How These Apply to This Plugin
+
+| Principle | How it shows up |
+|-----------|----------------|
+| You Are Responsible | Skills never send messages, make decisions, or take action |
+| Narrow Scope | 8 distinct skills, each with one clear purpose |
+| Build for Yourself | Tested with real managers first |
+| Start with a Plan | Every skill has structured input → output flow |
+| Don't Build Your Own Agent | Uses The platform MCP connectors and skill architecture |
+| Stick to the Point | Outputs are scannable summaries with links, not essays |
+| Don't Be Stingy on Input | Setup skill + reference files provide deep context |
+| Start with a Clean Slate | Every skill reads manager-context/ fresh |
+| Speak the Right Language | Uses team terminology via setup-built glossary |

--- a/plugins/people-management/references/management-framework.md
+++ b/plugins/people-management/references/management-framework.md
@@ -1,46 +1,31 @@
 # Management Framework
 
-How your organization evaluates and develops managers. Discovered during `/setup` and stored in `manager-context/management-framework.md`.
+How this plugin uses your org's management framework. The actual framework is configured during `/setup` and stored in `manager-context/management-framework.md`.
 
-If no org-specific framework is configured, skills fall back to two universal management dimensions.
+## What Setup Configures
 
-## Default Dimensions
+During `/setup` Phase 2, the plugin discovers or helps you define:
 
-### Results
-How the manager drives outcomes through their team.
+- **Management dimensions** -- what your org expects from managers (e.g., "Results + People", a competency model, or something custom)
+- **Competencies per dimension** -- the specific skills or behaviours expected
+- **How managers are evaluated** -- separate track, same as ICs, or informal
 
-- **Delegation** -- sets clear expectations, delegates appropriately, protects focus time
-- **Execution** -- removes blockers, drives accountability, manages dependencies
-- **Communication** -- keeps stakeholders informed, creates clarity, manages upward
+If your org doesn't have a formal management framework, setup provides sensible defaults.
 
-### People
-How the manager grows and retains their team.
+## How Skills Map to Management
 
-- **Development & Engagement** -- invests in growth, creates psychological safety, builds belonging
-- **Performance Management** -- gives timely feedback, has honest conversations, manages underperformance
-- **Hiring** -- maintains a strong bar, builds diverse teams, invests in onboarding
+Skills naturally support different management areas. The mapping uses whatever dimension names your org configured during setup.
 
-These defaults work for most organizations. During setup, the manager can replace or extend them with their org's actual management competencies.
+| Skill | What it supports |
+|-------|-----------------|
+| Triage Messages | Communication, staying responsive to the team |
+| Meeting Prep | Execution, being prepared and driving outcomes |
+| Priority Planner | Execution + people development, balancing delivery with growth |
+| 1:1 Prep | People development, investing in individual growth |
+| Team Health | Engagement, psychological safety, team culture |
+| Performance Cycle | Performance management, fair and evidence-based reviews |
+| Customer Status | Execution, delivery oversight |
 
-## Org-Specific Configuration
+## Why This Matters
 
-During `/setup`, the plugin discovers:
-- **Management competency model** -- what your org expects from managers
-- **How managers are evaluated** -- separate track, same framework as ICs, or informal
-- **Level expectations** -- if management levels exist with different expectations
-
-This is stored in `manager-context/management-framework.md` and loaded by skills that reference management dimensions.
-
-## How Skills Map to Management Dimensions
-
-Skills naturally support different management areas. When an org-specific framework is configured, this mapping is updated to use the org's dimension names.
-
-| Skill | Default mapping |
-|-------|----------------|
-| Triage Messages | Results -- Communication |
-| Meeting Prep | Results -- Execution |
-| Priority Planner | Results -- Execution + People |
-| 1:1 Prep | People -- Development |
-| Team Health | People -- Development & Engagement |
-| Performance Cycle | People -- Performance Management |
-| Customer Status | Results -- Execution |
+The management framework gives skills a lens for connecting day-to-day actions to bigger management outcomes. When a priority planner suggests an action, it can note which management dimension it supports. When a team health check surfaces a pattern, it can connect to the relevant competency.

--- a/plugins/people-management/references/management-framework.md
+++ b/plugins/people-management/references/management-framework.md
@@ -1,0 +1,53 @@
+# Management Framework
+
+A framework for evaluating and developing people managers. Two dimensions, six sub-dimensions.
+
+## Dimension 1: Deliver Excellence
+
+How the manager drives results through their team.
+
+### Delegation
+- Sets clear expectations and ownership
+- Delegates appropriately — doesn't micromanage or under-delegate
+- Protects team's focus time
+
+### Execution
+- Removes blockers, unblocks the team
+- Drives accountability and follow-through
+- Manages cross-functional dependencies
+
+### Communication
+- Keeps stakeholders informed without over-communicating
+- Creates clarity from ambiguity
+- Manages upward effectively
+
+## Dimension 2: Develop People
+
+How the manager grows and retains their team.
+
+### Team Development & Engagement
+- Invests in each person's growth
+- Creates psychological safety
+- Builds team identity and belonging
+
+### Performance Management
+- Gives timely, specific feedback
+- Has honest performance conversations
+- Manages underperformance with care and clarity
+
+### Hiring
+- Maintains a strong hiring bar
+- Builds diverse teams
+- Invests in onboarding
+
+## How Skills Map to This Framework
+
+| Skill | Primary dimension |
+|-------|------------------|
+| Triage Messages | Deliver Excellence — Communication |
+| Meeting Prep | Deliver Excellence — Execution |
+| Priority Planner | Deliver Excellence — Execution + Develop People |
+| 1:1 Prep | Develop People — Team Development |
+| Team Health | Develop People — Team Development & Engagement |
+| Performance Cycle | Develop People — Performance Management |
+| Customer Status | Deliver Excellence — Execution |

--- a/plugins/people-management/references/management-framework.md
+++ b/plugins/people-management/references/management-framework.md
@@ -1,53 +1,46 @@
 # Management Framework
 
-A framework for evaluating and developing people managers. Two dimensions, six sub-dimensions.
+How your organization evaluates and develops managers. Discovered during `/setup` and stored in `manager-context/management-framework.md`.
 
-## Dimension 1: Deliver Excellence
+If no org-specific framework is configured, skills fall back to two universal management dimensions.
 
-How the manager drives results through their team.
+## Default Dimensions
 
-### Delegation
-- Sets clear expectations and ownership
-- Delegates appropriately — doesn't micromanage or under-delegate
-- Protects team's focus time
+### Results
+How the manager drives outcomes through their team.
 
-### Execution
-- Removes blockers, unblocks the team
-- Drives accountability and follow-through
-- Manages cross-functional dependencies
+- **Delegation** -- sets clear expectations, delegates appropriately, protects focus time
+- **Execution** -- removes blockers, drives accountability, manages dependencies
+- **Communication** -- keeps stakeholders informed, creates clarity, manages upward
 
-### Communication
-- Keeps stakeholders informed without over-communicating
-- Creates clarity from ambiguity
-- Manages upward effectively
-
-## Dimension 2: Develop People
-
+### People
 How the manager grows and retains their team.
 
-### Team Development & Engagement
-- Invests in each person's growth
-- Creates psychological safety
-- Builds team identity and belonging
+- **Development & Engagement** -- invests in growth, creates psychological safety, builds belonging
+- **Performance Management** -- gives timely feedback, has honest conversations, manages underperformance
+- **Hiring** -- maintains a strong bar, builds diverse teams, invests in onboarding
 
-### Performance Management
-- Gives timely, specific feedback
-- Has honest performance conversations
-- Manages underperformance with care and clarity
+These defaults work for most organizations. During setup, the manager can replace or extend them with their org's actual management competencies.
 
-### Hiring
-- Maintains a strong hiring bar
-- Builds diverse teams
-- Invests in onboarding
+## Org-Specific Configuration
 
-## How Skills Map to This Framework
+During `/setup`, the plugin discovers:
+- **Management competency model** -- what your org expects from managers
+- **How managers are evaluated** -- separate track, same framework as ICs, or informal
+- **Level expectations** -- if management levels exist with different expectations
 
-| Skill | Primary dimension |
-|-------|------------------|
-| Triage Messages | Deliver Excellence — Communication |
-| Meeting Prep | Deliver Excellence — Execution |
-| Priority Planner | Deliver Excellence — Execution + Develop People |
-| 1:1 Prep | Develop People — Team Development |
-| Team Health | Develop People — Team Development & Engagement |
-| Performance Cycle | Develop People — Performance Management |
-| Customer Status | Deliver Excellence — Execution |
+This is stored in `manager-context/management-framework.md` and loaded by skills that reference management dimensions.
+
+## How Skills Map to Management Dimensions
+
+Skills naturally support different management areas. When an org-specific framework is configured, this mapping is updated to use the org's dimension names.
+
+| Skill | Default mapping |
+|-------|----------------|
+| Triage Messages | Results -- Communication |
+| Meeting Prep | Results -- Execution |
+| Priority Planner | Results -- Execution + People |
+| 1:1 Prep | People -- Development |
+| Team Health | People -- Development & Engagement |
+| Performance Cycle | People -- Performance Management |
+| Customer Status | Results -- Execution |

--- a/plugins/people-management/references/operating-principles.md
+++ b/plugins/people-management/references/operating-principles.md
@@ -1,0 +1,41 @@
+# Operating Principles
+
+Shared principles that apply to all People Manager skills. Every skill should reference this file and follow these principles.
+
+## Augment, Never Automate
+
+Every output is a draft for human review. Management is about human judgment, trust, and relationships. AI provides leverage on information-gathering — it never decides, prescribes, or acts on the manager's behalf.
+
+## Data Scope
+
+- All channels, documents, emails, and DMs the manager is part of are fair game.
+- **Never** surface DMs between other people that don't include the manager.
+- When using DM content, flag it as `(from DM)` so the manager knows it's sensitive context not visible to the team.
+- Wellbeing signals are especially sensitive — surface gently, as conversation starters, never as conclusions.
+
+## Signals, Not Diagnoses
+
+- Never say "this person is disengaged" or "this person is struggling."
+- Always frame as "signal worth exploring" or "pattern to check in on."
+- Decreased activity could mean many things — present observations, let the manager interpret.
+- Baseline matters: a quiet person being quiet isn't a signal. A usually active person going quiet might be.
+
+## Evidence Over Opinion
+
+- Every claim should link back to where you found it. Don't synthesise without attribution.
+- Recency matters — prioritise recent information and flag anything older than ~2 months.
+- Absence of evidence is not evidence of absence — especially for values and behaviours best observed in person.
+
+## Connector Unavailability
+
+If an MCP connector (Slack, Notion, Gmail, Google Drive, Google Calendar) is unavailable or returns errors:
+1. Note which connector is unavailable
+2. Proceed with the data you can access from other connectors
+3. Flag the gap in your output so the manager knows what's missing
+4. Never silently skip a data source — always tell the manager what you couldn't check
+
+## Source Everything
+
+- Link to the specific Slack message, Notion page, Drive doc, or email thread
+- "I found X in #channel on [date]" is better than "X is happening"
+- If volume is high, summarise with representative links rather than listing every item

--- a/plugins/people-management/references/performance-framework.md
+++ b/plugins/people-management/references/performance-framework.md
@@ -1,0 +1,71 @@
+# Performance Framework
+
+## Two Dimensions
+
+### Impact
+How effectively you deliver results and create value.
+
+| Sub-dimension | What it means |
+|--------------|---------------|
+| **Goal Achievement** | Did you achieve your goals? Were commitments met? |
+| **Quality of Outcomes** | Was the work excellent? Did it meet high standards? |
+| **Business & Team Impact** | Did it matter? Did the work move the needle for the business or team? |
+
+### Growth
+How you're developing as a professional and expanding your capabilities.
+
+| Sub-dimension | What it means |
+|--------------|---------------|
+| **Skill Development** | Are you building new technical or professional capabilities? |
+| **Behavioral Growth** | Are you growing in how you work with others, communicate, and lead? |
+| **Scope Expansion** | Are you taking on bigger, broader, or different challenges? |
+
+## Ratings
+
+| Rating | Description |
+|--------|-------------|
+| **Outstanding** | Consistently exceeds expectations across both Impact and Growth. Exceptional contributions that significantly elevate the team and business. |
+| **Exceptional** | Exceeds expectations in most areas. Strong contributions with notable excellence in specific dimensions. |
+| **Rising** | Meets expectations and shows clear upward trajectory. Growing into the role with visible momentum. |
+| **Strong** | Meets expectations consistently. Reliable, solid contributor delivering what's expected. |
+| **Below Expectations** | Not meeting expectations in key areas. Requires focused support and improvement plan. |
+
+## Promotion Readiness
+
+| Label | Meaning |
+|-------|---------|
+| **Ready Now** | Consistently performing at the next level. Ready for promotion in the current cycle. |
+| **Ready Soon** | Demonstrating next-level behaviours in some areas. 1-2 cycles away with continued growth. |
+| **Growth Path** | On a development trajectory but not yet showing next-level performance. Clear growth plan needed. |
+
+## Review Cadence
+
+| Cycle | Type | When |
+|-------|------|------|
+| Winter | Full review | December–January |
+| Spring | Light check-in | March–April |
+| Summer | Full review | June–July |
+| Fall | Light check-in | September–October |
+
+**Full reviews:** Comprehensive assessment across all dimensions, ratings assigned, promotion decisions made.
+
+**Light check-ins:** Goal progress review, development conversation, no formal ratings. Focus on "are we on track?"
+
+## Manager's Role in Performance
+
+From the management framework (see management-framework.md):
+- Conducts fair reviews, addresses underperformance, recognises strong performance
+- Uses the framework as a development tool (not just evaluation), makes tough calls early with empathy, creates a culture where excellence is visible
+
+## Evidence Gathering Guidelines
+
+When preparing reviews, look for evidence across:
+1. **Goal tracking systems** — Notion pages, OKR docs
+2. **Project deliverables** — shipped features, completed milestones, docs produced
+3. **Peer recognition** — Slack shoutouts, feedback from collaborators
+4. **Customer/stakeholder feedback** — visible in project channels, email threads
+5. **Development activities** — courses, workshops, mentoring, scope expansion
+
+**What digital signals CAN show:** Goal completion, project delivery, peer recognition, scope changes, activity patterns.
+
+**What digital signals CANNOT show:** Quality of thinking, relationship building, leadership presence, judgment calls, cultural contribution. These require the manager's direct observation.

--- a/plugins/people-management/references/performance-framework.md
+++ b/plugins/people-management/references/performance-framework.md
@@ -1,70 +1,51 @@
 # Performance Framework
 
-## Two Dimensions
+How your organization evaluates performance. Discovered during `/setup` and stored in `manager-context/performance-framework.md`.
+
+If no org-specific framework is configured, skills fall back to two universal dimensions that most performance systems share.
+
+## Default Dimensions
 
 ### Impact
-How effectively you deliver results and create value.
+How effectively someone delivers results and creates value.
 
 | Sub-dimension | What it means |
 |--------------|---------------|
-| **Goal Achievement** | Did you achieve your goals? Were commitments met? |
+| **Goal Achievement** | Did they achieve their goals? Were commitments met? |
 | **Quality of Outcomes** | Was the work excellent? Did it meet high standards? |
-| **Business & Team Impact** | Did it matter? Did the work move the needle for the business or team? |
+| **Business & Team Impact** | Did it matter? Did the work move the needle? |
 
 ### Growth
-How you're developing as a professional and expanding your capabilities.
+How someone is developing as a professional.
 
 | Sub-dimension | What it means |
 |--------------|---------------|
-| **Skill Development** | Are you building new technical or professional capabilities? |
-| **Behavioral Growth** | Are you growing in how you work with others, communicate, and lead? |
-| **Scope Expansion** | Are you taking on bigger, broader, or different challenges? |
+| **Skill Development** | Building new technical or professional capabilities? |
+| **Behavioral Growth** | Growing in how they work with others, communicate, lead? |
+| **Scope Expansion** | Taking on bigger, broader, or different challenges? |
 
-## Ratings
+These defaults work for most organizations. During setup, the manager can replace or extend them with their org's actual framework dimensions.
 
-| Rating | Description |
-|--------|-------------|
-| **Outstanding** | Consistently exceeds expectations across both Impact and Growth. Exceptional contributions that significantly elevate the team and business. |
-| **Exceptional** | Exceeds expectations in most areas. Strong contributions with notable excellence in specific dimensions. |
-| **Rising** | Meets expectations and shows clear upward trajectory. Growing into the role with visible momentum. |
-| **Strong** | Meets expectations consistently. Reliable, solid contributor delivering what's expected. |
-| **Below Expectations** | Not meeting expectations in key areas. Requires focused support and improvement plan. |
+## Org-Specific Configuration
 
-## Promotion Readiness
+During `/setup`, the plugin discovers:
 
-| Label | Meaning |
-|-------|---------|
-| **Ready Now** | Consistently performing at the next level. Ready for promotion in the current cycle. |
-| **Ready Soon** | Demonstrating next-level behaviours in some areas. 1-2 cycles away with continued growth. |
-| **Growth Path** | On a development trajectory but not yet showing next-level performance. Clear growth plan needed. |
+- **Framework dimensions** -- what your org evaluates (may differ from the defaults above)
+- **Rating scale** -- how performance is rated (e.g., 5-point scale, letter grades, descriptive labels)
+- **Promotion readiness labels** -- how your org tracks promotion readiness (if applicable)
+- **Review cadence** -- when reviews happen and what type (full review vs. light check-in)
+- **Goal cadence** -- how often goals are set and reviewed
 
-## Review Cadence
-
-| Cycle | Type | When |
-|-------|------|------|
-| Winter | Full review | December–January |
-| Spring | Light check-in | March–April |
-| Summer | Full review | June–July |
-| Fall | Light check-in | September–October |
-
-**Full reviews:** Comprehensive assessment across all dimensions, ratings assigned, promotion decisions made.
-
-**Light check-ins:** Goal progress review, development conversation, no formal ratings. Focus on "are we on track?"
-
-## Manager's Role in Performance
-
-From the management framework (see management-framework.md):
-- Conducts fair reviews, addresses underperformance, recognises strong performance
-- Uses the framework as a development tool (not just evaluation), makes tough calls early with empathy, creates a culture where excellence is visible
+This is stored in `manager-context/performance-framework.md` and loaded by skills that need it (performance-cycle, one-on-one-prep, team-health).
 
 ## Evidence Gathering Guidelines
 
 When preparing reviews, look for evidence across:
-1. **Goal tracking systems** — Notion pages, OKR docs
-2. **Project deliverables** — shipped features, completed milestones, docs produced
-3. **Peer recognition** — Slack shoutouts, feedback from collaborators
-4. **Customer/stakeholder feedback** — visible in project channels, email threads
-5. **Development activities** — courses, workshops, mentoring, scope expansion
+1. **Goal tracking systems** -- Notion pages, OKR docs
+2. **Project deliverables** -- shipped features, completed milestones, docs produced
+3. **Peer recognition** -- Slack shoutouts, feedback from collaborators
+4. **Customer/stakeholder feedback** -- visible in project channels, email threads
+5. **Development activities** -- courses, workshops, mentoring, scope expansion
 
 **What digital signals CAN show:** Goal completion, project delivery, peer recognition, scope changes, activity patterns.
 

--- a/plugins/people-management/references/performance-framework.md
+++ b/plugins/people-management/references/performance-framework.md
@@ -1,46 +1,32 @@
 # Performance Framework
 
-How your organization evaluates performance. Discovered during `/setup` and stored in `manager-context/performance-framework.md`.
+How this plugin uses your org's performance framework. The actual framework is configured during `/setup` and stored in `manager-context/performance-framework.md`.
 
-If no org-specific framework is configured, skills fall back to two universal dimensions that most performance systems share.
+## What Setup Configures
 
-## Default Dimensions
+During `/setup` Phase 2, the plugin discovers or helps you define:
 
-### Impact
-How effectively someone delivers results and creates value.
-
-| Sub-dimension | What it means |
-|--------------|---------------|
-| **Goal Achievement** | Did they achieve their goals? Were commitments met? |
-| **Quality of Outcomes** | Was the work excellent? Did it meet high standards? |
-| **Business & Team Impact** | Did it matter? Did the work move the needle? |
-
-### Growth
-How someone is developing as a professional.
-
-| Sub-dimension | What it means |
-|--------------|---------------|
-| **Skill Development** | Building new technical or professional capabilities? |
-| **Behavioral Growth** | Growing in how they work with others, communicate, lead? |
-| **Scope Expansion** | Taking on bigger, broader, or different challenges? |
-
-These defaults work for most organizations. During setup, the manager can replace or extend them with their org's actual framework dimensions.
-
-## Org-Specific Configuration
-
-During `/setup`, the plugin discovers:
-
-- **Framework dimensions** -- what your org evaluates (may differ from the defaults above)
-- **Rating scale** -- how performance is rated (e.g., 5-point scale, letter grades, descriptive labels)
+- **Framework dimensions** -- what your org evaluates (e.g., "What + How", "Impact + Growth", "Results + Behaviours", or something else entirely)
+- **Sub-dimensions** -- the specific areas within each dimension
+- **Rating scale** -- how performance is rated (descriptive labels, numbered scale, etc.)
 - **Promotion readiness labels** -- how your org tracks promotion readiness (if applicable)
-- **Review cadence** -- when reviews happen and what type (full review vs. light check-in)
+- **Review cadence** -- when reviews happen and what type
 - **Goal cadence** -- how often goals are set and reviewed
 
-This is stored in `manager-context/performance-framework.md` and loaded by skills that need it (performance-cycle, one-on-one-prep, team-health).
+If your org doesn't have a formal framework, setup provides sensible defaults you can use or adjust.
+
+## How Skills Use the Framework
+
+| Skill | What it loads | How it uses it |
+|-------|--------------|----------------|
+| Performance Cycle | Full framework (dimensions, ratings, cadence) | Organises evidence by dimension, checks coverage |
+| 1:1 Prep | Dimensions and sub-dimensions | Maps development goals to framework, suggests questions |
+| Team Health | Dimensions (high-level) | Checks team patterns across framework areas |
+| Priority Planner | Dimensions (high-level) | Notes which framework area an action supports |
 
 ## Evidence Gathering Guidelines
 
-When preparing reviews, look for evidence across:
+When preparing reviews, skills look for evidence across:
 1. **Goal tracking systems** -- Notion pages, OKR docs
 2. **Project deliverables** -- shipped features, completed milestones, docs produced
 3. **Peer recognition** -- Slack shoutouts, feedback from collaborators
@@ -50,3 +36,12 @@ When preparing reviews, look for evidence across:
 **What digital signals CAN show:** Goal completion, project delivery, peer recognition, scope changes, activity patterns.
 
 **What digital signals CANNOT show:** Quality of thinking, relationship building, leadership presence, judgment calls, cultural contribution. These require the manager's direct observation.
+
+## Evidence Patterns by Dimension Type
+
+Skills use these heuristics to know what to search for, regardless of what your org calls its dimensions:
+
+- **Results/delivery dimensions:** goal completion, shipped work, quality feedback, business outcomes
+- **Growth/development dimensions:** learning activities, new skills applied, scope expansion, behavioural changes
+- **Collaboration/leadership dimensions:** cross-team activity, mentoring, influence in discussions
+- **Behavioural/values dimensions:** see `values-guide.md`

--- a/plugins/people-management/references/values-guide.md
+++ b/plugins/people-management/references/values-guide.md
@@ -1,0 +1,35 @@
+# Values Guide
+
+How to use your organization's values in management skills. Values are defined during setup and stored in `manager-context/values.md`.
+
+## Why Values Matter in Management
+
+Values tell you *how* results should be delivered, not just *what* was achieved. They give managers conversation threads beyond goals and deliverables:
+- In 1:1s: values provide prompts to check in on behaviours, not just outputs
+- In team health: values surface whether the team is thriving culturally, not just performing
+- In performance reviews: values evidence shows how someone showed up, not just what they shipped
+
+## How Skills Use Values
+
+Each skill references your org's values differently:
+
+| Skill | How values are used |
+|-------|-------------------|
+| 1:1 Prep | Values snapshot — scan for signals related to each value, suggest conversation threads |
+| Team Health | Values as a lens alongside performance — are people living the values? |
+| Performance Cycle | Values evidence gathering — "how" someone delivered, organised by value |
+| Priority Planner | Values inform what gets prioritised beyond urgency |
+
+## Defining Good Value Signals
+
+For each of your org's values, consider:
+- **What does it look like in Slack?** (e.g., collaboration value → helping others in channels, cross-team activity)
+- **What does it look like in meetings?** (e.g., transparency value → sharing context, raising issues early)
+- **What does it look like in work output?** (e.g., quality value → iteration, attention to detail, peer feedback)
+- **What's hard to see digitally?** (e.g., empathy, presence, trust-building — flag these for manager's own observation)
+
+## Important Notes
+
+- **Values evidence is hardest to gather digitally.** Many values are best observed in person. Always caveat that the manager's direct observations carry more weight.
+- **Values are conversation threads, not checklists.** Don't force every value into every 1:1 or health check — surface values where there's a real signal.
+- **Absence of digital evidence ≠ absence of the behaviour.** Flag gaps honestly.

--- a/plugins/people-management/skills/customer-status/SKILL.md
+++ b/plugins/people-management/skills/customer-status/SKILL.md
@@ -79,49 +79,19 @@ For each account, determine a health signal based on evidence:
 
 ### 5. Produce the Overview
 
-```markdown
-# Customer Status — [Date]
-Team: [Manager's team name]
+Read `references/output-template.md` for the full output template structure.
 
-## Summary
-| Status | Count |
-|--------|-------|
-| 🟢 Healthy | [N] |
-| 🟡 Attention | [N] |
-| 🔴 At Risk | [N] |
+### 6. Sub-Agent Review
 
-## 🔴 Needs Attention
-### [Account Name]
-**Owner:** [team member] | **Channel:** #[channel] | **Phase:** [delivery phase]
-**Signal:** [1-2 sentences explaining why this is flagged — with links]
-**Last activity:** [date/time]
-**Suggested action:** [e.g., "Check in with [name] about the blocker they raised on [date]"]
+Spawn a sub-agent to review the customer status overview with fresh eyes. The reviewer should:
+- Check that **health signal assessments are evidence-based** -- every red/yellow rating should cite specific signals, not just absence of activity.
+- Verify that **silence is not over-interpreted** -- a quiet channel on a stable account is not the same as a quiet channel on an active delivery.
+- Check for **team member workload signals** -- if one person owns many flagged accounts, note it.
+- Flag any accounts where the evidence is thin enough that the health signal might be misleading.
 
-### [Account Name]
-...
+Incorporate the reviewer's feedback before presenting the final overview.
 
-## 🟡 Monitor
-### [Account Name]
-**Owner:** [team member] | **Channel:** #[channel]
-**Signal:** [1-2 sentences]
-**Last activity:** [date/time]
-
-## 🟢 On Track
-| Account | Owner | Last Activity | Notes |
-|---------|-------|--------------|-------|
-| [name] | [team member] | [date] | [1-line summary of recent positive signal] |
-
-## Upcoming Milestones
-| Account | Milestone | Date | Owner |
-|---------|-----------|------|-------|
-| [name] | [milestone] | [date] | [team member] |
-
-## Source Links
-- [link to customer channel]
-- [link to project page]
-```
-
-### 6. Present and Offer Follow-Up
+### 7. Present and Offer Follow-Up
 
 ```
 Here's your customer status overview. Want me to:

--- a/plugins/people-management/skills/customer-status/SKILL.md
+++ b/plugins/people-management/skills/customer-status/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: customer-status
+description: Synthesised view of account health and activity for managers overseeing customer-facing teams (Sales, CS, Professional Services, Presales). Scans project channels, email threads, and Notion pages to surface status, risks, and upcoming milestones — without requiring the manager to trawl through individual channels. Supports proactive account management.
+---
+
+# Customer Status Overview
+
+> **Principle: "Narrow scope, high impact."** One synthesised view across all accounts, so you can spot what needs attention without channel-hopping.
+
+Produces a dashboard-style overview of active customer accounts and internal projects for the manager's team.
+
+## When to Use
+
+- Weekly check-in on account health
+- Before leadership meetings where customer status is discussed
+- When the manager says "how are our accounts?", "customer status", "any customer risks?"
+- Can be filtered: "customer status for [account]", "customer status for [team member]'s accounts"
+
+## Instructions
+
+If any MCP connector is unavailable, follow the connector unavailability protocol in `../../references/operating-principles.md`.
+
+### 1. Load Context
+
+Read from `manager-context/`:
+- `sources.md` — customer/project channels, account mappings
+- `manager-profile.md` — team members and their account assignments
+- `team/` — individual team member profiles and project assignments
+
+If no manager-context exists:
+```
+⚠️ No manager context found. Run /setup first so I know which accounts and channels to monitor.
+I can still search broadly, but results will be less targeted.
+```
+
+### 2. Identify Active Accounts
+
+From manager-context, get the list of active accounts/projects and their:
+- Slack channels
+- Key contacts (team member and customer-side)
+- Notion project pages
+- Current delivery phase (if documented)
+
+If filtering by account or team member, narrow the scope.
+
+### 3. Scan Per Account
+
+For each active account, gather:
+
+**Slack (last 7 days):**
+- Recent messages in the project/customer channel
+- Volume of activity (high/normal/low compared to usual)
+- Any messages with escalation signals: "blocked", "risk", "delayed", "urgent", "escalate", "concerned"
+- Any positive signals: "shipped", "live", "approved", "happy", "great feedback"
+- Most recent message timestamp (to detect silent accounts)
+
+**Gmail (last 14 days):**
+- Email threads related to this customer
+- Any emails with escalation or risk language
+- Communication frequency
+
+**Notion:**
+- Project/customer status page (if documented in sources.md)
+- Last updated date
+- Any documented risks or decisions
+
+**Google Drive:**
+- Recent shared documents (SOWs, proposals, reports)
+
+### 4. Assess Health Signal
+
+For each account, determine a health signal based on evidence:
+
+- **🟢 Healthy:** Regular activity, positive signals, no escalations, milestones on track
+- **🟡 Attention:** Some risk signals, decreased activity, upcoming deadline, stale documentation
+- **🔴 At Risk:** Escalation language, blocked progress, customer complaints, silence for >5 days on active project
+
+**Important:** These are signals, not diagnoses. Always show the evidence that led to the assessment.
+
+### 5. Produce the Overview
+
+```markdown
+# Customer Status — [Date]
+Team: [Manager's team name]
+
+## Summary
+| Status | Count |
+|--------|-------|
+| 🟢 Healthy | [N] |
+| 🟡 Attention | [N] |
+| 🔴 At Risk | [N] |
+
+## 🔴 Needs Attention
+### [Account Name]
+**Owner:** [team member] | **Channel:** #[channel] | **Phase:** [delivery phase]
+**Signal:** [1-2 sentences explaining why this is flagged — with links]
+**Last activity:** [date/time]
+**Suggested action:** [e.g., "Check in with [name] about the blocker they raised on [date]"]
+
+### [Account Name]
+...
+
+## 🟡 Monitor
+### [Account Name]
+**Owner:** [team member] | **Channel:** #[channel]
+**Signal:** [1-2 sentences]
+**Last activity:** [date/time]
+
+## 🟢 On Track
+| Account | Owner | Last Activity | Notes |
+|---------|-------|--------------|-------|
+| [name] | [team member] | [date] | [1-line summary of recent positive signal] |
+
+## Upcoming Milestones
+| Account | Milestone | Date | Owner |
+|---------|-----------|------|-------|
+| [name] | [milestone] | [date] | [team member] |
+
+## Source Links
+- [link to customer channel]
+- [link to project page]
+```
+
+### 6. Present and Offer Follow-Up
+
+```
+Here's your customer status overview. Want me to:
+- Dig deeper into any specific account?
+- Prep for a conversation with [team member] about [account]?
+- Check email threads for a specific customer?
+```
+
+## Important Notes
+
+Read `../../references/operating-principles.md` for shared operating principles (data scope, DM flagging, signals vs diagnoses, connector unavailability).
+
+Additional notes specific to this skill:
+- **Don't alarm unnecessarily.** Silence on a channel might mean things are running smoothly. Combine multiple signals before flagging red.
+- **Recency matters.** Flag any account where project docs haven't been updated in >2 weeks on active projects.
+- **Respect customer confidentiality.** Summarise, don't reproduce customer communications verbatim. When surfacing DM content, flag it as `(from DM)`.
+- **Team member context.** If a team member owns multiple accounts, note that — they might be spread thin.

--- a/plugins/people-management/skills/customer-status/references/output-template.md
+++ b/plugins/people-management/skills/customer-status/references/output-template.md
@@ -1,0 +1,39 @@
+# Customer Status — [Date]
+Team: [Manager's team name]
+
+## Summary
+| Status | Count |
+|--------|-------|
+| 🟢 Healthy | [N] |
+| 🟡 Attention | [N] |
+| 🔴 At Risk | [N] |
+
+## 🔴 Needs Attention
+### [Account Name]
+**Owner:** [team member] | **Channel:** #[channel] | **Phase:** [delivery phase]
+**Signal:** [1-2 sentences explaining why this is flagged — with links]
+**Last activity:** [date/time]
+**Suggested action:** [e.g., "Check in with [name] about the blocker they raised on [date]"]
+
+### [Account Name]
+...
+
+## 🟡 Monitor
+### [Account Name]
+**Owner:** [team member] | **Channel:** #[channel]
+**Signal:** [1-2 sentences]
+**Last activity:** [date/time]
+
+## 🟢 On Track
+| Account | Owner | Last Activity | Notes |
+|---------|-------|--------------|-------|
+| [name] | [team member] | [date] | [1-line summary of recent positive signal] |
+
+## Upcoming Milestones
+| Account | Milestone | Date | Owner |
+|---------|-----------|------|-------|
+| [name] | [milestone] | [date] | [team member] |
+
+## Source Links
+- [link to customer channel]
+- [link to project page]

--- a/plugins/people-management/skills/meeting-prep/SKILL.md
+++ b/plugins/people-management/skills/meeting-prep/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: meeting-prep
+description: Comprehensive pre-meeting briefing that gathers all relevant context from Slack, email, Google Docs, Notion, and calendar. Produces a structured prep document so the manager walks into every meeting fully prepared. Supports thorough meeting preparation.
+---
+
+# Meeting Prep
+
+> **Principle: "Narrow scope, high impact."** One meeting, one thorough brief. No guessing — only sourced context.
+
+Gathers context from all connected sources for a specific upcoming meeting and produces a structured briefing.
+
+## When to Use
+
+- Before any meeting (1:1s have their own skill — use `/prep-one-on-one` instead)
+- When the manager says "prep me for [meeting]", "what do I need to know for [meeting]"
+- Can be invoked for the next upcoming meeting or a specific one by name/time
+
+## Instructions
+
+If any MCP connector is unavailable, follow the connector unavailability protocol in `../../references/operating-principles.md`.
+
+### 1. Identify the Meeting
+
+If not specified, check Google Calendar for the next upcoming meeting.
+
+If specified by name or time, search calendar for the matching event.
+
+Extract from the calendar event:
+- **Title**
+- **Time and duration**
+- **Attendees** (names and emails)
+- **Location/link**
+- **Description/agenda** (if present)
+- **Attached documents** (if any)
+
+If no matching meeting is found:
+```
+I couldn't find a meeting matching "[query]" on your calendar.
+Could you clarify which meeting you mean? Your upcoming meetings are:
+- [list next 5 meetings with times]
+```
+
+### 2. Load Manager Context
+
+Read from `manager-context/` (created by /setup):
+- `manager-profile.md` for team members and stakeholders
+- `terminology.md` for decoding any internal terms
+- `sources.md` for known data locations
+
+If manager-context doesn't exist, note this:
+```
+⚠️ No manager context found. Run /setup first for richer meeting prep.
+Proceeding with what I can find from sources directly.
+```
+
+### 3. Gather Attendee Context
+
+For each attendee, search across sources:
+
+**Slack:**
+- Recent messages from/by this person (last 7 days)
+- Threads they've been active in that relate to meeting topics
+- Any messages that mention the meeting topic
+
+**Gmail:**
+- Recent email threads with this person (last 14 days)
+- Especially any threads that include multiple meeting attendees
+
+**Google Drive:**
+- Shared documents with this person
+- Docs recently edited by them that relate to meeting topics
+
+**Notion:**
+- Pages authored or edited by them recently
+- Any decision logs or project pages relevant to the meeting
+
+**From manager-context** (if available):
+- Their role, team, and relationship to the manager
+- Any known context from previous interactions
+
+### 4. Gather Topic Context
+
+Based on the meeting title, description, and agenda:
+
+**Identify key topics** from the meeting title and description.
+
+For each topic, search:
+- **Slack** for recent discussions (last 14 days)
+- **Notion** for related pages, decisions, project status
+- **Google Drive** for related documents (pre-reads, previous meeting notes)
+- **Gmail** for related threads
+
+### 5. Find Previous Meeting Notes
+
+Search for prior instances of this meeting:
+- **Google Drive:** Search for docs matching the meeting name + "notes", "minutes", "recap"
+- **Notion:** Search for pages matching the meeting name
+
+If found, extract:
+- Action items from the last meeting
+- Decisions made
+- Open questions carried forward
+
+### 6. Produce the Briefing
+
+Structure the output as follows:
+
+```markdown
+# Meeting Prep: [Meeting Title]
+📅 [Day, Date] at [Time] ([Duration])
+👥 [Number] attendees
+
+## Attendees
+| Who | Role | Recent Context |
+|-----|------|----------------|
+| [Name] | [Role/team] | [1-line summary of what they've been working on or last interaction] |
+
+## Agenda & Context
+### [Topic 1 from agenda]
+[2-3 sentence summary of current state, sourced from Slack/Notion/Drive]
+- 🔗 [Link to relevant doc/thread]
+
+### [Topic 2]
+[Summary with sources]
+
+## Open Items from Last Meeting
+- [ ] [Action item] — assigned to [name], status: [done/pending/unknown]
+- [ ] [Action item] — assigned to [name], status: [done/pending/unknown]
+
+## Suggested Talking Points
+Based on what I've found, you might want to:
+- [Point based on a gap, conflict, or unresolved thread]
+- [Point based on a decision that needs to be made]
+- [Point based on something that's changed since last meeting]
+
+## Source Links
+- [Doc title](link)
+- [Slack thread](link)
+- [Notion page](link)
+```
+
+### 7. Present to Manager
+
+Share the briefing and offer follow-up:
+```
+Here's your prep for [meeting]. Anything you'd like me to dig deeper on?
+```
+
+## Important Notes
+
+Read `../../references/operating-principles.md` for shared operating principles (data scope, DM flagging, signals vs diagnoses, connector unavailability).
+
+Additional notes specific to this skill:
+- **Don't draft talking points as scripts.** Frame as prompts: "You might want to discuss..." not "Say this..."
+- **If context is thin**, say so: "I found limited context for this meeting."
+- **1:1 meetings:** Redirect to `/prep-one-on-one` which has deeper team-member-specific logic.

--- a/plugins/people-management/skills/meeting-prep/SKILL.md
+++ b/plugins/people-management/skills/meeting-prep/SKILL.md
@@ -103,41 +103,7 @@ If found, extract:
 
 ### 6. Produce the Briefing
 
-Structure the output as follows:
-
-```markdown
-# Meeting Prep: [Meeting Title]
-📅 [Day, Date] at [Time] ([Duration])
-👥 [Number] attendees
-
-## Attendees
-| Who | Role | Recent Context |
-|-----|------|----------------|
-| [Name] | [Role/team] | [1-line summary of what they've been working on or last interaction] |
-
-## Agenda & Context
-### [Topic 1 from agenda]
-[2-3 sentence summary of current state, sourced from Slack/Notion/Drive]
-- 🔗 [Link to relevant doc/thread]
-
-### [Topic 2]
-[Summary with sources]
-
-## Open Items from Last Meeting
-- [ ] [Action item] — assigned to [name], status: [done/pending/unknown]
-- [ ] [Action item] — assigned to [name], status: [done/pending/unknown]
-
-## Suggested Talking Points
-Based on what I've found, you might want to:
-- [Point based on a gap, conflict, or unresolved thread]
-- [Point based on a decision that needs to be made]
-- [Point based on something that's changed since last meeting]
-
-## Source Links
-- [Doc title](link)
-- [Slack thread](link)
-- [Notion page](link)
-```
+Read `references/output-template.md` for the full output template structure.
 
 ### 7. Present to Manager
 

--- a/plugins/people-management/skills/meeting-prep/references/output-template.md
+++ b/plugins/people-management/skills/meeting-prep/references/output-template.md
@@ -1,0 +1,31 @@
+# Meeting Prep: [Meeting Title]
+📅 [Day, Date] at [Time] ([Duration])
+👥 [Number] attendees
+
+## Attendees
+| Who | Role | Recent Context |
+|-----|------|----------------|
+| [Name] | [Role/team] | [1-line summary of what they've been working on or last interaction] |
+
+## Agenda & Context
+### [Topic 1 from agenda]
+[2-3 sentence summary of current state, sourced from Slack/Notion/Drive]
+- [Link to relevant doc/thread]
+
+### [Topic 2]
+[Summary with sources]
+
+## Open Items from Last Meeting
+- [ ] [Action item] — assigned to [name], status: [done/pending/unknown]
+- [ ] [Action item] — assigned to [name], status: [done/pending/unknown]
+
+## Suggested Talking Points
+Based on what I've found, you might want to:
+- [Point based on a gap, conflict, or unresolved thread]
+- [Point based on a decision that needs to be made]
+- [Point based on something that's changed since last meeting]
+
+## Source Links
+- [Doc title](link)
+- [Slack thread](link)
+- [Notion page](link)

--- a/plugins/people-management/skills/one-on-one-prep/SKILL.md
+++ b/plugins/people-management/skills/one-on-one-prep/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: one-on-one-prep
+description: Deep-dive preparation for 1:1 meetings with direct reports. Surfaces recent work, wins, friction, wellbeing signals, and development goal progress — anchored in the performance framework (Impact + Growth), organizational values, and management best practices. Produces a prep sheet with suggested conversation topics, not a script.
+---
+
+# 1:1 Prep
+
+> **Great 1:1s live at the intersection of performance and care.** Development keeps growth alive. Wellbeing makes sure the person behind the work is seen. Both matter every time.
+
+Deep-dive preparation for 1:1 meetings with a specific direct report, anchored in the performance framework and your organization's values.
+
+## When to Use
+
+- Before any 1:1 meeting with a direct report
+- When the manager says "prep my 1:1 with [name]", "what should I discuss with [name]"
+- Can be invoked with just a name — the skill finds the relevant context
+
+## Instructions
+
+If any MCP connector is unavailable, follow the connector unavailability protocol in `../../references/operating-principles.md`.
+
+### 1. Identify the Team Member
+
+If a name is provided, match it against `manager-context/team/` profiles.
+
+If no name is specified, check the calendar for the next upcoming 1:1 meeting and identify the attendee.
+
+If ambiguous:
+```
+Which team member? Your upcoming 1:1s are:
+- [Name] — [day] at [time]
+- [Name] — [day] at [time]
+```
+
+Load the team member's profile from `manager-context/team/[name].md` for:
+- Their role, current projects, communication style
+- Goals location (Notion page, Drive doc)
+- Last review date and development areas
+- Last 1:1 date and open items
+
+If no profile exists:
+```
+⚠️ No profile found for [name]. Run /setup to build team context, or I'll work with what I can find from sources directly.
+```
+
+### 2. Surface Recent Work & Wins
+
+**Slack (last 7-14 days):**
+- Messages posted by this person in team/project channels
+- Threads they've been active in
+- Any shoutouts or recognition they received (search for their name + positive signals like "great", "shipped", "amazing", "thanks")
+- Features shipped, PRs merged, deliverables completed (visible in public channels)
+
+**Google Drive:**
+- Documents they've recently created or edited
+- Especially docs related to their projects or deliverables
+
+**Notion:**
+- Pages they've authored or updated recently
+- Project status updates they've contributed to
+
+Compile into a "recent activity" summary.
+
+### 3. Detect Friction or Concerns
+
+Look for signals (NOT diagnoses — signals for the manager to explore):
+
+**Slack:**
+- Repeated blockers or unanswered questions
+- Messages where they expressed frustration or confusion
+- Decreased activity compared to usual patterns (if baseline is known)
+- Long threads where they're asking for help without clear resolution
+
+**Calendar:**
+- Cancelled or rescheduled 1:1s
+- Unusually heavy or light meeting load
+
+**Important:** Frame these as *conversation starters*, not assessments:
+```
+💡 Potential topics to explore (signals, not conclusions):
+- [Name] asked about [topic] in #channel 3 times this week without a clear resolution — might be a blocker worth discussing
+- [Name]'s activity in #project-channel has been lower than usual — could be fine, but worth checking in
+```
+
+### 4. Values & Wellbeing Check
+
+Scan for signals related to the organization's values (from `manager-context/values.md`) — these give the manager conversation threads beyond just goals and deliverables.
+
+If no values are configured, focus on these universal management dimensions:
+
+**Wellbeing & Energy:**
+- Late-night or weekend Slack activity (potential overwork)
+- Calendar density (back-to-back days, no focus time)
+- Tone in recent messages — enthusiasm vs. fatigue (soft signal only)
+- Have they taken time off recently?
+
+**Team Connection & Collaboration:**
+- Are they collaborating across the team, or working in isolation?
+- Engagement in team channels (social, celebrations)
+- Have they helped or unblocked teammates recently?
+
+**Communication & Transparency:**
+- Are they sharing context, asking for feedback, raising issues openly?
+- Any threads where they seemed hesitant to speak up?
+
+**Resourcefulness & Problem-Solving:**
+- Evidence of creative problem-solving, unblocking themselves, learning new things
+
+**Ownership & Initiative:**
+- Volunteering for stretch work, proposing ideas, taking initiative
+- Driving things to completion vs. waiting for direction
+
+If organizational values are configured, map these dimensions to the specific values and use value names in the output.
+
+Compile into a brief values snapshot (not a scorecard — conversation prompts):
+
+```
+Values Snapshot:
+- [Value/Dimension 1]: [observation or "no signal"]
+- [Value/Dimension 2]: [observation or "no signal"]
+...
+```
+
+_Only include values/dimensions where there's a meaningful signal — don't force all of them every time._
+
+### 5. Check Development Goals
+
+Using the goals location from the team member's profile:
+
+**Notion:**
+- Pull their current goals and development areas
+- Check when goals were last updated
+- Look for any self-assessment or progress notes
+
+**Google Drive:**
+- Pull the 1:1 document for this person
+- Check the most recent entries for open action items and commitments
+
+**Reference the performance framework dimensions:**
+- **Impact:** Goal achievement, quality of outcomes, business & team impact
+- **Growth:** Skill development, behavioral growth, scope expansion
+
+```
+📋 Development Goal Status:
+- Goal 1: "[goal text]" — [status: on track / needs attention / no update since [date]]
+- Goal 2: "[goal text]" — [status]
+- Development area: "[area]" — [any evidence of progress or attention]
+
+⏰ Last goal update: [date] — [flag if >6 weeks old]
+```
+
+### 6. Pull Previous 1:1 Notes
+
+Search for the last 1:1 document/notes:
+
+**Google Drive:** Search "[name] 1:1", "one on one [name]"
+
+Extract:
+- Open action items (for both manager and team member)
+- Topics that were "parked" for follow-up
+- Development commitments made
+
+```
+📝 From last 1:1 ([date]):
+Open items:
+- [ ] [Manager] to [action] — [status: done/pending/unknown]
+- [ ] [Team member] to [action] — [status: done/pending/unknown]
+Parked topics: [if any]
+```
+
+### 7. Produce the Prep Sheet
+
+Read `references/output-template.md` for the full output template structure.
+
+### 8. Present and Offer Follow-Up
+
+```
+Here's your prep for your 1:1 with [name]. Anything you'd like me to dig deeper on?
+```
+
+## Important Notes
+
+Read `../../references/operating-principles.md` for shared operating principles (data scope, DM flagging, signals vs diagnoses, connector unavailability).
+
+Additional notes specific to this skill:
+- **Wins first.** Always lead with recognition opportunities — this sets the tone.
+- **Goals are the backbone.** If goals are missing or stale, flag it prominently. Great 1:1s keep development goals alive.
+- **Framework + values alignment.** Suggested questions should map to Impact/Growth dimensions or your organization's values. Don't force all values every time — only surface values where there's a real signal.
+- **Values are conversation threads, not checklists.** The values snapshot helps managers notice things beyond deliverables. A 1:1 that only covers goals misses the human. A 1:1 that only covers feelings misses the growth. Both.
+- **Don't script the conversation.** Provide prompts and context, not a talk track.

--- a/plugins/people-management/skills/one-on-one-prep/SKILL.md
+++ b/plugins/people-management/skills/one-on-one-prep/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: one-on-one-prep
-description: Deep-dive preparation for 1:1 meetings with direct reports. Surfaces recent work, wins, friction, wellbeing signals, and development goal progress — anchored in the performance framework (Impact + Growth), organizational values, and management best practices. Produces a prep sheet with suggested conversation topics, not a script.
+description: "Deep-dive preparation for 1:1 meetings with direct reports. Surfaces recent work, wins, friction, wellbeing signals, and development goal progress — anchored in the org's performance framework, organizational values, and management best practices. Produces a prep sheet with suggested conversation topics, not a script."
 ---
 
 # 1:1 Prep
 
 > **Great 1:1s live at the intersection of performance and care.** Development keeps growth alive. Wellbeing makes sure the person behind the work is seen. Both matter every time.
 
-Deep-dive preparation for 1:1 meetings with a specific direct report, anchored in the performance framework and your organization's values.
+Deep-dive preparation for 1:1 meetings with a specific direct report, anchored in the org's performance framework (from `manager-context/performance-framework.md`) and organizational values.
 
 ## When to Use
 
@@ -136,9 +136,12 @@ Using the goals location from the team member's profile:
 - Pull the 1:1 document for this person
 - Check the most recent entries for open action items and commitments
 
-**Reference the performance framework dimensions:**
-- **Impact:** Goal achievement, quality of outcomes, business & team impact
-- **Growth:** Skill development, behavioral growth, scope expansion
+**Reference the org's performance framework dimensions** (from `manager-context/performance-framework.md`). Use the org's dimension names and sub-dimensions when checking goal progress. If no org framework was configured, fall back to the defaults in `../../references/performance-framework.md`.
+
+See the "Evidence Gathering Guidelines" section in `../../references/performance-framework.md` for what to look for per dimension type:
+- **Results/delivery dimensions:** goal completion, shipped work, quality feedback, business outcomes
+- **Growth/development dimensions:** learning activities, new skills applied, scope expansion, behavioural changes
+- **Collaboration/leadership dimensions:** cross-team activity, mentoring, influence in discussions
 
 ```
 📋 Development Goal Status:
@@ -172,7 +175,18 @@ Parked topics: [if any]
 
 Read `references/output-template.md` for the full output template structure.
 
-### 8. Present and Offer Follow-Up
+### 8. Sub-Agent Review
+
+Spawn a sub-agent to review the prep sheet with fresh eyes. The reviewer should:
+- Check that **wellbeing signals are framed as conversation starters**, not assessments or diagnoses.
+- Check that the **values snapshot** only includes values with meaningful signals -- not forcing all values every time.
+- Verify that **wins lead the document** and the tone is constructive, not surveillance-like.
+- Flag any phrasing that crosses from observation ("posted after 22:00 three times") into interpretation ("seems burned out").
+- Check that evidence gaps are noted where data is thin, rather than padded with weak signals.
+
+Incorporate the reviewer's feedback before presenting the final prep sheet.
+
+### 9. Present and Offer Follow-Up
 
 ```
 Here's your prep for your 1:1 with [name]. Anything you'd like me to dig deeper on?
@@ -185,6 +199,6 @@ Read `../../references/operating-principles.md` for shared operating principles 
 Additional notes specific to this skill:
 - **Wins first.** Always lead with recognition opportunities — this sets the tone.
 - **Goals are the backbone.** If goals are missing or stale, flag it prominently. Great 1:1s keep development goals alive.
-- **Framework + values alignment.** Suggested questions should map to Impact/Growth dimensions or your organization's values. Don't force all values every time — only surface values where there's a real signal.
+- **Framework + values alignment.** Suggested questions should map to the org's performance framework dimensions or organizational values. Don't force all values every time — only surface values where there's a real signal.
 - **Values are conversation threads, not checklists.** The values snapshot helps managers notice things beyond deliverables. A 1:1 that only covers goals misses the human. A 1:1 that only covers feelings misses the growth. Both.
 - **Don't script the conversation.** Provide prompts and context, not a talk track.

--- a/plugins/people-management/skills/one-on-one-prep/SKILL.md
+++ b/plugins/people-management/skills/one-on-one-prep/SKILL.md
@@ -136,7 +136,7 @@ Using the goals location from the team member's profile:
 - Pull the 1:1 document for this person
 - Check the most recent entries for open action items and commitments
 
-**Reference the org's performance framework dimensions** (from `manager-context/performance-framework.md`). Use the org's dimension names and sub-dimensions when checking goal progress. If no org framework was configured, fall back to the defaults in `../../references/performance-framework.md`.
+**Reference the org's performance framework dimensions** (from `manager-context/performance-framework.md`). Use the org's dimension names and sub-dimensions when checking goal progress. If this file doesn't exist, ask the manager to run `/setup` first.
 
 See the "Evidence Gathering Guidelines" section in `../../references/performance-framework.md` for what to look for per dimension type:
 - **Results/delivery dimensions:** goal completion, shipped work, quality feedback, business outcomes

--- a/plugins/people-management/skills/one-on-one-prep/references/output-template.md
+++ b/plugins/people-management/skills/one-on-one-prep/references/output-template.md
@@ -2,16 +2,16 @@
 📅 [Day, Date] at [Time]
 🔄 Last 1:1: [date]
 
-## Recent Wins 🎉
+## Recent Wins
 - [Win 1 with source link]
 - [Win 2 with source link]
 (Recognition to give: these are great conversation openers)
 
 ## What They've Been Working On
-- [Project/activity 1] — [brief context]
-- [Project/activity 2] — [brief context]
+- [Project/activity 1] -- [brief context]
+- [Project/activity 2] -- [brief context]
 
-## Topics to Explore 💬
+## Topics to Explore
 Based on signals from the past [N] days:
 - [Topic 1: what was observed, framed as a question not a conclusion]
 - [Topic 2]
@@ -19,29 +19,26 @@ Based on signals from the past [N] days:
 ## Values Snapshot
 | Value / Dimension | Signal | Conversation thread |
 |-------------------|--------|-------------------|
-| [Value 1 from manager-context/values.md] | [observation] | [question if relevant] |
-| [Value 2] | [observation] | [question if relevant] |
-| ... | ... | ... |
+| [Value from manager-context/values.md] | [observation] | [question if relevant] |
 
-_Only include values where there's a meaningful signal — don't force all every time._
+_Only include values where there's a meaningful signal -- don't force all every time. Skip this section entirely if no values were configured._
 
 ## Development Goals
 | Goal | Status | Last Updated | Framework Dimension |
 |------|--------|-------------|-------------------|
-| [goal] | [on track / needs attention] | [date] | Impact: Goal Achievement |
-| [goal] | [status] | [date] | Growth: Skill Development |
+| [goal] | [on track / needs attention] | [date] | [dimension from org's framework] |
 
 ## Open Items from Last 1:1
-- [ ] [item] — [who owns it, status]
+- [ ] [item] -- [who owns it, status]
 
 ## Suggested Questions
-Aligned with the performance framework and organizational values:
+Aligned with the org's performance framework dimensions and organizational values:
 
-**Impact:**
+**[Framework Dimension 1]:**
 - How are you feeling about progress on [goal]? Any blockers I can help with?
 - [Question based on observed activity]
 
-**Growth:**
+**[Framework Dimension 2]:**
 - [Question about development area, based on goals]
 - What's been the most challenging thing this [week/sprint]? What did you learn from it?
 

--- a/plugins/people-management/skills/one-on-one-prep/references/output-template.md
+++ b/plugins/people-management/skills/one-on-one-prep/references/output-template.md
@@ -1,0 +1,58 @@
+# 1:1 Prep: [Manager] <-> [Team Member]
+📅 [Day, Date] at [Time]
+🔄 Last 1:1: [date]
+
+## Recent Wins 🎉
+- [Win 1 with source link]
+- [Win 2 with source link]
+(Recognition to give: these are great conversation openers)
+
+## What They've Been Working On
+- [Project/activity 1] — [brief context]
+- [Project/activity 2] — [brief context]
+
+## Topics to Explore 💬
+Based on signals from the past [N] days:
+- [Topic 1: what was observed, framed as a question not a conclusion]
+- [Topic 2]
+
+## Values Snapshot
+| Value / Dimension | Signal | Conversation thread |
+|-------------------|--------|-------------------|
+| [Value 1 from manager-context/values.md] | [observation] | [question if relevant] |
+| [Value 2] | [observation] | [question if relevant] |
+| ... | ... | ... |
+
+_Only include values where there's a meaningful signal — don't force all every time._
+
+## Development Goals
+| Goal | Status | Last Updated | Framework Dimension |
+|------|--------|-------------|-------------------|
+| [goal] | [on track / needs attention] | [date] | Impact: Goal Achievement |
+| [goal] | [status] | [date] | Growth: Skill Development |
+
+## Open Items from Last 1:1
+- [ ] [item] — [who owns it, status]
+
+## Suggested Questions
+Aligned with the performance framework and organizational values:
+
+**Impact:**
+- How are you feeling about progress on [goal]? Any blockers I can help with?
+- [Question based on observed activity]
+
+**Growth:**
+- [Question about development area, based on goals]
+- What's been the most challenging thing this [week/sprint]? What did you learn from it?
+
+**Values-informed** _(pick 1-2 based on signals, not all every time):_
+- How's your energy? Anything I can take off your plate? _(if overwork signals)_
+- How's collaboration with [team/person] going? _(if isolation or friction signals)_
+- Is there anything you've been hesitant to bring up? _(if they've been quiet)_
+- What's been the hardest problem you cracked recently? _(if resourcefulness signals)_
+- What would you want to take on next if you had the bandwidth? _(if ambition signals)_
+
+## Source Links
+- [1:1 doc](link)
+- [Goals page](link)
+- [Relevant Slack thread](link)

--- a/plugins/people-management/skills/performance-cycle/SKILL.md
+++ b/plugins/people-management/skills/performance-cycle/SKILL.md
@@ -24,7 +24,7 @@ Load the org's performance framework from `manager-context/performance-framework
 - Promotion readiness labels (if tracked)
 - Review cadence
 
-If no org-specific framework was configured, fall back to the defaults in `../../references/performance-framework.md` (Impact + Growth).
+If `manager-context/performance-framework.md` doesn't exist, ask the manager to run `/setup` first.
 
 ## Instructions
 

--- a/plugins/people-management/skills/performance-cycle/SKILL.md
+++ b/plugins/people-management/skills/performance-cycle/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: performance-cycle
+description: Evidence gathering for bi-annual review cycles (winter/summer) and lighter check-ins (spring/fall). Gathers goal completion evidence, peer feedback, development progress, scope changes, and values alignment — organised along the Impact and Growth dimensions of the performance framework, with organizational values as the "how" lens. Surfaces evidence gaps. Never suggests ratings — only organises evidence for the manager's judgment.
+---
+
+# Performance Cycle Assistant
+
+> **Principle: "You are responsible."** This skill gathers and organises evidence. Rating decisions and development assessments are the manager's alone.
+
+Helps managers prepare evidence-based assessments for performance review cycles. Impact and Growth measure *what* was achieved and *how the person developed*. Organizational values measure *how they showed up* while doing it.
+
+## When to Use
+
+- During bi-annual review cycles (winter, summer)
+- During lighter check-ins (spring, fall)
+- When the manager says "help me prep [name]'s review", "gather evidence for [name]'s performance"
+- Can be run for one team member or all reports in batch
+
+## Context: Performance Framework
+
+The framework has two dimensions:
+
+**Impact:**
+- Goal achievement — did they hit their goals?
+- Quality of outcomes — was the work excellent?
+- Business & team impact — did it matter?
+
+**Growth:**
+- Skill development — are they building new capabilities?
+- Behavioral growth — are they growing in how they work with others?
+- Scope expansion — are they taking on more / bigger / different challenges?
+
+**Ratings:** Outstanding, Exceptional, Rising, Strong, Below Expectations
+
+**Promotion readiness:** Ready Now, Ready Soon, Growth Path
+
+See `../../references/performance-framework.md` for full details.
+
+## Instructions
+
+If any MCP connector is unavailable, follow the connector unavailability protocol in `../../references/operating-principles.md`.
+
+### 1. Identify Scope
+
+Determine who to prepare for:
+- Single team member: "prep [name]'s review"
+- Whole team: "prep all reviews" (runs sequentially for each report)
+
+Determine the review period:
+- Default: last 6 months (for bi-annual review) or last 3 months (for check-in)
+- Can be customised: "since [date]"
+
+### 2. Load Context
+
+For the target team member, read from `manager-context/team/[name].md`:
+- Their goals (locations in Notion/Drive)
+- Their development areas from last review
+- Their role and level (from Job Architecture)
+- Their projects and responsibilities
+
+Also load:
+- `../../references/performance-framework.md` — for framework dimensions and rating descriptors
+- `../../references/management-framework.md` — for management dimensions and level expectations
+- `../../references/values-guide.md` — for values definitions and signal guidance
+- `manager-context/values.md` — for the organization's specific values
+
+### 3. Gather Evidence Along Each Dimension
+
+#### Impact: Goal Achievement
+- **Notion:** Pull their goals and check for completion status, progress notes
+- **Slack:** Search for messages about shipping, completing, delivering related to their goals
+- **Google Drive:** Look for deliverables, reports, or outputs tied to goals
+- Compile: which goals were met, exceeded, or missed with evidence
+
+#### Impact: Quality of Outcomes
+- **Slack:** Search for feedback on their deliverables — positive and constructive
+- **Notion:** Check for any quality metrics or peer reviews
+- **Google Drive:** Look for iteration history or feedback on their work
+- Compile: evidence of excellence (or gaps in quality)
+
+#### Impact: Business & Team Impact
+- **Slack:** Search for mentions of business outcomes tied to their work
+- **Notion:** Check for impact metrics, customer feedback, business results
+- Compile: how their work connected to team/business outcomes
+
+#### Growth: Skill Development
+- **Slack/Notion:** Search for learning activities, workshops, certifications
+- **Google Drive:** Training materials, course completions
+- Compare to development areas from last review: is there visible progress?
+
+#### Growth: Behavioral Growth
+- **Slack:** Look for leadership behaviours, mentoring, cross-functional collaboration
+- Evidence of growing influence or maturity in communication
+- This is the hardest dimension to gather evidence for — flag that the manager likely has better context here
+
+#### Growth: Scope Expansion
+- **Slack/Calendar:** New channels, new meetings, new stakeholders
+- **Notion:** New project pages they're leading
+- Evidence of taking on bigger or different challenges
+
+### 4. Gather Values Evidence
+
+Values are the "how" — how this person delivered their results and showed up for the team. Search for evidence across the organization's values (from `manager-context/values.md`). See `../../references/values-guide.md` for guidance on finding value signals.
+
+For each value defined in `manager-context/values.md`, search for evidence using the signal guidance stored there. Common evidence sources by value type:
+
+**Collaboration / teamwork values:**
+- Slack: cross-team collaboration, helping unblock others, participating in team decisions
+- DMs (with manager): conversations about team dynamics, commitment to group decisions
+
+**Ambition / ownership values:**
+- Slack/Notion: volunteering for stretch work, proposing ideas, driving outcomes
+- Evidence of taking things to completion without being pushed
+
+**Innovation / resourcefulness values:**
+- Slack: creative problem-solving, finding workarounds, learning from obstacles
+- Evidence of unblocking themselves or the team under constraints
+
+**Transparency / communication values:**
+- Slack: sharing context proactively, raising issues early, giving and receiving feedback
+- DMs (with manager): being open about challenges, asking for help
+
+**Care / wellbeing values:**
+- Slack: celebrating others, recognising teammates, showing empathy
+- Calendar: sustainable work patterns or concerning overwork patterns
+
+For each value, compile evidence as observations (not judgments):
+- **Strong signal:** Multiple visible examples
+- **Some signal:** 1-2 examples
+- **Gap:** No evidence found (note: absence of evidence ≠ absence of the behaviour)
+
+### 5. Check Peer Recognition
+
+Search Slack for recognition this person received during the review period:
+- Direct shoutouts from teammates
+- Recognition in team channels
+- Reactions on their messages (high-reaction messages = valued contributions)
+
+### 6. Identify Evidence Gaps
+
+For each dimension, assess evidence strength:
+- **Strong evidence:** Multiple sources corroborate
+- **Some evidence:** 1-2 data points
+- **Gap:** No evidence found — manager needs to gather this manually
+
+### 7. Produce the Evidence Summary
+
+Read `references/output-template.md` for the full output template structure (individual and batch mode).
+
+### 8. For Batch Mode (All Reports)
+
+If preparing for the whole team, produce individual evidence summaries for each team member plus a team-level comparison view. See the batch mode template in `references/output-template.md`.
+
+### 9. Present
+
+```
+Here's the evidence I gathered for [name]'s review. I've flagged gaps where you'll want to add your own observations.
+
+Remember: this is evidence gathering only. Rating decisions and promotion assessments are yours to make based on the full picture — including things I can't see.
+```
+
+### 10. Sub-Agent Review
+
+Spawn a sub-agent to review the evidence summary with fresh eyes. The reviewer should:
+- Check for **recency bias** — is most evidence from the last few weeks, or spread across the review period?
+- Check for **dimension imbalance** — are some dimensions well-evidenced while others are thin? Flag under-covered areas.
+- Check for **interpretive language** — flag any phrasing that crosses from evidence ("shipped X on time") into interpretation ("demonstrated strong execution").
+- Verify evidence gaps are honestly flagged, not papered over with weak data.
+- Check that values evidence is presented as "examples I found", not "the full picture."
+
+Incorporate the reviewer's feedback before presenting the final summary to the manager.
+
+## Important Notes
+
+Read `../../references/operating-principles.md` for shared operating principles (data scope, DM flagging, signals vs diagnoses, connector unavailability).
+
+Additional notes specific to this skill:
+- **NEVER suggest a rating.** Not even hints. The manager decides ratings. Period.
+- **NEVER compare team members to each other.** Evidence is per-person. Calibration is the manager's job.
+- **Evidence, not interpretation.** "Shipped feature X on time" is evidence. "Demonstrated strong execution" is interpretation. Stick to evidence.
+- **Flag gaps honestly.** "I found no evidence for behavioral growth" is more useful than padding with weak data.
+- **Recency bias warning.** Note if most evidence is from the last month vs. spread across the review period.
+- **Values evidence is hardest to gather digitally.** Many values are lived in person, not in Slack. The manager's direct observations are more authoritative.
+- **This supplements, not replaces.** The manager has 6 months of direct observation.

--- a/plugins/people-management/skills/performance-cycle/SKILL.md
+++ b/plugins/people-management/skills/performance-cycle/SKILL.md
@@ -1,40 +1,30 @@
 ---
 name: performance-cycle
-description: Evidence gathering for bi-annual review cycles (winter/summer) and lighter check-ins (spring/fall). Gathers goal completion evidence, peer feedback, development progress, scope changes, and values alignment — organised along the Impact and Growth dimensions of the performance framework, with organizational values as the "how" lens. Surfaces evidence gaps. Never suggests ratings — only organises evidence for the manager's judgment.
+description: "Evidence gathering for performance review cycles. Gathers goal completion evidence, peer feedback, development progress, scope changes, and values alignment — organised along the org's performance framework dimensions, with organizational values as the 'how' lens. Surfaces evidence gaps. Never suggests ratings — only organises evidence for the manager's judgment."
 ---
 
 # Performance Cycle Assistant
 
 > **Principle: "You are responsible."** This skill gathers and organises evidence. Rating decisions and development assessments are the manager's alone.
 
-Helps managers prepare evidence-based assessments for performance review cycles. Impact and Growth measure *what* was achieved and *how the person developed*. Organizational values measure *how they showed up* while doing it.
+Helps managers prepare evidence-based assessments for performance review cycles. The org's performance framework dimensions measure *what* was achieved and *how the person developed*. Organizational values measure *how they showed up* while doing it.
 
 ## When to Use
 
-- During bi-annual review cycles (winter, summer)
-- During lighter check-ins (spring, fall)
+- During full review cycles (per the org's review cadence)
+- During lighter check-ins between full reviews
 - When the manager says "help me prep [name]'s review", "gather evidence for [name]'s performance"
 - Can be run for one team member or all reports in batch
 
 ## Context: Performance Framework
 
-The framework has two dimensions:
+Load the org's performance framework from `manager-context/performance-framework.md` (created during `/setup`). This defines:
+- Framework dimensions and sub-dimensions
+- Rating scale
+- Promotion readiness labels (if tracked)
+- Review cadence
 
-**Impact:**
-- Goal achievement — did they hit their goals?
-- Quality of outcomes — was the work excellent?
-- Business & team impact — did it matter?
-
-**Growth:**
-- Skill development — are they building new capabilities?
-- Behavioral growth — are they growing in how they work with others?
-- Scope expansion — are they taking on more / bigger / different challenges?
-
-**Ratings:** Outstanding, Exceptional, Rising, Strong, Below Expectations
-
-**Promotion readiness:** Ready Now, Ready Soon, Growth Path
-
-See `../../references/performance-framework.md` for full details.
+If no org-specific framework was configured, fall back to the defaults in `../../references/performance-framework.md` (Impact + Growth).
 
 ## Instructions
 
@@ -59,44 +49,28 @@ For the target team member, read from `manager-context/team/[name].md`:
 - Their projects and responsibilities
 
 Also load:
-- `../../references/performance-framework.md` — for framework dimensions and rating descriptors
-- `../../references/management-framework.md` — for management dimensions and level expectations
+- `manager-context/performance-framework.md` — for org-specific framework dimensions and rating descriptors (falls back to `../../references/performance-framework.md` defaults)
+- `manager-context/management-framework.md` — for org-specific management dimensions (falls back to `../../references/management-framework.md` defaults)
 - `../../references/values-guide.md` — for values definitions and signal guidance
 - `manager-context/values.md` — for the organization's specific values
 
 ### 3. Gather Evidence Along Each Dimension
 
-#### Impact: Goal Achievement
-- **Notion:** Pull their goals and check for completion status, progress notes
-- **Slack:** Search for messages about shipping, completing, delivering related to their goals
-- **Google Drive:** Look for deliverables, reports, or outputs tied to goals
-- Compile: which goals were met, exceeded, or missed with evidence
+For each dimension and sub-dimension in the org's performance framework (from `manager-context/performance-framework.md`), gather evidence from connected sources.
 
-#### Impact: Quality of Outcomes
-- **Slack:** Search for feedback on their deliverables — positive and constructive
-- **Notion:** Check for any quality metrics or peer reviews
-- **Google Drive:** Look for iteration history or feedback on their work
-- Compile: evidence of excellence (or gaps in quality)
+For each sub-dimension:
+- **Notion:** Pull goals, project pages, status updates, metrics relevant to this dimension
+- **Slack:** Search for messages showing activity, feedback, recognition, or friction related to this dimension
+- **Google Drive:** Look for deliverables, reports, documents tied to this dimension
+- **Calendar:** Check for activities that signal growth or scope changes (new meetings, new stakeholders)
+- Compile: what evidence was found, with links
 
-#### Impact: Business & Team Impact
-- **Slack:** Search for mentions of business outcomes tied to their work
-- **Notion:** Check for impact metrics, customer feedback, business results
-- Compile: how their work connected to team/business outcomes
+**Common evidence patterns by dimension type:**
+- **Results/delivery dimensions:** goal completion, shipped work, quality feedback, business outcomes
+- **Growth/development dimensions:** learning activities, new skills applied, scope expansion, behavioural changes
+- **Collaboration/leadership dimensions:** cross-team activity, mentoring, influence in discussions
 
-#### Growth: Skill Development
-- **Slack/Notion:** Search for learning activities, workshops, certifications
-- **Google Drive:** Training materials, course completions
-- Compare to development areas from last review: is there visible progress?
-
-#### Growth: Behavioral Growth
-- **Slack:** Look for leadership behaviours, mentoring, cross-functional collaboration
-- Evidence of growing influence or maturity in communication
-- This is the hardest dimension to gather evidence for — flag that the manager likely has better context here
-
-#### Growth: Scope Expansion
-- **Slack/Calendar:** New channels, new meetings, new stakeholders
-- **Notion:** New project pages they're leading
-- Evidence of taking on bigger or different challenges
+For dimensions that are hardest to assess digitally (e.g., behavioural growth, leadership presence), explicitly flag that the manager's direct observations carry more weight.
 
 ### 4. Gather Values Evidence
 

--- a/plugins/people-management/skills/performance-cycle/references/output-template.md
+++ b/plugins/people-management/skills/performance-cycle/references/output-template.md
@@ -1,0 +1,96 @@
+# Performance Review Prep: [Name]
+Review period: [start] — [end]
+Role: [role] | Level: [level] | Manager: [manager]
+Last review rating: [if known]
+
+## Impact
+
+### Goal Achievement
+| Goal | Status | Evidence |
+|------|--------|----------|
+| [goal text] | ✅ Met / ⚠️ Partial / ❌ Missed | [evidence with links] |
+
+Evidence strength: [Strong / Some / Gap]
+
+### Quality of Outcomes
+[Evidence compiled, with links]
+
+Evidence strength: [Strong / Some / Gap]
+
+### Business & Team Impact
+[Evidence compiled, with links]
+
+Evidence strength: [Strong / Some / Gap]
+
+## Growth
+
+### Skill Development
+[Evidence compiled, especially vs. development areas from last review]
+
+Evidence strength: [Strong / Some / Gap]
+
+### Behavioral Growth
+[Evidence compiled — note that manager likely has richer context here]
+
+Evidence strength: [Strong / Some / Gap]
+⚠️ This dimension is hardest to assess from digital signals. Your 1:1 observations are more valuable here.
+
+### Scope Expansion
+[Evidence of new responsibilities, projects, stakeholders]
+
+Evidence strength: [Strong / Some / Gap]
+
+## Values — How They Showed Up
+
+_Values are how results were delivered. This section helps paint the full picture beyond what and how much._
+
+| Value | Evidence | Strength |
+|-------|----------|----------|
+| [Value 1 from manager-context/values.md] | [evidence] | [Strong / Some / Gap] |
+| [Value 2] | [evidence] | [Strong / Some / Gap] |
+| ... | ... | ... |
+
+**Values highlights:**
+- [1-2 strongest examples with links — moments that exemplify this person's character]
+
+**Values development areas:**
+- [Any patterns worth discussing — e.g., "Strong on [value] but limited evidence of [value] — may benefit from more cross-team visibility"]
+
+⚠️ Values are often best observed in person, not in digital channels. Your direct observations carry more weight here than anything I can find.
+
+## Peer Recognition Highlights
+- "[quote/summary]" — from [person] in #[channel] on [date]
+- [additional recognition]
+
+## Evidence Gaps
+Areas where I found limited or no evidence — you may want to gather more context:
+- [ ] [Dimension]: [what's missing and where to look]
+- [ ] [Dimension]: [what's missing]
+
+## Questions for the Manager
+Before finalising the review, consider:
+- Does the evidence align with your direct observations?
+- Are there contributions you know about that aren't visible in digital channels?
+- Have there been any circumstances (personal, team changes, priority shifts) that should factor in?
+- **Values check:** Were results delivered in a way consistent with our values? Is there a value this person could lean into more?
+
+## Source Links
+- [Goals page](link)
+- [Relevant Slack threads](links)
+- [Deliverables/docs](links)
+
+---
+
+# Batch Mode: Team Review Prep
+
+# Team Review Prep — [Cycle Name]
+
+## Evidence Readiness
+| Name | Impact Evidence | Growth Evidence | Values Evidence | Gaps to Fill |
+|------|----------------|-----------------|----------------|-------------|
+| [name] | Strong | Some | Strong | Behavioral growth |
+| [name] | Some | Strong | Some | Business impact, [value] |
+
+## Patterns Across Team
+- [Any team-level observations: e.g., "Goal completion is strong but quality evidence is thin across the board"]
+- [Values patterns: e.g., "Strong [value] across the team but limited evidence of [value] — might be a team culture thing to explore"]

--- a/plugins/people-management/skills/performance-cycle/references/output-template.md
+++ b/plugins/people-management/skills/performance-cycle/references/output-template.md
@@ -1,69 +1,48 @@
 # Performance Review Prep: [Name]
-Review period: [start] — [end]
+Review period: [start] -- [end]
 Role: [role] | Level: [level] | Manager: [manager]
 Last review rating: [if known]
 
-## Impact
+## [Framework Dimension 1 Name]
 
-### Goal Achievement
-| Goal | Status | Evidence |
-|------|--------|----------|
-| [goal text] | ✅ Met / ⚠️ Partial / ❌ Missed | [evidence with links] |
+For each sub-dimension in the org's framework, create a section:
 
-Evidence strength: [Strong / Some / Gap]
-
-### Quality of Outcomes
-[Evidence compiled, with links]
+### [Sub-dimension Name]
+| Goal / Area | Status | Evidence |
+|-------------|--------|----------|
+| [item] | [met / partial / missed / N/A] | [evidence with links] |
 
 Evidence strength: [Strong / Some / Gap]
 
-### Business & Team Impact
-[Evidence compiled, with links]
+_For dimensions that are hardest to assess digitally, add:_
+_This dimension is hardest to assess from digital signals. Your 1:1 observations are more valuable here._
 
-Evidence strength: [Strong / Some / Gap]
+## [Framework Dimension 2 Name]
 
-## Growth
+[Same structure as above, one section per sub-dimension]
 
-### Skill Development
-[Evidence compiled, especially vs. development areas from last review]
-
-Evidence strength: [Strong / Some / Gap]
-
-### Behavioral Growth
-[Evidence compiled — note that manager likely has richer context here]
-
-Evidence strength: [Strong / Some / Gap]
-⚠️ This dimension is hardest to assess from digital signals. Your 1:1 observations are more valuable here.
-
-### Scope Expansion
-[Evidence of new responsibilities, projects, stakeholders]
-
-Evidence strength: [Strong / Some / Gap]
-
-## Values — How They Showed Up
+## Values -- How They Showed Up
 
 _Values are how results were delivered. This section helps paint the full picture beyond what and how much._
 
 | Value | Evidence | Strength |
 |-------|----------|----------|
-| [Value 1 from manager-context/values.md] | [evidence] | [Strong / Some / Gap] |
-| [Value 2] | [evidence] | [Strong / Some / Gap] |
-| ... | ... | ... |
+| [Value from manager-context/values.md] | [evidence] | [Strong / Some / Gap] |
 
 **Values highlights:**
-- [1-2 strongest examples with links — moments that exemplify this person's character]
+- [1-2 strongest examples with links -- moments that exemplify this person's character]
 
 **Values development areas:**
-- [Any patterns worth discussing — e.g., "Strong on [value] but limited evidence of [value] — may benefit from more cross-team visibility"]
+- [Any patterns worth discussing]
 
-⚠️ Values are often best observed in person, not in digital channels. Your direct observations carry more weight here than anything I can find.
+This section is only included if organizational values were configured during setup.
 
 ## Peer Recognition Highlights
-- "[quote/summary]" — from [person] in #[channel] on [date]
+- "[quote/summary]" -- from [person] in #[channel] on [date]
 - [additional recognition]
 
 ## Evidence Gaps
-Areas where I found limited or no evidence — you may want to gather more context:
+Areas where I found limited or no evidence -- you may want to gather more context:
 - [ ] [Dimension]: [what's missing and where to look]
 - [ ] [Dimension]: [what's missing]
 
@@ -83,14 +62,13 @@ Before finalising the review, consider:
 
 # Batch Mode: Team Review Prep
 
-# Team Review Prep — [Cycle Name]
+# Team Review Prep -- [Cycle Name]
 
 ## Evidence Readiness
-| Name | Impact Evidence | Growth Evidence | Values Evidence | Gaps to Fill |
-|------|----------------|-----------------|----------------|-------------|
-| [name] | Strong | Some | Strong | Behavioral growth |
-| [name] | Some | Strong | Some | Business impact, [value] |
+| Name | [Dimension 1] Evidence | [Dimension 2] Evidence | Values Evidence | Gaps to Fill |
+|------|------------------------|------------------------|-----------------|-------------|
+| [name] | Strong | Some | Strong | [specific gap] |
 
 ## Patterns Across Team
-- [Any team-level observations: e.g., "Goal completion is strong but quality evidence is thin across the board"]
-- [Values patterns: e.g., "Strong [value] across the team but limited evidence of [value] — might be a team culture thing to explore"]
+- [Any team-level observations across framework dimensions]
+- [Values patterns if applicable]

--- a/plugins/people-management/skills/priority-planner/SKILL.md
+++ b/plugins/people-management/skills/priority-planner/SKILL.md
@@ -118,7 +118,7 @@ Read `../../references/operating-principles.md` for shared operating principles 
 Additional notes specific to this skill:
 - **Never prescribe.** Use "I'd suggest", "Consider". The manager knows context the tool doesn't.
 - **The Invest bucket is crucial.** Don't let it be empty. Great managers always invest time in development, even when busy.
-- **Connect to frameworks.** Note which management framework dimension an action supports.
+- **Connect to frameworks.** Note which management framework dimension (from `manager-context/management-framework.md`) an action supports.
 - **Don't just list everything.** The "What I'd Deprioritise" section is often more valuable than the priority list itself.
 - **Time-box awareness.** If the calendar is packed, don't suggest 8 hours of focus work. Be realistic.
 - **Goal alignment is the core insight.** If there's persistent drift between daily activity and goals, say so clearly.

--- a/plugins/people-management/skills/priority-planner/SKILL.md
+++ b/plugins/people-management/skills/priority-planner/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: priority-planner
+description: Helps managers cut through noise and identify their highest-leverage actions for the day or week. Aggregates signals from calendar, triage, team context, and OKRs/goals. Presents a suggested focus list grouped by urgency, importance, and investment — the manager reviews and adjusts. Supports effective execution and prioritisation.
+---
+
+# Priority Planner
+
+> **Principle: "You are responsible."** The skill proposes, the manager decides. This is not a task manager — it's a thinking partner for prioritisation.
+
+Aggregates signals from multiple sources to surface the manager's highest-leverage actions.
+
+## When to Use
+
+- Start of day: "what should I focus on today?"
+- Start of week: "plan my week"
+- When overwhelmed: "help me prioritise"
+- After a triage: "fold these into my priorities"
+
+## Instructions
+
+If any MCP connector is unavailable, follow the connector unavailability protocol in `../../references/operating-principles.md`.
+
+### 1. Determine Scope
+
+Ask or infer whether this is a daily or weekly plan:
+- Daily: focus on today's calendar, current triage, immediate needs
+- Weekly: broader view including upcoming deadlines, OKRs, team development
+
+### 2. Load Goals
+
+Before gathering signals, load the manager's goals — these are the lens through which everything gets prioritised.
+
+**From `manager-context/manager-goals.md`:**
+- The manager's own OKRs and goals
+- Their manager's key priorities
+- Upcoming personal milestones and deadlines
+
+**From Notion/Drive (if goals location is known):**
+- Pull the latest version of OKRs in case they've been updated since setup
+
+If no goals are found:
+```
+⚠️ I don't have your goals on file. Without them I can prioritise by urgency, but not by impact alignment.
+Run /setup or tell me your current OKRs so I can connect your priorities to what matters most.
+```
+
+### 3. Gather Signals
+
+Pull from multiple sources:
+
+**Calendar (today or this week):**
+- Meetings scheduled and their topics
+- Free blocks (potential focus time)
+- Deadlines tied to calendar events
+
+**Triage results (if /triage-messages was recently run):**
+- Any 🔴 "Needs Decision" items still unresolved
+- 🟡 Team needs awaiting attention
+- Customer items flagged
+
+**Manager Context (from manager-context/):**
+- Team members' current projects and any known blockers
+- Development conversations due
+- 1:1s this week and prep status
+- Triage rules (VIPs, hot channels) from `triage-rules.md`
+
+**Notion:**
+- Search for OKRs, quarterly goals, team priorities docs
+- Any pages tagged with deadlines or milestones
+
+**Slack:**
+- Threads where the manager promised to follow up
+- Open questions directed at the manager
+
+### 4. Categorise into Buckets
+
+Group everything into three categories (inspired by Eisenhower):
+
+**🔴 Urgent — Time-Sensitive Decisions**
+Things where someone is blocked or a deadline is imminent:
+- Decisions only the manager can make
+- Escalations that need resolution today
+- Deadlines within 24-48 hours
+- Framework: Execution
+
+**🟡 Important — High-Impact Work**
+Things that move OKRs and team goals forward:
+- Strategic work (planning, decision-making, alignment)
+- Cross-functional alignment needed
+- Customer-related actions that affect account health
+- Framework: Delegation & Execution
+
+**🟢 Invest — Development & Strategic Thinking**
+Things that compound over time but rarely feel urgent:
+- 1:1 preparation and development conversations
+- Team health check-ins
+- Hiring pipeline attention
+- Strategic thinking and planning
+- Framework: People Development
+
+### 5. Produce the Plan
+
+Read `references/output-template.md` for the full output template structure.
+
+### 6. Present and Iterate
+
+```
+Here's a suggested priority plan. This is a starting point — adjust based on your judgment. Want me to:
+- Move anything between categories?
+- Add something I missed?
+- Prep for any of these items?
+```
+
+## Important Notes
+
+Read `../../references/operating-principles.md` for shared operating principles (data scope, DM flagging, signals vs diagnoses, connector unavailability).
+
+Additional notes specific to this skill:
+- **Never prescribe.** Use "I'd suggest", "Consider". The manager knows context the tool doesn't.
+- **The Invest bucket is crucial.** Don't let it be empty. Great managers always invest time in development, even when busy.
+- **Connect to frameworks.** Note which management framework dimension an action supports.
+- **Don't just list everything.** The "What I'd Deprioritise" section is often more valuable than the priority list itself.
+- **Time-box awareness.** If the calendar is packed, don't suggest 8 hours of focus work. Be realistic.
+- **Goal alignment is the core insight.** If there's persistent drift between daily activity and goals, say so clearly.
+- **Be honest about drift.** Don't sugarcoat. If 80% of time is reactive and 0% on OKRs, name it.

--- a/plugins/people-management/skills/priority-planner/references/output-template.md
+++ b/plugins/people-management/skills/priority-planner/references/output-template.md
@@ -1,0 +1,42 @@
+# Priority Plan — [Date/Week]
+
+## 🔴 Urgent (do today)
+1. **[Action]** — [1-line why, with source link]
+   _[Who's waiting, deadline]_
+2. **[Action]** — [why]
+
+## 🟡 Important (this week)
+1. **[Action]** — [1-line why, with source link]
+   _[Connects to OKR: "[OKR text]"]_
+2. **[Action]** — [why]
+
+## 🟢 Invest (make time for)
+1. **[Action]** — [1-line why]
+   _[Framework: People Development]_
+2. **[Action]** — [why]
+
+## 🎯 Goal Alignment Check
+Map today's/this week's activities against the manager's goals to surface where energy is going vs. where it should go.
+
+| Goal / OKR | Status | This [day/week]'s activities that advance it | Gap? |
+|-------------|--------|----------------------------------------------|------|
+| [OKR 1] | [on track / behind / at risk] | [matching actions from above, or "—" if none] | [yes/no] |
+| [OKR 2] | [status] | [matching actions] | [yes/no] |
+| [OKR 3] | [status] | [matching actions] | [yes/no] |
+
+**Reflection:**
+- **Well-covered:** [goals that have clear activity this period]
+- **Underserved:** [goals with no matching activity — might need deliberate time]
+- **Drift risk:** [areas consuming significant time that don't connect to any goal — worth questioning whether this is the right use of energy]
+
+💡 _[1-2 sentences of honest, direct reflection. E.g., "Most of your day is spent on urgent operational items. None of your top 3 OKRs have dedicated time this week — consider blocking focus time for [specific goal]." or "Good alignment — your 🟡 items directly advance OKR 2 and 3. OKR 1 could use attention next week."]_
+
+## Calendar Fit
+Here's how this maps to your day/week:
+- [Time block] — Free: could use for [suggested urgent/important item]
+- [Meeting] — Prep needed? [yes/no, link to /prep-meeting if yes]
+- [1:1 with Name] — Prep available? [yes/no, link to /prep-one-on-one if no]
+
+## What I'd Deprioritise
+Based on what's on your plate, these could wait:
+- [Thing that seems lower priority, with reasoning]

--- a/plugins/people-management/skills/setup/SKILL.md
+++ b/plugins/people-management/skills/setup/SKILL.md
@@ -32,7 +32,7 @@ Identify the manager (name, role, teams), crawl sources for direct reports, vali
 Persist: `manager-context/manager-profile.md`, `manager-context/team/[name].md` per report, `manager-context/terminology.md`, `manager-context/sources.md`
 
 ### Phase 2: Performance & Management Frameworks
-Discover how the org evaluates performance and managers. Present the defaults from `../../references/performance-framework.md` and `../../references/management-framework.md`, then ask the manager to confirm, adjust, or replace with their org's framework. Key things to discover: framework dimensions, rating scale, promotion readiness labels, review cadence, goal cadence, and management competencies.
+Discover how the org evaluates performance and managers. Search for existing framework docs, then walk the manager through defining their dimensions, rating scale, promotion readiness labels, review cadence, goal cadence, and management competencies. See `../../references/performance-framework.md` and `../../references/management-framework.md` for how skills use these frameworks.
 
 Persist: `manager-context/performance-framework.md`, `manager-context/management-framework.md`
 

--- a/plugins/people-management/skills/setup/SKILL.md
+++ b/plugins/people-management/skills/setup/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: setup
+description: Interactive onboarding that discovers team structure, terminology, development goals, organizational values, and ways of working by crawling Slack, Notion, Google Drive, Gmail, and Calendar. Validates everything with the manager before persisting. Run this first before using any other skill. Also handles periodic context refreshes via /setup --refresh. Triggers on "setup", "configure", "onboard", "get started", "refresh context".
+---
+
+# Setup
+
+> **Principle: "You are responsible."** This skill discovers and proposes — the manager validates and decides what's accurate.
+
+Interactive onboarding that builds the foundation every other skill relies on. Crawls connected sources, extracts context, and validates with the manager before saving.
+
+If any MCP connector is unavailable, follow the connector unavailability protocol in `../../references/operating-principles.md`.
+
+## Prerequisites
+
+Ensure these MCP connectors are available:
+- **Slack** — team channels, messages, terminology
+- **Notion** — performance docs, goals, team pages
+- **Google Drive** — 1:1 docs, meeting notes, strategy docs
+- **Gmail** — communication patterns
+- **Google Calendar** — recurring meetings, team rhythms
+
+If any connector is missing, note it and proceed with what's available. Flag gaps at the end.
+
+## Instructions
+
+Run phases sequentially. Each phase discovers, validates with the manager, then persists. Read `references/discovery-phases.md` for detailed instructions per phase.
+
+### Phase 1: Team Discovery
+Identify the manager (name, role, teams), crawl sources for direct reports, validate the team list, discover internal terminology, find development goals and performance data, map ways of working, and identify customer/project context if applicable.
+
+Persist: `manager-context/manager-profile.md`, `manager-context/team/[name].md` per report, `manager-context/terminology.md`, `manager-context/sources.md`
+
+### Phase 2: Organizational Values
+Ask if the org has defined values. If yes, search for documentation, extract value names and behaviours, ask what signals to look for per value. If no, skip the values lens.
+
+Persist: `manager-context/values.md`
+
+### Phase 3: Output Preferences
+Present defaults (language, tone, file format, folder structure) and let the manager adjust.
+
+Persist: `manager-context/output-preferences.md`
+
+### Phase 4: Manager's Own Context
+Capture upward context — OKRs, who they report to, key deadlines.
+
+Persist: `manager-context/manager-goals.md`
+
+### Phase 5: Triage Rules
+Capture VIP people, hot channels, deprioritise list, privacy boundaries.
+
+Persist: `manager-context/triage-rules.md`
+
+### Phase 6: Review Calendar
+Capture review cycle dates, calibration sessions, promotion windows, goal cadence.
+
+Persist: `manager-context/review-calendar.md`
+
+### Phase 7: Skill Preferences
+Capture 1:1 style and suggest a skill rhythm (daily triage, weekly health check, etc.).
+
+Persist: `manager-context/skill-preferences.md`
+
+### Phase 8: Staleness Check
+Flag any discovered data older than ~2 months. Ask the manager to confirm or update.
+
+### Phase 9: Persist & Wrap Up
+Save all validated context. Read `references/context-templates.md` for file templates. Present a summary of what was captured, flag gaps, and suggest first skills to try.
+
+## Refresh Mode
+
+When called with `--refresh`:
+1. Read existing `manager-context/` files
+2. Re-crawl sources for changes since last update
+3. Present only what's changed (new team members, updated goals, new terminology, stale data)
+4. Update files with confirmed changes
+5. Don't re-ask about things already validated
+
+## Important Notes
+
+Read `../../references/operating-principles.md` for shared principles (data scope, DM flagging, connector unavailability).
+
+- **Never assume — always validate.** If something looks like a team member but you're not sure, ask.
+- **Flag gaps explicitly.** "I couldn't find X" is more useful than silently skipping it.
+- **Stale data is worse than no data.** Always check recency and flag anything older than ~2 months.

--- a/plugins/people-management/skills/setup/SKILL.md
+++ b/plugins/people-management/skills/setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: setup
-description: Interactive onboarding that discovers team structure, terminology, development goals, organizational values, and ways of working by crawling Slack, Notion, Google Drive, Gmail, and Calendar. Validates everything with the manager before persisting. Run this first before using any other skill. Also handles periodic context refreshes via /setup --refresh. Triggers on "setup", "configure", "onboard", "get started", "refresh context".
+description: "Interactive onboarding that discovers team structure, terminology, development goals, performance and management frameworks, organizational values, and ways of working by crawling Slack, Notion, Google Drive, Gmail, and Calendar. Validates everything with the manager before persisting. Run this first before using any other skill. Also handles periodic context refreshes via /setup --refresh."
 ---
 
 # Setup
@@ -31,40 +31,45 @@ Identify the manager (name, role, teams), crawl sources for direct reports, vali
 
 Persist: `manager-context/manager-profile.md`, `manager-context/team/[name].md` per report, `manager-context/terminology.md`, `manager-context/sources.md`
 
-### Phase 2: Organizational Values
+### Phase 2: Performance & Management Frameworks
+Discover how the org evaluates performance and managers. Present the defaults from `../../references/performance-framework.md` and `../../references/management-framework.md`, then ask the manager to confirm, adjust, or replace with their org's framework. Key things to discover: framework dimensions, rating scale, promotion readiness labels, review cadence, goal cadence, and management competencies.
+
+Persist: `manager-context/performance-framework.md`, `manager-context/management-framework.md`
+
+### Phase 3: Organizational Values
 Ask if the org has defined values. If yes, search for documentation, extract value names and behaviours, ask what signals to look for per value. If no, skip the values lens.
 
 Persist: `manager-context/values.md`
 
-### Phase 3: Output Preferences
+### Phase 4: Output Preferences
 Present defaults (language, tone, file format, folder structure) and let the manager adjust.
 
 Persist: `manager-context/output-preferences.md`
 
-### Phase 4: Manager's Own Context
+### Phase 5: Manager's Own Context
 Capture upward context — OKRs, who they report to, key deadlines.
 
 Persist: `manager-context/manager-goals.md`
 
-### Phase 5: Triage Rules
+### Phase 6: Triage Rules
 Capture VIP people, hot channels, deprioritise list, privacy boundaries.
 
 Persist: `manager-context/triage-rules.md`
 
-### Phase 6: Review Calendar
+### Phase 7: Review Calendar
 Capture review cycle dates, calibration sessions, promotion windows, goal cadence.
 
 Persist: `manager-context/review-calendar.md`
 
-### Phase 7: Skill Preferences
+### Phase 8: Skill Preferences
 Capture 1:1 style and suggest a skill rhythm (daily triage, weekly health check, etc.).
 
 Persist: `manager-context/skill-preferences.md`
 
-### Phase 8: Staleness Check
+### Phase 9: Staleness Check
 Flag any discovered data older than ~2 months. Ask the manager to confirm or update.
 
-### Phase 9: Persist & Wrap Up
+### Phase 10: Persist & Wrap Up
 Save all validated context. Read `references/context-templates.md` for file templates. Present a summary of what was captured, flag gaps, and suggest first skills to try.
 
 ## Refresh Mode

--- a/plugins/people-management/skills/setup/references/context-templates.md
+++ b/plugins/people-management/skills/setup/references/context-templates.md
@@ -33,6 +33,83 @@ Templates for all files persisted during manager setup. Each template shows the 
 - [Any custom preferences noted during setup]
 ```
 
+## `manager-context/performance-framework.md`
+
+> **Fallback:** If this file is absent, skills fall back to the defaults in `../../references/performance-framework.md`.
+
+```markdown
+# Performance Framework
+
+**Last updated:** [date]
+
+## Dimensions
+
+### [Dimension 1 Name, e.g., Impact]
+[Description]
+
+| Sub-dimension | What it means |
+|--------------|---------------|
+| [sub-dimension] | [description] |
+
+### [Dimension 2 Name, e.g., Growth]
+[Description]
+
+| Sub-dimension | What it means |
+|--------------|---------------|
+| [sub-dimension] | [description] |
+
+## Rating Scale
+| Rating | Description |
+|--------|-------------|
+| [rating] | [description] |
+
+## Promotion Readiness
+| Label | Meaning |
+|-------|---------|
+| [label] | [meaning] |
+
+(If not tracked, note: "Not formally tracked")
+
+## Review Cadence
+| Cycle | Type | When |
+|-------|------|------|
+| [cycle name] | [full review / light check-in] | [period] |
+
+## Goal Cadence
+- Cycle: [quarterly / half-yearly / annual]
+- Current period: [period]
+```
+
+## `manager-context/management-framework.md`
+
+> **Fallback:** If this file is absent, skills fall back to the defaults in `../../references/management-framework.md`.
+
+```markdown
+# Management Framework
+
+**Last updated:** [date]
+
+## Dimensions
+
+### [Dimension 1 Name, e.g., Results]
+[Description]
+
+- **[Competency]** -- [what it looks like]
+- **[Competency]** -- [what it looks like]
+
+### [Dimension 2 Name, e.g., People]
+[Description]
+
+- **[Competency]** -- [what it looks like]
+- **[Competency]** -- [what it looks like]
+
+## How Managers Are Evaluated
+- [Separate management track / same framework as ICs / informal]
+
+## Notes
+- [Any org-specific context]
+```
+
 ## `manager-context/manager-goals.md`
 
 ```markdown
@@ -94,12 +171,9 @@ Templates for all files persisted during manager setup. Each template shows the 
 **Last updated:** [date]
 
 ## Cycle Dates
-| Cycle | Period | Self-review Due | Manager Review Due | Calibration |
-|-------|--------|----------------|-------------------|-------------|
-| Winter | [dates] | [date] | [date] | [date] |
-| Summer | [dates] | [date] | [date] | [date] |
-| Spring check-in | [dates] | — | [date] | — |
-| Fall check-in | [dates] | — | [date] | — |
+| Cycle | Period | Type | Self-review Due | Manager Review Due | Calibration |
+|-------|--------|------|----------------|-------------------|-------------|
+| [cycle name] | [dates] | [full review / check-in] | [date] | [date] | [date] |
 
 ## Goal Cadence
 - Cycle: [quarterly / half-yearly]

--- a/plugins/people-management/skills/setup/references/context-templates.md
+++ b/plugins/people-management/skills/setup/references/context-templates.md
@@ -35,7 +35,7 @@ Templates for all files persisted during manager setup. Each template shows the 
 
 ## `manager-context/performance-framework.md`
 
-> **Fallback:** If this file is absent, skills fall back to the defaults in `../../references/performance-framework.md`.
+> **Required:** Skills that need the performance framework will ask the manager to run `/setup` if this file is missing.
 
 ```markdown
 # Performance Framework
@@ -82,7 +82,7 @@ Templates for all files persisted during manager setup. Each template shows the 
 
 ## `manager-context/management-framework.md`
 
-> **Fallback:** If this file is absent, skills fall back to the defaults in `../../references/management-framework.md`.
+> **Required:** Skills that need the management framework will ask the manager to run `/setup` if this file is missing.
 
 ```markdown
 # Management Framework

--- a/plugins/people-management/skills/setup/references/context-templates.md
+++ b/plugins/people-management/skills/setup/references/context-templates.md
@@ -1,0 +1,241 @@
+# Manager Context File Templates
+
+Templates for all files persisted during manager setup. Each template shows the expected structure — fill in validated data from discovery phases.
+
+## `manager-context/output-preferences.md`
+
+```markdown
+# Output Preferences
+
+**Last updated:** [date]
+
+## General Style
+- Language: English
+- Tone: Professional, concise — bullet points over prose
+- Detail level: Moderate (summaries with source links)
+- Emoji: Yes (for visual scanning in triage/priorities)
+
+## File Format
+- Default: Markdown (.md)
+- Exceptions: [any noted by manager, e.g. .docx for performance reviews]
+
+## Filename Format
+- Pattern: `YYYY-MM-DD-<skill>-<subject>`
+- Date position: prefix
+- Example: `2026-03-13-one-on-one-prep-alex.md`
+
+## Folder Structure
+- Root: `outputs/`
+- Organisation: by skill type (subdirectory per skill)
+- Subdirectories: meeting-prep, one-on-one-prep, triage, team-health, performance, customer-status, priorities
+
+## Notes
+- [Any custom preferences noted during setup]
+```
+
+## `manager-context/manager-goals.md`
+
+```markdown
+# Manager's Own Context
+
+**Last updated:** [date]
+
+## Reports To
+- Name: [name]
+- Role: [role]
+- Key priorities: [what they care about]
+
+## My OKRs / Goals
+- Location: [Notion page / Drive doc link]
+- [Goal 1]
+- [Goal 2]
+- [Goal 3]
+
+## Upcoming Milestones
+- [milestone] — [date]
+
+## Notes
+- [Any context about what's being measured, org priorities, etc.]
+```
+
+## `manager-context/triage-rules.md`
+
+```markdown
+# Triage & Priority Rules
+
+**Last updated:** [date]
+
+## VIP — Always Surface
+| Who | Why |
+|-----|-----|
+| [name] | [manager / key stakeholder / customer champion] |
+
+## Hot Channels & Keywords
+| Channel / Keyword | Why |
+|-------------------|-----|
+| #[channel] | [incident channel / escalation path] |
+| "[keyword]" | [signals urgency] |
+
+## Deprioritise
+- [bot channels, automated notifications, etc.]
+
+## Privacy Boundaries
+- [channels or topics to skip]
+
+## Notes
+- [Any other triage preferences]
+```
+
+## `manager-context/review-calendar.md`
+
+```markdown
+# Performance & Review Calendar
+
+**Last updated:** [date]
+
+## Cycle Dates
+| Cycle | Period | Self-review Due | Manager Review Due | Calibration |
+|-------|--------|----------------|-------------------|-------------|
+| Winter | [dates] | [date] | [date] | [date] |
+| Summer | [dates] | [date] | [date] | [date] |
+| Spring check-in | [dates] | — | [date] | — |
+| Fall check-in | [dates] | — | [date] | — |
+
+## Goal Cadence
+- Cycle: [quarterly / half-yearly]
+- Current period: [Q1 2026 / H1 2026]
+
+## Promotion Nominations
+- Next window: [date or "unknown"]
+
+## Notes
+- [Any team-specific exceptions or context]
+```
+
+## `manager-context/skill-preferences.md`
+
+```markdown
+# Skill & 1:1 Preferences
+
+**Last updated:** [date]
+
+## 1:1 Style
+- Format: [structured / free-flow / hybrid]
+- Always include: [goals check, wins, blockers, development — whatever they said]
+- Share prep with report: [yes / no]
+- Notes: [any other preferences]
+
+## Skill Rhythm
+| Skill | Cadence | When |
+|-------|---------|------|
+| triage-messages | Daily | Morning |
+| plan-priorities | Daily | After triage |
+| prep-one-on-one | Per 1:1 | Day before |
+| prep-meeting | As needed | Before meetings |
+| check-team-health | [Weekly / Biweekly] | [day] |
+| customer-status | [Weekly / As needed] | [day] |
+| prep-performance | Per cycle | [weeks before deadline] |
+```
+
+## `manager-context/manager-profile.md`
+
+```markdown
+# Manager Profile
+
+**Name:** [name]
+**Role:** [role]
+**Teams:** [teams]
+**Last updated:** [date]
+
+## Direct Reports
+| Name | Slack | Role | 1:1 Cadence | Goals Location | Last Review |
+|------|-------|------|-------------|----------------|-------------|
+| [name] | @[handle] | [role] | Weekly | [Notion page / Drive doc] | [date] |
+
+## Key Stakeholders
+| Name | Relationship | Context |
+|------|-------------|---------|
+| [name] | [skip-level / cross-functional / etc.] | [context] |
+
+## Communication Preferences
+- [preferences discovered]
+
+## Rhythm
+- [meeting cadence, working patterns]
+```
+
+## `manager-context/team/[name].md`
+
+One file per direct report:
+
+```markdown
+# [Full Name]
+
+**Slack:** @[handle]
+**Role:** [role]
+**Reports to:** [manager]
+
+## Goals & Development
+- **Current goals location:** [Notion page link / Drive doc link]
+- **Last goal update:** [date]
+- **Development areas:** [from most recent review/goals]
+
+## Context
+- **Primary channels:** #[channel], #[channel]
+- **Current projects:** [projects]
+- **Working style notes:** [any patterns noticed]
+```
+
+## `manager-context/terminology.md`
+
+```markdown
+# Team Terminology
+
+| Term | Meaning | Context |
+|------|---------|---------|
+| [term] | [meaning] | [where it's used] |
+```
+
+## `manager-context/sources.md`
+
+```markdown
+# Data Source Locations
+
+Where to find key information for this manager's team.
+
+## Performance & Goals
+| Team Member | Goals | Reviews | 1:1 Notes |
+|-------------|-------|---------|-----------|
+| [name] | [Notion link] | [Notion link] | [Drive link] |
+
+## Team Docs
+- Team page: [link]
+- OKRs: [link]
+- Hiring pipeline: [link]
+
+## Customer/Project Channels
+| Account | Slack Channel | Project Page | Key Contact |
+|---------|--------------|--------------|-------------|
+| [account] | #[channel] | [Notion link] | [name] |
+```
+
+## values.md
+
+**Persist to `manager-context/values.md`:**
+```markdown
+# Organizational Values
+
+**Last updated:** [date]
+
+## Values
+
+| Value | Description | Signals to look for |
+|-------|-------------|-------------------|
+| [value name] | [brief description] | [what it looks like in Slack, docs, meetings] |
+
+## How Values Are Used in Reviews
+- [any org-specific guidance on values in performance reviews]
+
+## Notes
+- [how heavily to weigh values, any org-specific context]
+```

--- a/plugins/people-management/skills/setup/references/discovery-phases.md
+++ b/plugins/people-management/skills/setup/references/discovery-phases.md
@@ -1,0 +1,293 @@
+# Discovery Phases — Detailed Instructions
+
+Detailed crawl instructions, conversation prompts, and validation formats for each setup phase.
+
+## Phase 1: Team Discovery
+
+### 1.1 Identify the Manager
+
+Ask:
+```
+Let's set up your manager context. A few quick questions:
+
+1. What's your name and role?
+2. Which team(s) do you manage?
+3. How many direct reports do you have? (rough count is fine)
+```
+
+### 1.2 Crawl Team Structure
+
+Search for the manager's team across sources:
+
+**Slack:**
+- Channels the manager is in (especially team/project prefixes)
+- Frequent DM partners and channel participants
+- People who @-mention or are @-mentioned by the manager frequently
+
+**Notion:**
+- Team pages, org charts, reporting structure docs
+- Pages with the manager's name or team name
+
+**Google Calendar:**
+- Recurring 1:1 meetings — attendees are likely direct reports
+- Team syncs, standups, regular meetings
+
+**Gmail:**
+- Frequent email correspondents within the company
+
+For each person, gather: full name, Slack handle, role/title, how they were discovered.
+
+### 1.3 Validate Team
+
+Present findings:
+```
+I found these people who appear to be your direct reports:
+
+1. [Name] — [role], found via [1:1 calendar + Slack #team-channel]
+2. [Name] — [role], found via [Slack DMs + Notion team page]
+3. [Name] — [role], found via [Slack channel only — unsure if direct report]
+
+Are these correct? Anyone missing? Anyone who shouldn't be on this list?
+```
+
+Wait for confirmation. Adjust based on feedback.
+
+### 1.4 Discover Terminology & Shorthand
+
+**Slack:** Search recent messages (last 30 days) in team channels for capitalized abbreviations, quoted terms, internal codenames.
+
+**Notion:** Search for glossary pages, onboarding docs.
+
+Present grouped:
+```
+I found these internal terms:
+
+**Confident:** [term] → [meaning]
+**Needs verification:** [term] → [guess]?
+**Uncertain:** [term] → ?
+
+Please correct anything wrong and fill in the uncertain ones.
+```
+
+### 1.5 Discover Development Goals & Performance Data
+
+For each team member, search:
+
+**Notion:** Performance review pages, goal banks, 90-day plans, development notes.
+**Google Drive:** 1:1 documents, performance notes, development plans.
+
+Report per person:
+```
+✅ [Name] — Found goals in Notion, 1:1 doc in Drive, last review [date]
+⚠️ [Name] — Found 1:1 doc but NO goals. Where do you track these?
+❌ [Name] — Couldn't find any performance data. Where should I look?
+```
+
+If goals are missing, explicitly ask where they're documented.
+
+### 1.6 Discover Ways of Working
+
+**Calendar:** 1:1 cadence per report, team sync frequency, skip-level meetings, cross-functional meetings.
+**Slack:** Primary channels, communication rhythm, purpose-specific channels.
+
+Present:
+```
+Your rhythm looks like this:
+- 1:1s: Weekly with [names], biweekly with [names]
+- Team sync: [day/time] in [channel/meeting]
+- Communication style: [batch responder / real-time]
+- Most active channels: #[channel], #[channel]
+
+Anything I should know about how you prefer to work?
+```
+
+### 1.7 Customer & Project Context (if applicable)
+
+For customer-facing teams:
+
+**Slack:** Identify project/customer channels (#proj-*, #customer-*, #account-*). Map team members to channels.
+**Notion:** Project pages, customer status docs, delivery trackers.
+
+Present:
+```
+Active accounts/projects:
+- [Customer] — [team member] is primary, channel: #proj-[name]
+- [Project] — Internal, [team member] is leading
+
+Any accounts I'm missing?
+```
+
+---
+
+## Phase 2: Organizational Values
+
+Ask:
+```
+Does your organization have defined core values?
+
+If yes:
+1. What are they? (list the names)
+2. Where are they documented? (Notion page, handbook, etc.)
+3. How are they used in performance reviews or feedback?
+
+If no:
+That's fine — we can skip the values lens in skills, or you can define informal values later.
+```
+
+If documented, search Notion and Drive for the values page. Extract value names and associated behaviours.
+
+For each value, ask:
+- What does this value look like in practice for your team?
+- What signals might I find in Slack, docs, or meetings?
+
+Present:
+```
+Here's my understanding of your values:
+
+1. [Value Name] — [description]. Signals: [what to look for]
+2. [Value Name] — [description]. Signals: [what to look for]
+
+Correct? Any values I should weigh more heavily in 1:1 prep or team health?
+```
+
+Persist to `manager-context/values.md`. Read `references/context-templates.md` for template.
+
+---
+
+## Phase 3: Output Preferences
+
+Present defaults and let the manager adjust:
+```
+How should I produce and save outputs? Defaults — adjust anything:
+
+**Style:** English, professional/concise, moderate detail, emoji for visual scanning
+**File format:** Markdown (.md)
+**Filename:** YYYY-MM-DD-<skill>-<subject>.md
+**Folders:** outputs/ with subdirectories per skill type
+
+Options: language, shorter/longer, .docx/.html, flat/weekly folders, different naming
+```
+
+Persist to `manager-context/output-preferences.md`. All other skills must read this before saving output.
+
+---
+
+## Phase 4: Manager's Own Context
+
+```
+A few questions about your own context:
+
+1. **Who do you report to?** (name, role)
+2. **What are your current OKRs or goals?** (or where documented?)
+3. **What does your manager care most about right now?**
+4. **Any key deadlines or milestones coming up?**
+```
+
+Search Notion and Drive for the manager's own goals if they point to a location.
+
+Persist to `manager-context/manager-goals.md`.
+
+---
+
+## Phase 5: Triage Rules
+
+```
+Let's set up your triage rules:
+
+1. **VIP people** — whose messages always bubble to the top?
+2. **Hot channels or topics** — channels/keywords that always mean urgent?
+3. **Deprioritise** — anything to push to the bottom?
+4. **Privacy boundaries** — channels, people, or topics to skip entirely?
+```
+
+Persist to `manager-context/triage-rules.md`. The triage-messages and priority-planner skills must read and apply these rules.
+
+---
+
+## Phase 6: Review Calendar
+
+```
+When are your review cycles?
+
+Common patterns:
+- Winter & Summer: Full bi-annual reviews (Impact + Growth ratings)
+- Spring & Fall: Lighter check-ins
+
+For your team:
+1. When is the next review cycle?
+2. When are calibration sessions?
+3. Any promotion nomination windows coming up?
+4. Do you track goals per quarter or per half?
+```
+
+Persist to `manager-context/review-calendar.md`.
+
+---
+
+## Phase 7: Skill Preferences
+
+```
+A couple more things:
+
+**1:1 style:** Structured (always cover goals, wins, blockers) or free-flow?
+Topics you always want included? Share prep with the report beforehand?
+
+**Suggested skill rhythm:**
+- Daily: /triage-messages (morning), /plan-priorities (after triage)
+- Day before 1:1s: /prep-one-on-one [name]
+- Before meetings: /prep-meeting (as needed)
+- Weekly or biweekly: /check-team-health
+- Before review cycles: /prep-performance
+
+Does this rhythm work?
+```
+
+Persist to `manager-context/skill-preferences.md`.
+
+---
+
+## Phase 8: Staleness Check
+
+Flag anything stale:
+```
+Staleness alerts:
+
+- [Name]'s goals were last updated 4 months ago — still current?
+- The "Q4 OKRs" page hasn't been edited since November — have new OKRs been set?
+- [Name] hasn't been active in #[channel] for 3 weeks — still on the project?
+- Your 1:1 with [Name] was cancelled 3 times in a row — intentional?
+```
+
+Ask the manager to confirm or update each flagged item.
+
+---
+
+## Phase 9: Persist & Wrap Up
+
+Save all validated context. Read `references/context-templates.md` for file templates.
+
+Present summary:
+```
+Setup complete! Here's what I know:
+
+- [N] direct reports profiled
+- Goals tracked for [N/M] team members ([list gaps])
+- [N] internal terms decoded
+- [N] recurring meetings mapped
+- [N] data source locations saved
+- Your OKRs and upward context captured
+- Triage rules: [N] VIPs, [N] hot channels, [N] deprioritised
+- Review calendar: next cycle [date]
+- Output style: [language], [format], [folder structure]
+- Skill rhythm configured
+- Values: [N values configured / skipped]
+
+Missing connectors: [list any]
+Data gaps to fill later: [list any]
+
+You're ready to go! Try:
+- /triage-messages to catch up on what needs attention
+- /plan-priorities to plan your day
+- /prep-one-on-one [name] before your next 1:1
+- /prep-meeting for your next meeting
+```

--- a/plugins/people-management/skills/setup/references/discovery-phases.md
+++ b/plugins/people-management/skills/setup/references/discovery-phases.md
@@ -39,15 +39,32 @@ For each person, gather: full name, Slack handle, role/title, how they were disc
 
 ### 1.3 Validate Team
 
-Present findings:
+Present findings. If connectors were available, show how each person was discovered. If connectors were unavailable, ask the manager to provide the team list directly.
+
+For each team member, also ask for their **Slack handle** — this is needed for searching messages and mapping activity later.
+
 ```
 I found these people who appear to be your direct reports:
 
-1. [Name] — [role], found via [1:1 calendar + Slack #team-channel]
-2. [Name] — [role], found via [Slack DMs + Notion team page]
-3. [Name] — [role], found via [Slack channel only — unsure if direct report]
+1. [Name] — @[slack-handle], [role], found via [1:1 calendar + Slack #team-channel]
+2. [Name] — @[slack-handle], [role], found via [Slack DMs + Notion team page]
+3. [Name] — @[slack-handle], [role], found via [Slack channel only — unsure if direct report]
 
 Are these correct? Anyone missing? Anyone who shouldn't be on this list?
+For anyone I'm missing a Slack handle, what is it?
+```
+
+If connectors were unavailable, use this format instead:
+```
+Since I couldn't crawl your tools, I'll need you to provide your team list:
+
+For each direct report, please share:
+- Full name
+- Slack handle (e.g., @alex-rivera)
+- Role/title
+- What they're currently working on
+
+Also, what's your own Slack handle?
 ```
 
 Wait for confirmation. Adjust based on feedback.
@@ -85,6 +102,19 @@ Report per person:
 
 If goals are missing, explicitly ask where they're documented.
 
+**If connectors are unavailable**, ask the manager directly:
+```
+I couldn't search your tools, so I need a few things to make the skills useful:
+
+1. **Where do you keep 1:1 notes?** (Google Docs, Notion, somewhere else?)
+2. **Where are goals tracked?** (Notion OKR page, spreadsheet, goal-setting tool?)
+3. **Where are performance reviews stored?** (Notion, Google Drive folder, HR tool?)
+4. **For each team member, do you know their current development areas or goals?**
+   - [Name]: [goals / development focus / "will gather in 1:1"]
+
+Even rough answers help — I'll fill in the details when connectors become available.
+```
+
 ### 1.6 Discover Ways of Working
 
 **Calendar:** 1:1 cadence per report, team sync frequency, skip-level meetings, cross-functional meetings.
@@ -101,11 +131,27 @@ Your rhythm looks like this:
 Anything I should know about how you prefer to work?
 ```
 
-### 1.7 Customer & Project Context (if applicable)
+### 1.7 Channels & Project Context
 
-For customer-facing teams:
+Map team members to their primary Slack channels. This is used by triage, team health, and 1:1 prep to know where to look for each person's activity.
 
-**Slack:** Identify project/customer channels (#proj-*, #customer-*, #account-*). Map team members to channels.
+**If connectors are available:**
+
+**Slack:** Identify project/customer channels (#proj-*, #customer-*, #account-*, #team-*). Map team members to channels based on membership and activity.
+
+**If connectors are unavailable**, ask:
+```
+Which Slack channels is each team member most active in?
+
+| Team member | Primary channels |
+|-------------|-----------------|
+| [Name] | #[channel], #[channel] |
+
+Also, are there any project or customer channels I should monitor?
+```
+
+For customer-facing teams, also discover:
+
 **Notion:** Project pages, customer status docs, delivery trackers.
 
 Present:
@@ -119,42 +165,224 @@ Any accounts I'm missing?
 
 ---
 
-## Phase 2: Organizational Values
+## Phase 2: Performance & Management Frameworks
 
-Ask:
+Discover how the org evaluates individual performance and management effectiveness. This is critical — the performance framework shapes how 1:1 prep, team health, and performance cycle skills organise their output.
+
+### 2.1 Crawl for Existing Framework Docs
+
+Before asking the manager, search for existing documentation:
+
+**Notion:** Search for pages matching: "performance framework", "performance review", "review process", "career framework", "career ladder", "leveling", "competency", "rating", "promotion", "management competencies", "people manager expectations".
+
+**Google Drive:** Search for docs matching: "performance review template", "review guide", "career framework", "leveling guide", "management expectations".
+
+**Slack:** Search for recent messages mentioning: "review cycle", "calibration", "promotion", "performance review" — these often link to framework docs.
+
+For each document found, extract:
+- Framework dimension names and descriptions
+- Rating scale labels and descriptions
+- Promotion readiness labels (if any)
+- Review cadence and timeline
+- Management-specific competencies or expectations
+
+### 2.2 Present Findings & Fill Gaps
+
+If framework docs were found, present what was extracted:
 ```
-Does your organization have defined core values?
+I found your org's performance framework! Here's what I extracted:
 
-If yes:
-1. What are they? (list the names)
-2. Where are they documented? (Notion page, handbook, etc.)
-3. How are they used in performance reviews or feedback?
+**Performance dimensions:**
+1. [Dimension name] — [description, sub-dimensions]
+2. [Dimension name] — [description, sub-dimensions]
 
-If no:
-That's fine — we can skip the values lens in skills, or you can define informal values later.
+**Rating scale:** [extracted labels]
+**Promotion tracking:** [extracted labels / not found]
+**Review cadence:** [extracted timeline]
+
+Is this accurate? Anything missing or outdated?
 ```
 
-If documented, search Notion and Drive for the values page. Extract value names and associated behaviours.
-
-For each value, ask:
-- What does this value look like in practice for your team?
-- What signals might I find in Slack, docs, or meetings?
-
-Present:
+If NO framework docs were found, walk through building it:
 ```
-Here's my understanding of your values:
+I couldn't find a documented performance framework. Let's set one up — I'll ask a few questions and you can tell me what your org uses. If you're unsure on anything, I have sensible defaults.
 
-1. [Value Name] — [description]. Signals: [what to look for]
-2. [Value Name] — [description]. Signals: [what to look for]
+**1. How does your org evaluate performance?**
+Most orgs use 2-3 dimensions. Common patterns:
+- **Results + Growth** — what someone delivered AND how they're developing
+- **What + How** — outcomes AND behaviours/values
+- **Single dimension** — just overall performance rating
 
-Correct? Any values I should weigh more heavily in 1:1 prep or team health?
+What dimensions does your org use? (If unsure, I'll use "Impact" and "Growth" as defaults — you can change these anytime.)
 ```
 
-Persist to `manager-context/values.md`. Read `references/context-templates.md` for template.
+Wait for the manager's answer. Then continue:
+
+```
+**2. Rating scale** — how are people rated in reviews?
+Common patterns:
+- Descriptive labels (e.g., "Exceeds Expectations / Meets / Below")
+- Numbered scale (e.g., 1-5)
+- Custom labels (e.g., "Outstanding / Strong / Developing")
+- No formal ratings
+
+What does your org use?
+```
+
+```
+**3. Promotion readiness** — does your org track this separately?
+Common patterns:
+- Labels like "Ready Now / Ready Soon / Not Yet"
+- Integrated into the rating (e.g., top rating = promotion-ready)
+- Not formally tracked
+
+What does your org use? (Fine to skip if not applicable.)
+```
+
+```
+**4. Review cadence** — when do formal reviews happen?
+- Annual (once a year)
+- Bi-annual (twice a year, e.g., summer + winter)
+- Quarterly
+- Something else?
+
+And are there lighter check-ins between full reviews?
+```
+
+```
+**5. Goal cadence** — how often are goals set and reviewed?
+- Quarterly (OKRs or similar)
+- Half-yearly
+- Annually
+- Continuous / no fixed cadence
+```
+
+For each answer, confirm understanding and note any sub-dimensions or nuances the manager mentions.
+
+### 2.3 Management Framework
+
+If management-specific docs were found in 2.1, present them. Otherwise:
+
+```
+**6. Management expectations** — does your org have a formal model for what makes a good manager?
+
+Common patterns:
+- **Two-dimensional:** driving results AND developing people
+- **Competency model:** specific skills like delegation, communication, hiring, coaching
+- **No formal model** — that's fine, we'll use sensible defaults (Results + People)
+
+What does your org expect from managers? Are managers evaluated separately or on the same framework as ICs?
+```
+
+If the manager describes specific competencies, capture each one with a brief description.
+
+### 2.4 Validate & Persist
+
+Present the complete framework for confirmation:
+```
+Here's your complete framework configuration:
+
+**Performance Framework:**
+- Dimensions: [list with sub-dimensions]
+- Rating scale: [labels]
+- Promotion tracking: [labels / not tracked]
+- Review cadence: [cadence with dates if known]
+- Goal cadence: [cadence]
+
+**Management Framework:**
+- Dimensions: [list with competencies]
+- How managers are evaluated: [separate track / same as ICs / informal]
+
+These will shape how 1:1 prep, team health, and performance cycle skills organise their output. Anything to adjust?
+```
+
+Wait for confirmation. Then persist to `manager-context/performance-framework.md` and `manager-context/management-framework.md`. Read `references/context-templates.md` for file templates.
 
 ---
 
-## Phase 3: Output Preferences
+## Phase 3: Organizational Values
+
+Values tell skills *how* results should be delivered. They provide conversation threads beyond goals and deliverables — especially valuable in 1:1 prep, team health, and performance reviews.
+
+### 3.1 Crawl for Values Documentation
+
+Search for existing values documentation before asking:
+
+**Notion:** Search for pages matching: "values", "core values", "company values", "culture", "handbook", "how we work", "principles".
+
+**Google Drive:** Search for docs matching: "values", "culture deck", "handbook", "ways of working".
+
+**Slack:** Search for pinned messages or channels like #values, #culture, #handbook that may link to values docs.
+
+### 3.2 Present Findings or Ask
+
+If values docs were found, extract value names, descriptions, and any associated behaviours:
+```
+I found your org's values! Here's what I extracted:
+
+1. **[Value Name]** — [description from doc]
+2. **[Value Name]** — [description from doc]
+3. **[Value Name]** — [description from doc]
+
+Is this the current list? Any that are missing or outdated?
+```
+
+If NO values docs were found:
+```
+I couldn't find documented company values. Does your organization have defined core values?
+
+If yes:
+1. What are they? (just list the names — I'll help flesh them out)
+2. Where are they documented? (Notion page, handbook, website, etc.)
+
+If no — that's fine. We can skip the values lens in skills, or you can define informal team values. You can always add values later by running /setup --refresh.
+```
+
+### 3.3 Define Signals Per Value
+
+For each value, help the manager define what to look for. This is the key step — generic value names are useless without signals.
+
+For each value, ask:
+```
+Let's make "[Value Name]" actionable for the skills. For each question, give me examples or say "skip" if unsure:
+
+1. **What does this value look like in Slack?**
+   (e.g., for a "Collaboration" value: helping others in channels, cross-team threads, sharing context proactively)
+
+2. **What does it look like in work output?**
+   (e.g., for a "Quality" value: iteration on docs, peer feedback, attention to detail)
+
+3. **How is it used in performance reviews?**
+   (e.g., "we ask for examples of each value" or "it's part of the 'How' rating")
+
+4. **What's hard to see digitally?**
+   (e.g., empathy in person, trust-building, tone of voice — these I'll flag for your own observation)
+```
+
+If the manager has many values (5+), offer to batch:
+```
+You have [N] values — want me to go through each one, or would you rather give me a quick summary of what signals matter most and I'll fill in the rest?
+```
+
+### 3.4 Validate & Persist
+
+Present the complete values configuration:
+```
+Here's your values configuration:
+
+| Value | Description | Signals to look for | Hard to see digitally |
+|-------|-------------|--------------------|-----------------------|
+| [name] | [description] | [signals] | [what needs manager's own observation] |
+
+These will be used as a lens in 1:1 prep, team health, and performance reviews.
+Any values I should weigh more heavily? Any to skip in certain skills?
+```
+
+Persist to `manager-context/values.md`. Read `references/context-templates.md` for the template. See `../../references/values-guide.md` for how skills use values.
+
+---
+
+## Phase 4: Output Preferences
 
 Present defaults and let the manager adjust:
 ```
@@ -172,7 +400,7 @@ Persist to `manager-context/output-preferences.md`. All other skills must read t
 
 ---
 
-## Phase 4: Manager's Own Context
+## Phase 5: Manager's Own Context
 
 ```
 A few questions about your own context:
@@ -189,7 +417,7 @@ Persist to `manager-context/manager-goals.md`.
 
 ---
 
-## Phase 5: Triage Rules
+## Phase 6: Triage Rules
 
 ```
 Let's set up your triage rules:
@@ -204,14 +432,15 @@ Persist to `manager-context/triage-rules.md`. The triage-messages and priority-p
 
 ---
 
-## Phase 6: Review Calendar
+## Phase 7: Review Calendar
 
 ```
 When are your review cycles?
 
 Common patterns:
-- Winter & Summer: Full bi-annual reviews (Impact + Growth ratings)
-- Spring & Fall: Lighter check-ins
+- Bi-annual: full reviews twice a year with lighter check-ins in between
+- Annual: one big review per year
+- Quarterly: lighter but more frequent
 
 For your team:
 1. When is the next review cycle?
@@ -224,7 +453,7 @@ Persist to `manager-context/review-calendar.md`.
 
 ---
 
-## Phase 7: Skill Preferences
+## Phase 8: Skill Preferences
 
 ```
 A couple more things:
@@ -233,11 +462,11 @@ A couple more things:
 Topics you always want included? Share prep with the report beforehand?
 
 **Suggested skill rhythm:**
-- Daily: /triage-messages (morning), /plan-priorities (after triage)
-- Day before 1:1s: /prep-one-on-one [name]
-- Before meetings: /prep-meeting (as needed)
-- Weekly or biweekly: /check-team-health
-- Before review cycles: /prep-performance
+- Daily: /triage-messages (morning), /priority-planner (after triage)
+- Day before 1:1s: /one-on-one-prep [name]
+- Before meetings: /meeting-prep (as needed)
+- Weekly or biweekly: /team-health
+- Before review cycles: /performance-cycle
 
 Does this rhythm work?
 ```
@@ -246,7 +475,7 @@ Persist to `manager-context/skill-preferences.md`.
 
 ---
 
-## Phase 8: Staleness Check
+## Phase 9: Staleness Check
 
 Flag anything stale:
 ```
@@ -262,7 +491,7 @@ Ask the manager to confirm or update each flagged item.
 
 ---
 
-## Phase 9: Persist & Wrap Up
+## Phase 10: Persist & Wrap Up
 
 Save all validated context. Read `references/context-templates.md` for file templates.
 
@@ -287,7 +516,7 @@ Data gaps to fill later: [list any]
 
 You're ready to go! Try:
 - /triage-messages to catch up on what needs attention
-- /plan-priorities to plan your day
-- /prep-one-on-one [name] before your next 1:1
-- /prep-meeting for your next meeting
+- /priority-planner to plan your day
+- /one-on-one-prep [name] before your next 1:1
+- /meeting-prep for your next meeting
 ```

--- a/plugins/people-management/skills/team-health/SKILL.md
+++ b/plugins/people-management/skills/team-health/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: team-health
-description: Periodic check on team dynamics, engagement signals, and development trajectory for all direct reports. Surfaces patterns across the team — who might need more challenge, who might need more support, who hasn't had a 1:1 recently. Uses two universal lenses: performance & growth, and wellbeing & connection. Outputs are prompts for reflection, not diagnoses.
+description: "Periodic check on team dynamics, engagement signals, and development trajectory for all direct reports. Surfaces patterns across the team — who might need more challenge, who might need more support, who hasn't had a 1:1 recently. Uses two universal lenses: performance & growth, and wellbeing & connection. Outputs are prompts for reflection, not diagnoses."
 ---
 
 # Team Health Check

--- a/plugins/people-management/skills/team-health/SKILL.md
+++ b/plugins/people-management/skills/team-health/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: team-health
+description: Periodic check on team dynamics, engagement signals, and development trajectory for all direct reports. Surfaces patterns across the team — who might need more challenge, who might need more support, who hasn't had a 1:1 recently. Uses two universal lenses: performance & growth, and wellbeing & connection. Outputs are prompts for reflection, not diagnoses.
+---
+
+# Team Health Check
+
+> **Two lenses, always.** "Development" asks: is this person growing and performing? "Wellbeing" asks: is this person thriving, connected, and energised? Great managers hold both.
+
+A periodic overview of team dynamics, engagement signals, wellbeing, and development trajectory across all direct reports.
+
+## When to Use
+
+- Weekly or biweekly team health review
+- Before calibration or planning meetings
+- When the manager says "how's my team doing?", "team health check", "anyone I should check in with?"
+- When preparing for skip-level conversations
+
+## Instructions
+
+If any MCP connector is unavailable, follow the connector unavailability protocol in `../../references/operating-principles.md`.
+
+### 1. Load Team Context
+
+Read from `manager-context/`:
+- `manager-profile.md` — full list of direct reports
+- `team/` — individual profiles with goals, projects, last review dates
+- `sources.md` — channels and data locations per team member
+
+If context is missing, note it and work with available sources.
+
+### 2. Scan Per Team Member
+
+For each direct report, gather data from the last 14 days (or since last health check):
+
+**Activity & Engagement (Slack):**
+- Message volume in team/project channels (relative to their baseline if known)
+- Types of messages: asking questions, answering questions, sharing updates, celebrating, flagging issues
+- Channels they're active in
+- Any public wins or recognition received
+- Any public frustration or repeated blockers
+
+**1:1 Cadence (Calendar):**
+- When was their last 1:1 with the manager?
+- Were recent 1:1s kept or cancelled?
+- Are they overdue for a 1:1?
+
+**Development Goals (Notion/Drive):**
+- Last time their goals were updated
+- Any progress notes or self-assessments
+- Are there development areas with no recent activity?
+
+**Workload Signals (Calendar + Slack):**
+- Meeting load (heavy/normal/light for their role)
+- Are they in channels/meetings outside their usual scope? (scope expansion — could be good or concerning)
+
+**Wellbeing & Connection Signals (Slack + Calendar):**
+- Energy & wellbeing: late-night messages, weekend activity, signs of overwork
+- Connection: are they participating in non-work channels (#random, social threads, team celebrations)?
+- Celebration: have they been recognised or praised recently? Have they celebrated others?
+- Tone: are their messages upbeat, neutral, or showing signs of frustration/fatigue? (use as a soft signal only — never diagnose)
+- Fun & enjoyment: any signs of passion, enthusiasm, or joy in their work (shipping excitement, sharing wins, volunteering for things)?
+
+### 3. Synthesise Per Person
+
+For each team member, produce a brief profile covering both lenses:
+
+```
+### [Name] — [Role]
+
+**🎯 Development & Performance:**
+**Activity:** [Normal / Increased / Decreased] — [1-line evidence]
+**Recent wins:** [list any, or "None surfaced"]
+**Goals:** [last updated date] — [current / stale]
+**Development focus:** [area from goals] — [evidence of progress / no visible progress]
+**Growth signals:** [scope expansion, new skills, leadership behaviours — or "None"]
+
+**🫂 Wellbeing & Connection:**
+**Energy:** [Balanced / High output / Signs of overwork] — [evidence, e.g., "messages after 22:00 on 3 nights"]
+**Connection:** [Active in social channels / Quiet / Only work-related activity]
+**Celebrated/been celebrated:** [yes — details / not recently]
+**Tone:** [Positive / Neutral / Worth checking in] — [soft signal only]
+
+**Last 1:1:** [date] — [on track / overdue]
+**Signals to explore:** [friction, blockers, wellbeing patterns — or "None"]
+```
+
+### 4. Surface Team-Level Patterns
+
+Look across the team for patterns in both dimensions:
+
+**🎯 Development & Performance patterns:**
+- **Recognition gap:** Anyone who hasn't received public recognition in >2 weeks?
+- **1:1 gap:** Anyone overdue for a 1:1?
+- **Goal staleness:** Anyone whose development goals haven't been updated in >6 weeks?
+- **Growth signals:** Anyone taking on new scope or showing leadership behaviours?
+- **Performance signals:** Anyone showing decreased engagement across multiple indicators?
+
+**🫂 Wellbeing & Connection patterns:**
+- **Energy imbalance:** Anyone consistently working late, weekends, or showing signs of overwork?
+- **Isolation risk:** Anyone who's gone quiet in social channels or stopped engaging beyond work tasks?
+- **Celebration deficit:** Is the team celebrating wins? Are specific people consistently uncelebrated?
+- **Fun factor:** Is there joy and energy in team channels, or has everything become purely transactional?
+- **Workload imbalance:** Anyone significantly more or less loaded than peers?
+
+### 5. Produce the Health Check
+
+Read `references/output-template.md` for the full output template structure.
+
+### 6. Present
+
+```
+Here's your team health check. These are signals for your reflection — you know your people better than any tool.
+
+Want me to prep a 1:1 for anyone specific?
+```
+
+### 7. Sub-Agent Review
+
+Spawn a sub-agent to review the health check with fresh eyes. The reviewer should:
+- Check that **both lenses** (Development & Performance and Wellbeing & Connection) are meaningfully covered — neither should be thin or skipped.
+- Check for **baseline awareness** — are signals calibrated against known baselines, or is normal behaviour being flagged?
+- Verify that language stays in "signal" territory, never crossing into diagnosis ("seems disengaged", "is struggling").
+- Check that **celebration and recognition** are given adequate weight — not just problem-flagging.
+- Flag any team member who appears to have very thin data — the manager should know where the blind spots are.
+
+Incorporate the reviewer's feedback before presenting the final health check to the manager.
+
+## Important Notes
+
+Read `../../references/operating-principles.md` for shared operating principles (data scope, DM flagging, signals vs diagnoses, connector unavailability).
+
+Additional notes specific to this skill:
+- **Celebrate first.** Lead with wins, recognition, and positive energy. Wellbeing & Connection starts with seeing the good.
+- **Both lenses, every time.** Don't skip Wellbeing & Connection when the team is performing well — high performance without care leads to burnout. Don't skip Development & Performance when someone is struggling — care without growth isn't enough.
+- **Goals are the anchor for growth.** The most actionable Development & Performance insight is usually about development goals — are they current? Is there visible progress?
+- **Connection is the anchor for care.** The most actionable Wellbeing & Connection insight is usually about belonging — does this person feel seen, celebrated, and connected?
+- **Don't run too frequently.** Weekly or biweekly is ideal. Daily health checks would over-index on noise.

--- a/plugins/people-management/skills/team-health/references/output-template.md
+++ b/plugins/people-management/skills/team-health/references/output-template.md
@@ -1,0 +1,62 @@
+# Team Health Check — [Date]
+Team: [N] direct reports | Period: last 14 days
+
+## 🌟 Highlight
+[1-2 sentences on the most notable positive observation — a win to celebrate, growth to recognise, or care to acknowledge]
+
+## Per-Person Summary
+| Name | Activity | Energy | Last 1:1 | Goals | Flags |
+|------|----------|--------|----------|-------|-------|
+| [name] | ✅ Normal | ✅ Balanced | Mar 10 | Current | — |
+| [name] | ⬆️ High | ⚠️ Late nights | Mar 8 | Current | 🌟 Scope expansion, Check energy |
+| [name] | ⬇️ Low | ✅ Balanced | Feb 24 | Stale (8w) | ⚠️ Overdue 1:1, stale goals |
+
+## 🎯 Development & Performance
+
+### Development Goals
+- ✅ [N] team members have current goals
+- ⚠️ [Names] have goals last updated [date] — time for a refresh
+
+### Growth & Performance
+- 🌟 [Names] showing growth signals: [scope expansion, leadership, new skills]
+- ⚠️ [Names] showing decreased engagement — worth exploring
+
+### 1:1 Cadence
+- ✅ [N] team members are on cadence
+- ⚠️ [Names] are overdue — last 1:1 was [date]
+
+## Wellbeing & Connection
+
+### Energy & Wellbeing
+- ✅ [Names] appear balanced
+- ⚠️ [Names] showing signs of high load: [late messages, weekend activity, back-to-back calendars]
+- 💡 Consider: is anyone quietly burning out without flagging it?
+
+### Connection & Belonging
+- ✅ [Names] active in social/team channels
+- ⚠️ [Names] only visible in work contexts — may be fine, but worth a check-in
+- 💡 How connected does the team feel right now? Any new joiners who might need extra inclusion?
+
+### Celebration
+- 🎉 [Names] received recognition this period
+- ⚠️ [Names] haven't been recognised recently — consider acknowledging their work
+- 💡 Is the team celebrating enough? Wins, milestones, personal moments?
+
+## Suggested Actions
+Based on these signals:
+1. **[Name]** — [action, e.g., "Recognise their work on [project] in the team channel"] _(Wellbeing)_
+2. **[Name]** — [action, e.g., "Check in on energy levels — they've been online late 4 nights this week"] _(Wellbeing)_
+3. **[Name]** — [action, e.g., "Schedule a 1:1 to refresh development goals"] _(Development & Performance)_
+4. **[Name]** — [action, e.g., "Explore whether they're ready for more scope"] _(Development & Performance)_
+
+## Reflection Prompts
+**Development & Performance:**
+- Is the right person on the right challenge right now?
+- Who might be ready for more scope?
+- Are 1:1s happening consistently enough to keep development conversations alive?
+
+**Wellbeing & Connection:**
+- Who on my team might need me to just ask "how are you, really?"
+- Am I celebrating enough — not just big wins, but effort and progress?
+- Is anyone carrying too much quietly? What would I not see in Slack?
+- When was the last time we did something fun as a team?

--- a/plugins/people-management/skills/triage-messages/SKILL.md
+++ b/plugins/people-management/skills/triage-messages/SKILL.md
@@ -109,32 +109,7 @@ Sort everything into these buckets:
 
 ### 6. Present the Triage
 
-```markdown
-# Message Triage — [Date], [Time Window]
-
-## 🔴 Needs Your Decision ([count])
-| Priority | From | Channel/Subject | Summary | Link |
-|----------|------|-----------------|---------|------|
-| 1 | [name] | #[channel] | [1-line summary — what they need from you] | [link] |
-
-## 🟡 Team Member Needs ([count])
-| From | Channel/Subject | Summary | Link |
-|------|-----------------|---------|------|
-| [name] | #[channel] | [1-line summary] | [link] |
-
-## 🟢 Customer-Related ([count])
-| Account | From | Summary | Link |
-|---------|------|---------|------|
-| [customer] | [name] | [1-line summary] | [link] |
-
-## 🔵 FYI / Context ([count])
-| From | Channel/Subject | Summary | Link |
-|------|-----------------|---------|------|
-| [name] | #[channel] | [1-line summary] | [link] |
-
----
-📊 Total: [N] items ([X] decisions, [Y] team needs, [Z] customer, [W] FYI)
-```
+Read `references/output-template.md` for the full output template structure.
 
 ### 7. Offer Follow-Up
 

--- a/plugins/people-management/skills/triage-messages/SKILL.md
+++ b/plugins/people-management/skills/triage-messages/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: triage-messages
+description: Batch-processes Slack messages and emails to surface what needs the manager's attention, categorised by urgency and type. Designed for batch-responder managers who do Slack sweeps rather than staying in reactive mode. Supports effective communication and responsiveness. Never drafts replies — only surfaces and prioritises.
+---
+
+# Triage Messages
+
+> **Principle: "You are responsible."** This skill surfaces and categorises. The manager decides what to act on and how.
+
+Scans unread Slack messages and recent emails, categorises them by urgency and type, and presents a prioritised overview.
+
+## When to Use
+
+- Morning routine — catch up on what happened overnight
+- After a block of focus time or meetings
+- When the manager says "what did I miss?", "catch me up", "triage my messages"
+- Can be scoped to a time window: "triage since yesterday", "triage last 2 hours"
+
+## Instructions
+
+If any MCP connector is unavailable, follow the connector unavailability protocol in `../../references/operating-principles.md`.
+
+### 1. Determine Time Window
+
+Default: since the manager's last likely check-in (use calendar to estimate — if they were in back-to-back meetings for 3 hours, scan those 3 hours).
+
+If specified: use the provided time window.
+
+If unclear, ask:
+```
+What time period should I triage? Options:
+- Since this morning
+- Last [N] hours
+- Since yesterday
+- Custom range
+```
+
+### 2. Load Manager Context
+
+Read from `manager-context/` (if available):
+- `manager-profile.md` — to know who the direct reports are (their messages get higher priority)
+- `terminology.md` — to decode internal shorthand in messages
+- `team/` — to understand team members' projects and responsibilities
+- `sources.md` — to know which customer/project channels to monitor
+
+### 3. Scan Slack
+
+Search for messages in the time window:
+
+**Priority channels** (scan first):
+- Channels where the manager was @-mentioned
+- DMs to the manager
+- Team channels (from manager-context)
+- Customer/project channels (from manager-context)
+
+**Broader channels** (scan for relevance):
+- Company-wide channels
+- Cross-functional channels the manager is in
+
+For each message/thread, capture:
+- Who sent it
+- Channel
+- Content summary (1 line)
+- Whether the manager was mentioned or it's in a direct thread
+- Link to the message
+
+### 4. Scan Email
+
+Search Gmail for messages in the time window:
+
+- Unread emails
+- Emails where the manager is in To: (not just CC:)
+- Emails from direct reports or known stakeholders
+- Emails with urgent/action keywords
+
+For each email, capture:
+- Sender
+- Subject
+- Brief summary
+- Whether it requires action or is FYI
+
+### 5. Categorise
+
+Sort everything into these buckets:
+
+**🔴 Needs Your Decision**
+- Blockers waiting on the manager
+- Approval requests
+- Escalations
+- Time-sensitive decisions
+- Criteria: someone is explicitly waiting for the manager's input
+
+**🟡 Team Member Needs**
+- Questions from direct reports
+- Requests for help or guidance
+- Friction signals (repeated blockers, frustration)
+- Criteria: a team member needs support but isn't fully blocked
+
+**🔵 FYI / Context**
+- Status updates
+- Announcements
+- Cross-functional threads where the manager should be aware
+- Criteria: useful to know, no action needed right now
+
+**🟢 Customer-Related** (if applicable)
+- Messages in customer/project channels
+- Customer-related emails
+- Delivery updates, escalations, timeline changes
+
+### 6. Present the Triage
+
+```markdown
+# Message Triage — [Date], [Time Window]
+
+## 🔴 Needs Your Decision ([count])
+| Priority | From | Channel/Subject | Summary | Link |
+|----------|------|-----------------|---------|------|
+| 1 | [name] | #[channel] | [1-line summary — what they need from you] | [link] |
+
+## 🟡 Team Member Needs ([count])
+| From | Channel/Subject | Summary | Link |
+|------|-----------------|---------|------|
+| [name] | #[channel] | [1-line summary] | [link] |
+
+## 🟢 Customer-Related ([count])
+| Account | From | Summary | Link |
+|---------|------|---------|------|
+| [customer] | [name] | [1-line summary] | [link] |
+
+## 🔵 FYI / Context ([count])
+| From | Channel/Subject | Summary | Link |
+|------|-----------------|---------|------|
+| [name] | #[channel] | [1-line summary] | [link] |
+
+---
+📊 Total: [N] items ([X] decisions, [Y] team needs, [Z] customer, [W] FYI)
+```
+
+### 7. Offer Follow-Up
+
+```
+That's your triage for [time window]. Want me to:
+- Dig deeper on any specific item?
+- Prep context for responding to something?
+- Run /plan-priorities to fold these into your day?
+```
+
+## Important Notes
+
+Read `../../references/operating-principles.md` for shared operating principles (data scope, DM flagging, signals vs diagnoses, connector unavailability).
+
+Additional notes specific to this skill:
+- **Never draft replies.** The manager writes their own messages. This skill only surfaces and categorises.
+- **Don't over-categorise as urgent.** Reserve the red category for genuine blockers. Most things are FYI.
+- **Link everything.** Every item should link directly to the source message/email.
+- **Decode shorthand.** Use terminology.md to translate internal terms so the triage is immediately clear.
+- **If volume is high** (50+ messages), summarise the FYI bucket rather than listing every item.

--- a/plugins/people-management/skills/triage-messages/references/output-template.md
+++ b/plugins/people-management/skills/triage-messages/references/output-template.md
@@ -1,0 +1,24 @@
+# Message Triage — [Date], [Time Window]
+
+## 🔴 Needs Your Decision ([count])
+| Priority | From | Channel/Subject | Summary | Link |
+|----------|------|-----------------|---------|------|
+| 1 | [name] | #[channel] | [1-line summary — what they need from you] | [link] |
+
+## 🟡 Team Member Needs ([count])
+| From | Channel/Subject | Summary | Link |
+|------|-----------------|---------|------|
+| [name] | #[channel] | [1-line summary] | [link] |
+
+## 🟢 Customer-Related ([count])
+| Account | From | Summary | Link |
+|---------|------|---------|------|
+| [customer] | [name] | [1-line summary] | [link] |
+
+## 🔵 FYI / Context ([count])
+| From | Channel/Subject | Summary | Link |
+|------|-----------------|---------|------|
+| [name] | #[channel] | [1-line summary] | [link] |
+
+---
+📊 Total: [N] items ([X] decisions, [Y] team needs, [Z] customer, [W] FYI)


### PR DESCRIPTION
## Summary
- Add the people-management plugin: AI-augmented management tooling with 8 skills (setup, meeting prep, 1:1 prep, triage, priority planner, team health, performance cycle, customer status)
- Fully generic and open-source ready: configurable org values, generic performance framework (Impact + Growth), no company-specific branding
- Uses MCP connectors (Slack, Notion, Gmail, Drive, Calendar) as data sources

## Skills
| Skill | Purpose |
|-------|---------|
| Setup | Interactive onboarding — discovers team, terminology, goals, values |
| Meeting Prep | Pre-meeting briefing from all connected sources |
| 1:1 Prep | Deep-dive preparation anchored in performance framework |
| Triage Messages | Batch-processes Slack/email by urgency |
| Priority Planner | Highest-leverage actions with OKR alignment |
| Team Health | Periodic check on development and wellbeing |
| Performance Cycle | Evidence gathering for review cycles |
| Customer Status | Account health dashboard |

## Test plan
- [ ] Install plugin and verify all 8 skills are listed
- [ ] Run /setup and confirm interactive onboarding flow
- [ ] Verify no company-specific branding in any output
- [ ] Confirm all reference file paths resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)