### PR TITLE
Add missing /api/content route files

### DIFF
--- a/plugins/content-studio/.gitignore
+++ b/plugins/content-studio/.gitignore
@@ -32,4 +32,6 @@ working/
 temp/
 
 # Content (user-generated, not part of plugin)
-content/
+# Use /content/ (anchored) so it only matches the root content/ dir,
+# not nested paths like content-studio/app/api/content/
+/content/

--- a/plugins/content-studio/content-studio/app/api/content/[type]/[slug]/delete/route.ts
+++ b/plugins/content-studio/content-studio/app/api/content/[type]/[slug]/delete/route.ts
@@ -1,0 +1,37 @@
+// DELETE /api/content/[type]/[slug]/delete - Delete content and its images
+
+import { NextRequest, NextResponse } from 'next/server';
+import { deleteContent, isValidContentType } from '@/lib/content';
+import { ContentType } from '@/types/content';
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ type: string; slug: string }> }
+) {
+  try {
+    const { type, slug } = await params;
+
+    if (!isValidContentType(type)) {
+      return NextResponse.json(
+        { success: false, error: `Invalid content type: ${type}` },
+        { status: 400 }
+      );
+    }
+
+    await deleteContent(type as ContentType, slug);
+
+    return NextResponse.json({
+      success: true,
+      data: {
+        slug,
+        deleted: true
+      }
+    });
+  } catch (error) {
+    console.error('Error deleting content:', error);
+    return NextResponse.json(
+      { success: false, error: 'Failed to delete content' },
+      { status: 500 }
+    );
+  }
+}

--- a/plugins/content-studio/content-studio/app/api/content/[type]/[slug]/duplicate/route.ts
+++ b/plugins/content-studio/content-studio/app/api/content/[type]/[slug]/duplicate/route.ts
@@ -1,0 +1,114 @@
+// POST /api/content/[type]/[slug]/duplicate - Duplicate content
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getContentByType, createContent, isValidContentType } from '@/lib/content';
+import { ContentType, ContentMetadata, ContentImage } from '@/types/content';
+import { generateTimestampSlug } from '@/lib/slug';
+import fs from 'fs/promises';
+import path from 'path';
+import { CONTENT_DIR } from '@/lib/paths';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ type: string; slug: string }> }
+) {
+  try {
+    const { type, slug } = await params;
+
+    if (!isValidContentType(type)) {
+      return NextResponse.json(
+        { success: false, error: `Invalid content type: ${type}` },
+        { status: 400 }
+      );
+    }
+
+    // Get the original content
+    const original = await getContentByType(type as ContentType, slug);
+
+    if (!original) {
+      return NextResponse.json(
+        { success: false, error: 'Content not found' },
+        { status: 404 }
+      );
+    }
+
+    // Generate new timestamp-based slug
+    const now = new Date();
+    const newSlug = generateTimestampSlug(now);
+
+    // Copy images if they exist
+    let newImages: ContentImage[] | undefined = undefined;
+    if (original.metadata.images && original.metadata.images.length > 0) {
+      const oldImagesDir = path.join(CONTENT_DIR, 'images', slug);
+      const newImagesDir = path.join(CONTENT_DIR, 'images', newSlug);
+
+      try {
+        // Check if source images folder exists
+        await fs.access(oldImagesDir);
+
+        // Create new images directory
+        await fs.mkdir(newImagesDir, { recursive: true });
+
+        // Copy each image file
+        newImages = [];
+        for (const image of original.metadata.images) {
+          const srcPath = path.join(oldImagesDir, image.filename);
+          const destPath = path.join(newImagesDir, image.filename);
+
+          try {
+            await fs.copyFile(srcPath, destPath);
+            newImages.push({
+              ...image,
+              path: `images/${newSlug}/${image.filename}`
+            });
+          } catch (copyError) {
+            console.error(`Failed to copy image ${image.filename}:`, copyError);
+          }
+        }
+      } catch {
+        // Images directory doesn't exist, skip copying
+        console.log('No images directory found for original content');
+      }
+    }
+
+    // Create new metadata with modifications (use full ISO timestamps)
+    const nowISO = now.toISOString();
+    const newMetadata: ContentMetadata = {
+      ...original.metadata,
+      title: `Copy of ${original.metadata.title}`,
+      slug: newSlug,
+      stage: '01-ideas',
+      status: 'concept',
+      created: nowISO,
+      lastUpdated: nowISO,
+      feedbackLog: [], // Reset feedback log for the copy
+      images: newImages, // Use copied images with new paths
+      // Clear published-specific fields
+      publishedDate: undefined,
+      finalVersion: undefined,
+      channel: undefined,
+      url: undefined,
+      engagement: undefined,
+      notes: undefined
+    };
+
+    // Create the duplicate content (keep same type)
+    const filename = await createContent(type as ContentType, newMetadata, original.content);
+
+    return NextResponse.json({
+      success: true,
+      data: {
+        filename,
+        stage: '01-ideas',
+        slug: newSlug,
+        type
+      }
+    });
+  } catch (error) {
+    console.error('Error duplicating content:', error);
+    return NextResponse.json(
+      { success: false, error: 'Failed to duplicate content' },
+      { status: 500 }
+    );
+  }
+}

