### PR TITLE
Fix invalid hooks format in content-studio setup

### DIFF
--- a/plugins/content-studio/skills/setup-content-studio/references/repo-setup.md
+++ b/plugins/content-studio/skills/setup-content-studio/references/repo-setup.md
@@ -77,8 +77,13 @@ Create `.claude/settings.json`:
   "hooks": {
     "SessionStart": [
       {
-        "type": "command",
-        "command": "bash .claude/hooks/ensure-content-studio.sh"
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/ensure-content-studio.sh"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Summary
- Fixed the Claude Code hooks JSON format in `repo-setup.md` section 6d
- The old format put `type` and `command` directly in the `SessionStart` array, but Claude Code requires a `matcher` + `hooks` array structure
- No other files in the repo had the same invalid pattern

## Test plan
- [ ] Verify the JSON in section 6d of `repo-setup.md` matches the Claude Code hooks schema
- [ ] Confirm Claude Code accepts a `settings.json` using this format without validation errors

Fixes #11

Generated with [Claude Code](https://claude.com/claude-code)