### PR TITLE
Release v1.3.0: techwolf-brand-kit plugin + fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog and this project follows Semantic Versioning.
 
+## [1.3.0] - 2026-04-10
+
+### Added
+
+- `techwolf-brand-kit` plugin with TechWolf logo skill providing 4 variants (dark, white, mono-dark, mono-white) in SVG and PNG formats.
+
+### Changed
+
+- Renamed `brand-kit` plugin to `techwolf-brand-kit` for consistency.
+
+### Fixed
+
+- Invalid hooks format in content-studio setup instructions.
+- Missing `/api/content` route files in content-studio.
+
 ## [1.2.0] - 2026-03-24
 
 ### Added


### PR DESCRIPTION
## Summary

- Adds v1.3.0 changelog entry covering all changes since v1.2.0:
  - New `techwolf-brand-kit` plugin with logo skill (4 variants, SVG + PNG)
  - Renamed `brand-kit` to `techwolf-brand-kit`
  - Fixed invalid hooks format in content-studio setup
  - Fixed missing `/api/content` route files in content-studio

## After merge

- Tag `v1.3.0` on the merge commit
- Create GitHub Release for v1.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)