--- a/plugins/content-studio/content-studio/app/api/content/[type]/[slug]/export/route.ts
+++ b/plugins/content-studio/content-studio/app/api/content/[type]/[slug]/export/route.ts
@@ -1,0 +1,302 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getContentByType, isValidContentType } from '@/lib/content';
+import { ContentType } from '@/types/content';
+import puppeteer from 'puppeteer';
+import { readFile } from 'fs/promises';
+import path from 'path';
+import { marked } from 'marked';
+import { CONTENT_DIR, isPathWithin } from '@/lib/paths';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ type: string; slug: string }> }
+) {
+  try {
+    const { type, slug } = await params;
+
+    if (!isValidContentType(type)) {
+      return NextResponse.json(
+        { success: false, error: `Invalid content type: ${type}` },
+        { status: 400 }
+      );
+    }
+
+    const content = await getContentByType(type as ContentType, slug);
+
+    if (!content) {
+      return NextResponse.json(
+        { success: false, error: 'Content not found' },
+        { status: 404 }
+      );
+    }
+
+    // Convert images to base64
+    const imageData: Record<string, string> = {};
+    if (content.metadata.images) {
+      for (const img of content.metadata.images) {
+        try {
+          const imgPath = path.join(CONTENT_DIR, img.path);
+          if (!isPathWithin(imgPath, CONTENT_DIR)) continue;
+          const buffer = await readFile(imgPath);
+          const ext = path.extname(img.filename).slice(1).toLowerCase();
+          const mimeType = ext === 'png' ? 'image/png' : ext === 'gif' ? 'image/gif' : 'image/jpeg';
+          imageData[img.filename] = `data:${mimeType};base64,${buffer.toString('base64')}`;
+        } catch {
+          // Skip missing images
+        }
+      }
+    }
+
+    // Parse markdown to HTML
+    const contentHtml = await marked(content.content || '');
+
+    // Build HTML document
+    const html = `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>${content.metadata.title || 'Untitled'}</title>
+  <style>
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      font-size: 14px;
+      line-height: 1.6;
+      color: #1a1a1a;
+      padding: 40px;
+      max-width: 800px;
+      margin: 0 auto;
+    }
+
+    .header {
+      border-bottom: 2px solid #e5e5e5;
+      padding-bottom: 20px;
+      margin-bottom: 30px;
+    }
+
+    .stage-badge {
+      display: inline-block;
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      padding: 4px 10px;
+      border-radius: 4px;
+      background: ${content.metadata.stage === '03-published' ? '#dcfce7' : content.metadata.stage === '02-drafts' ? '#fef3c7' : '#ede9fe'};
+      color: ${content.metadata.stage === '03-published' ? '#166534' : content.metadata.stage === '02-drafts' ? '#92400e' : '#5b21b6'};
+      margin-bottom: 12px;
+    }
+
+    .title {
+      font-family: Georgia, 'Times New Roman', serif;
+      font-size: 28px;
+      font-weight: 600;
+      line-height: 1.3;
+      margin-bottom: 16px;
+    }
+
+    .core-insight {
+      font-size: 16px;
+      color: #4a4a4a;
+      font-style: italic;
+      padding: 16px;
+      background: #f9f9f9;
+      border-left: 3px solid #0066cc;
+      margin-bottom: 16px;
+    }
+
+    .meta {
+      font-size: 12px;
+      color: #666;
+    }
+
+    .meta span {
+      margin-right: 16px;
+    }
+
+    .tags {
+      margin-top: 8px;
+    }
+
+    .tag {
+      display: inline-block;
+      font-size: 11px;
+      padding: 2px 8px;
+      background: #f0f0f0;
+      border-radius: 3px;
+      margin-right: 6px;
+      color: #555;
+    }
+
+    .content {
+      margin-top: 30px;
+    }
+
+    .content p {
+      margin-bottom: 16px;
+    }
+
+    .content h1, .content h2, .content h3 {
+      font-family: Georgia, 'Times New Roman', serif;
+      margin-top: 24px;
+      margin-bottom: 12px;
+    }
+
+    .content h1 { font-size: 24px; }
+    .content h2 { font-size: 20px; }
+    .content h3 { font-size: 16px; }
+
+    .content ul, .content ol {
+      margin-bottom: 16px;
+      padding-left: 24px;
+    }
+
+    .content li {
+      margin-bottom: 8px;
+    }
+
+    .content strong {
+      font-weight: 600;
+    }
+
+    .content blockquote {
+      margin: 16px 0;
+      padding: 12px 20px;
+      border-left: 3px solid #ddd;
+      color: #555;
+      font-style: italic;
+    }
+
+    .content code {
+      font-family: 'SF Mono', Monaco, monospace;
+      font-size: 13px;
+      background: #f5f5f5;
+      padding: 2px 6px;
+      border-radius: 3px;
+    }
+
+    .images {
+      margin-top: 30px;
+      border-top: 1px solid #e5e5e5;
+      padding-top: 20px;
+    }
+
+    .images-title {
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: #666;
+      margin-bottom: 16px;
+    }
+
+    .image-grid {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 16px;
+    }
+
+    .image-item img {
+      width: 100%;
+      height: auto;
+      border-radius: 4px;
+      border: 1px solid #e5e5e5;
+    }
+
+    .footer {
+      margin-top: 40px;
+      padding-top: 20px;
+      border-top: 1px solid #e5e5e5;
+      font-size: 11px;
+      color: #999;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <div class="stage-badge">${content.metadata.stage.replace(/^\d+-/, '')}</div>
+    <h1 class="title">${content.metadata.title || 'Untitled'}</h1>
+    ${content.metadata.coreInsight ? `<div class="core-insight">${content.metadata.coreInsight}</div>` : ''}
+    <div class="meta">
+      <span><strong>Type:</strong> ${content.metadata.type}</span>
+      <span><strong>Created:</strong> ${new Date(content.metadata.created).toLocaleDateString()}</span>
+      <span><strong>Updated:</strong> ${new Date(content.metadata.lastUpdated).toLocaleDateString()}</span>
+    </div>
+    ${content.metadata.tags && content.metadata.tags.length > 0 ? `
+    <div class="tags">
+      ${content.metadata.tags.map(tag => `<span class="tag">${tag}</span>`).join('')}
+    </div>
+    ` : ''}
+  </div>
+
+  <div class="content">
+    ${contentHtml}
+  </div>
+
+  ${content.metadata.images && content.metadata.images.length > 0 ? `
+  <div class="images">
+    <div class="images-title">Attached Images</div>
+    <div class="image-grid">
+      ${content.metadata.images.map(img => `
+        <div class="image-item">
+          <img src="${imageData[img.filename] || ''}" alt="${img.alt || img.filename}" />
+        </div>
+      `).join('')}
+    </div>
+  </div>
+  ` : ''}
+
+  <div class="footer">
+    Exported from Content Studio on ${new Date().toLocaleDateString()} at ${new Date().toLocaleTimeString()}
+  </div>
+</body>
+</html>
+    `;
+
+    // Launch Puppeteer and generate PDF
+    const browser = await puppeteer.launch({
+      headless: true,
+      args: ['--no-sandbox', '--disable-setuid-sandbox']
+    });
+
+    const page = await browser.newPage();
+    await page.setContent(html, { waitUntil: 'networkidle0' });
+
+    const pdf = await page.pdf({
+      format: 'A4',
+      printBackground: true,
+      margin: {
+        top: '20mm',
+        right: '20mm',
+        bottom: '20mm',
+        left: '20mm'
+      }
+    });
+
+    await browser.close();
+
+    // Return PDF
+    const filename = `${slug}-${content.metadata.stage.replace(/^\d+-/, '')}.pdf`;
+
+    return new NextResponse(Buffer.from(pdf), {
+      headers: {
+        'Content-Type': 'application/pdf',
+        'Content-Disposition': `attachment; filename="${filename}"`
+      }
+    });
+
+  } catch (error) {
+    console.error('Error exporting PDF:', error);
+    return NextResponse.json(
+      { success: false, error: 'Failed to export PDF' },
+      { status: 500 }
+    );
+  }
+}

--- a/plugins/content-studio/content-studio/app/api/content/[type]/[slug]/move/route.ts
+++ b/plugins/content-studio/content-studio/app/api/content/[type]/[slug]/move/route.ts
@@ -1,0 +1,71 @@
+// POST /api/content/[type]/[slug]/move - Move content to a different stage
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getContentByType, moveContent, isValidContentType } from '@/lib/content';
+import { ContentStage, ContentType } from '@/types/content';
+
+const VALID_STAGES: ContentStage[] = ['01-ideas', '02-drafts', '03-published'];
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ type: string; slug: string }> }
+) {
+  try {
+    const { type, slug } = await params;
+    const body = await request.json();
+    const { targetStage } = body;
+
+    if (!isValidContentType(type)) {
+      return NextResponse.json(
+        { success: false, error: `Invalid content type: ${type}` },
+        { status: 400 }
+      );
+    }
+
+    // Validate target stage
+    if (!targetStage || !VALID_STAGES.includes(targetStage as ContentStage)) {
+      return NextResponse.json(
+        { success: false, error: 'Invalid target stage' },
+        { status: 400 }
+      );
+    }
+
+    // Get the content to verify it exists and get current stage
+    const content = await getContentByType(type as ContentType, slug);
+
+    if (!content) {
+      return NextResponse.json(
+        { success: false, error: 'Content not found' },
+        { status: 404 }
+      );
+    }
+
+    // Don't allow moving to the same stage
+    if (content.metadata.stage === targetStage) {
+      return NextResponse.json(
+        { success: false, error: 'Content is already in this stage' },
+        { status: 400 }
+      );
+    }
+
+    const previousStage = content.metadata.stage;
+
+    // Move the content to the new stage
+    await moveContent(type as ContentType, slug, targetStage as ContentStage);
+
+    return NextResponse.json({
+      success: true,
+      data: {
+        slug,
+        previousStage,
+        newStage: targetStage
+      }
+    });
+  } catch (error) {
+    console.error('Error moving content:', error);
+    return NextResponse.json(
+      { success: false, error: 'Failed to move content' },
+      { status: 500 }
+    );
+  }
+}

--- a/plugins/content-studio/content-studio/app/api/content/[type]/[slug]/route.ts
+++ b/plugins/content-studio/content-studio/app/api/content/[type]/[slug]/route.ts
@@ -1,0 +1,93 @@
+// GET /api/content/[type]/[slug] - Get specific content
+// PUT /api/content/[type]/[slug] - Update content
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getContentByType, saveContent, getSuggestions, isValidContentType } from '@/lib/content';
+import { ContentType, ContentMetadata } from '@/types/content';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ type: string; slug: string }> }
+) {
+  try {
+    const { type, slug } = await params;
+
+    if (!isValidContentType(type)) {
+      return NextResponse.json(
+        { success: false, error: `Invalid content type: ${type}` },
+        { status: 400 }
+      );
+    }
+
+    const content = await getContentByType(type as ContentType, slug);
+
+    if (!content) {
+      return NextResponse.json(
+        { success: false, error: 'Content not found' },
+        { status: 404 }
+      );
+    }
+
+    // Also fetch suggestions if they exist
+    const suggestions = await getSuggestions(type as ContentType, slug);
+
+    return NextResponse.json({
+      success: true,
+      data: { ...content, suggestions }
+    });
+  } catch (error) {
+    console.error('Error fetching content:', error);
+    return NextResponse.json(
+      { success: false, error: 'Failed to fetch content' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ type: string; slug: string }> }
+) {
+  try {
+    const { type, slug } = await params;
+
+    if (!isValidContentType(type)) {
+      return NextResponse.json(
+        { success: false, error: `Invalid content type: ${type}` },
+        { status: 400 }
+      );
+    }
+
+    const body = await request.json();
+    const { metadata, content } = body;
+
+    const existing = await getContentByType(type as ContentType, slug);
+
+    if (!existing) {
+      return NextResponse.json(
+        { success: false, error: 'Content not found' },
+        { status: 404 }
+      );
+    }
+
+    const result = await saveContent(
+      type as ContentType,
+      slug,
+      metadata as ContentMetadata,
+      content,
+      existing.path
+    );
+
+    return NextResponse.json({
+      success: true,
+      lastUpdated: result.lastUpdated,
+      newPath: result.newPath
+    });
+  } catch (error) {
+    console.error('Error updating content:', error);
+    return NextResponse.json(
+      { success: false, error: 'Failed to update content' },
+      { status: 500 }
+    );
+  }
+}

--- a/plugins/content-studio/content-studio/app/api/content/[type]/[slug]/suggestions/route.ts
+++ b/plugins/content-studio/content-studio/app/api/content/[type]/[slug]/suggestions/route.ts
@@ -1,0 +1,67 @@
+// GET /api/content/[type]/[slug]/suggestions - Get suggestions
+// PUT /api/content/[type]/[slug]/suggestions - Update suggestions
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getSuggestions, saveSuggestions, isValidContentType } from '@/lib/content';
+import { ContentType, SuggestionFile } from '@/types/content';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ type: string; slug: string }> }
+) {
+  try {
+    const { type, slug } = await params;
+
+    if (!isValidContentType(type)) {
+      return NextResponse.json(
+        { success: false, error: `Invalid content type: ${type}` },
+        { status: 400 }
+      );
+    }
+
+    const suggestions = await getSuggestions(type as ContentType, slug);
+
+    if (!suggestions) {
+      return NextResponse.json(
+        { success: false, error: 'No suggestions found' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({ success: true, data: suggestions });
+  } catch (error) {
+    console.error('Error fetching suggestions:', error);
+    return NextResponse.json(
+      { success: false, error: 'Failed to fetch suggestions' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ type: string; slug: string }> }
+) {
+  try {
+    const { type, slug } = await params;
+
+    if (!isValidContentType(type)) {
+      return NextResponse.json(
+        { success: false, error: `Invalid content type: ${type}` },
+        { status: 400 }
+      );
+    }
+
+    const body = await request.json();
+
+    await saveSuggestions(type as ContentType, slug, body as SuggestionFile);
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error updating suggestions:', error);
+    return NextResponse.json(
+      { success: false, error: 'Failed to update suggestions' },
+      { status: 500 }
+    );
+  }
+}

--- a/plugins/content-studio/content-studio/app/api/content/route.ts
+++ b/plugins/content-studio/content-studio/app/api/content/route.ts
@@ -1,0 +1,58 @@
+// GET /api/content - Get all content across stages
+// POST /api/content - Create new content
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getAllContent, createContent, isValidContentType } from '@/lib/content';
+import { ContentMetadata, ContentType } from '@/types/content';
+import { generateTimestampSlug } from '@/lib/slug';
+
+export async function GET() {
+  try {
+    const content = await getAllContent();
+    return NextResponse.json({ success: true, data: content });
+  } catch (error) {
+    console.error('Error fetching content:', error);
+    return NextResponse.json(
+      { success: false, error: 'Failed to fetch content' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { stage, metadata, content } = body;
+
+    const now = new Date().toISOString();
+
+    // Ensure slug and timestamps are set server-side if not provided
+    const fullMetadata: ContentMetadata = {
+      ...metadata,
+      slug: metadata.slug || generateTimestampSlug(),
+      created: metadata.created || now,
+      lastUpdated: now
+    };
+
+    // Validate content type
+    if (!isValidContentType(fullMetadata.type)) {
+      return NextResponse.json(
+        { success: false, error: `Invalid content type: ${fullMetadata.type}` },
+        { status: 400 }
+      );
+    }
+
+    const filename = await createContent(fullMetadata.type as ContentType, fullMetadata, content || '');
+
+    return NextResponse.json({
+      success: true,
+      data: { filename, stage, slug: fullMetadata.slug, type: fullMetadata.type }
+    });
+  } catch (error) {
+    console.error('Error creating content:', error);
+    return NextResponse.json(
+      { success: false, error: 'Failed to create content' },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Adds 7 untracked API route files under `plugins/content-studio/content-studio/app/api/content/` that were never committed
- These routes connect the frontend Dashboard to `lib/content.ts` and provide CRUD, move, duplicate, export, and suggestions endpoints
- Without them, all `/api/content` calls returned 404, making the Dashboard unusable

## Notes
- Files were force-added because the `content/` gitignore rule (meant for user-generated content directories) was also matching `app/api/content/`. Once tracked, git will continue tracking them correctly.
- All 18 existing tests pass. Pre-existing TS errors in test files are unrelated.

Fixes #10

## Test plan
- [ ] Verify `npm run build` succeeds in `plugins/content-studio/content-studio/`
- [ ] Confirm Dashboard can list, create, read, update, delete, move, duplicate, and export content
- [ ] Verify suggestions endpoint returns and accepts AI suggestions

Generated with [Claude Code](https://claude.com/claude-code)