### PR TITLE
Replace double dashes with proper punctuation repo-wide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 
 ### Added
 
-- `people-management` plugin -- AI-augmented management tooling for people managers.
+- `people-management` plugin: AI-augmented management tooling for people managers.
   - 8 skills: setup, meeting-prep, one-on-one-prep, triage-messages, customer-status, priority-planner, team-health, performance-cycle.
   - 10-phase interactive setup that discovers team structure, performance frameworks, values, and ways of working.
   - Framework-agnostic: adapts to any org's performance dimensions, rating scale, management competencies, and values.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,10 +10,10 @@ Thanks for your interest in contributing to the TechWolf AI-First Toolkit!
 
 ## What You Can Contribute
 
-- **New skills** -- Add skills to existing plugins or propose new plugins
-- **Bug fixes** -- Fix issues in existing skills, scripts, or docs
-- **Documentation** -- Improve READMEs, add examples, fix typos
-- **Ideas** -- Open an issue to discuss new plugins or improvements
+- **New skills**: Add skills to existing plugins or propose new plugins
+- **Bug fixes**: Fix issues in existing skills, scripts, or docs
+- **Documentation**: Improve READMEs, add examples, fix typos
+- **Ideas**: Open an issue to discuss new plugins or improvements
 
 ## Project Structure
 
@@ -37,7 +37,7 @@ plugins/
 
 ## Submitting Changes
 
-1. Keep PRs focused -- one feature or fix per PR
+1. Keep PRs focused: one feature or fix per PR
 2. Update relevant READMEs if your change affects usage
 3. Test your skills with Claude Code (and Codex via `./install.sh` if possible)
 4. Open a PR against `main` with a clear description of what and why

--- a/README.md
+++ b/README.md
@@ -8,37 +8,37 @@ Open-source Claude Code skills and Codex skills from [TechWolf](https://techwolf
 
 ## What's inside
 
-### ai-firstify -- AI-First Skill
+### ai-firstify: AI-First Skill
 
 Audit, re-engineer, or bootstrap any codebase to align with 9 AI-first design principles and 7 design patterns. Three modes:
 
-- **Audit** -- deep analysis across 7 dimensions with a scored report
-- **Re-engineer** -- actively restructures your project to be AI-first
-- **Bootstrap** -- guides new project setup with discovery questions
+- **Audit**: deep analysis across 7 dimensions with a scored report
+- **Re-engineer**: actively restructures your project to be AI-first
+- **Bootstrap**: guides new project setup with discovery questions
 
-### content-studio -- Thought Leadership Pipeline
+### content-studio: Thought Leadership Pipeline
 
 Full content pipeline for LinkedIn posts, blog posts, and opinion pieces. Includes 8 specialized skills, a visual Kanban editor, and hooks that auto-start the companion app.
 
-- **Write** -- LinkedIn posts, blog posts, opinion pieces with voice-matched style
-- **Brainstorm** -- generate ideas from URLs, files, or recent posts
-- **Analyze** -- engagement pattern analysis across published content
-- **Setup** -- interactive onboarding that learns your voice and creates a personalized content repo
+- **Write**: LinkedIn posts, blog posts, opinion pieces with voice-matched style
+- **Brainstorm**: generate ideas from URLs, files, or recent posts
+- **Analyze**: engagement pattern analysis across published content
+- **Setup**: interactive onboarding that learns your voice and creates a personalized content repo
 
-### people-management -- AI-Augmented Management
+### people-management: AI-Augmented Management
 
-AI-augmented tooling for people managers. Surfaces the right context at the right time -- before meetings, during 1:1 prep, when triaging messages, or reviewing performance. Adapts to any org's frameworks and values.
+AI-augmented tooling for people managers. Surfaces the right context at the right time, before meetings, during 1:1 prep, when triaging messages, or reviewing performance. Adapts to any org's frameworks and values.
 
-- **Setup** -- interactive onboarding (10 phases) that discovers your team, frameworks, values, and ways of working
-- **8 skills** -- meeting prep, 1:1 prep, triage, customer status, priority planner, team health, performance cycle
-- **Framework-agnostic** -- configures to your org's performance dimensions, rating scale, management competencies, and values
+- **Setup**: interactive onboarding (10 phases) that discovers your team, frameworks, values, and ways of working
+- **8 skills**: meeting prep, 1:1 prep, triage, customer status, priority planner, team health, performance cycle
+- **Framework-agnostic**: configures to your org's performance dimensions, rating scale, management competencies, and values
 
-### techwolf-brand-kit -- Brand Assets
+### techwolf-brand-kit: Brand Assets
 
 Official TechWolf brand assets for AI-generated outputs. Ensures agents use the correct logo files instead of guessing or approximating.
 
-- **TechWolf Logo** -- 4 variants (dark, white, mono-dark, mono-white) in SVG and PNG
-- **currentColor SVG** -- inline variant that inherits color from parent CSS for themed contexts
+- **TechWolf Logo**: 4 variants (dark, white, mono-dark, mono-white) in SVG and PNG
+- **currentColor SVG**: inline variant that inherits color from parent CSS for themed contexts
 
 ## Quick start
 
@@ -111,4 +111,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## License
 
-[MIT](LICENSE) -- see [CHANGELOG.md](CHANGELOG.md) for release history.
+[MIT](LICENSE). See [CHANGELOG.md](CHANGELOG.md) for release history.

--- a/plugins/ai-firstify/README.md
+++ b/plugins/ai-firstify/README.md
@@ -48,9 +48,9 @@ Or invoke directly:
 
 ## Modes
 
-1. **Audit** -- Read-only analysis across 7 dimensions with a scored report
-2. **Re-Engineer** -- Full audit followed by active fixes in 7 phases
-3. **Bootstrap** -- Interactive new project setup with discovery questions
+1. **Audit**: Read-only analysis across 7 dimensions with a scored report
+2. **Re-Engineer**: Full audit followed by active fixes in 7 phases
+3. **Bootstrap**: Interactive new project setup with discovery questions
 
 ## License
 

--- a/plugins/ai-firstify/skills/ai-firstify/SKILL.md
+++ b/plugins/ai-firstify/skills/ai-firstify/SKILL.md
@@ -28,7 +28,7 @@ Read **references/mode-reengineer.md** for the full re-engineering procedure.
 
 ## Mode 3: Bootstrap (New Project Setup)
 
-Guide the user through setting up a new AI-first project from scratch. Interactive -- ask discovery questions, recommend architecture, scaffold, and test.
+Guide the user through setting up a new AI-first project from scratch. Interactive: ask discovery questions, recommend architecture, scaffold, and test.
 
 Read **references/mode-bootstrap.md** for the full bootstrap procedure.
 
@@ -36,15 +36,15 @@ Read **references/mode-bootstrap.md** for the full bootstrap procedure.
 
 Domain knowledge (load on demand per dimension):
 
-- **references/principles.md** -- All 9 AI-first design principles in depth
-- **references/patterns.md** -- All 7 design patterns with implementation guidance
-- **references/anti-patterns.md** -- Common mistakes with detection patterns and fixes
-- **references/skill-architecture.md** -- How to structure skills, sub-agents, and workflows
-- **references/project-structure.md** -- Ideal project layouts, CLAUDE.md templates, .gitignore
-- **references/assessment-rubric.md** -- Scoring criteria and report template
+- **references/principles.md**: All 9 AI-first design principles in depth
+- **references/patterns.md**: All 7 design patterns with implementation guidance
+- **references/anti-patterns.md**: Common mistakes with detection patterns and fixes
+- **references/skill-architecture.md**: How to structure skills, sub-agents, and workflows
+- **references/project-structure.md**: Ideal project layouts, CLAUDE.md templates, .gitignore
+- **references/assessment-rubric.md**: Scoring criteria and report template
 
-Load the relevant reference file for the dimension you are currently analyzing. Do not load all references at once -- use progressive disclosure.
+Load the relevant reference file for the dimension you are currently analyzing. Do not load all references at once. Use progressive disclosure.
 
 ## Tools
 
-- **scripts/validate-report.sh** -- Validates that a generated assessment report has all required sections, dimensions, and scores
+- **scripts/validate-report.sh**: Validates that a generated assessment report has all required sections, dimensions, and scores

--- a/plugins/ai-firstify/skills/ai-firstify/references/assessment-rubric.md
+++ b/plugins/ai-firstify/skills/ai-firstify/references/assessment-rubric.md
@@ -249,10 +249,10 @@ git log --oneline --since="1 week ago" 2>/dev/null | wc -l
 
 ## Priority Recommendations
 
-1. **[HIGH]** [recommendation] -- [estimated effort]
-2. **[HIGH]** [recommendation] -- [estimated effort]
-3. **[MEDIUM]** [recommendation] -- [estimated effort]
-4. **[LOW]** [recommendation] -- [estimated effort]
+1. **[HIGH]** [recommendation]: [estimated effort]
+2. **[HIGH]** [recommendation]: [estimated effort]
+3. **[MEDIUM]** [recommendation]: [estimated effort]
+4. **[LOW]** [recommendation]: [estimated effort]
 
 ## Detailed Findings
 

--- a/plugins/ai-firstify/skills/ai-firstify/references/mode-bootstrap.md
+++ b/plugins/ai-firstify/skills/ai-firstify/references/mode-bootstrap.md
@@ -1,14 +1,14 @@
 # Mode 3: Bootstrap (New Project Setup)
 
-Guide the user through setting up a new AI-first project from scratch. This mode is interactive -- ask questions, do discovery, and build the right foundation.
+Guide the user through setting up a new AI-first project from scratch. This mode is interactive: ask questions, do discovery, and build the right foundation.
 
 ## Phase 1: Discovery (Ask Questions)
 
-Ask the user these questions one at a time. Don't overwhelm -- ask 2-3, then follow up based on answers.
+Ask the user these questions one at a time. Don't overwhelm. Ask 2-3, then follow up based on answers.
 
 **Problem definition:**
 1. What specific problem are you trying to solve? (One sentence)
-2. Who benefits? (Start with "me" -- build for yourself first)
+2. Who benefits? (Start with "me", build for yourself first)
 3. What does "done" look like? What's the concrete output?
 4. How will you measure impact? (Time saved, quality improved, tasks completed)
 
@@ -19,7 +19,7 @@ Ask the user these questions one at a time. Don't overwhelm -- ask 2-3, then fol
 8. Should this be a skill, a content studio, or a standalone tool?
 
 **Architecture decisions:**
-9. Does this need to run without you present? (Deployment check -- if no, make it a skill)
+9. Does this need to run without you present? (Deployment check. If no, make it a skill)
 10. Do you need to search external systems? (MCP connections: Slack, Notion, Atlassian?)
 11. Will this involve multiple phases? (Research -> create -> review = sub-agent opportunity)
 12. Are there quality criteria that can be checked automatically? (Validation tools)
@@ -28,7 +28,7 @@ Ask the user these questions one at a time. Don't overwhelm -- ask 2-3, then fol
 
 Based on the answers, recommend one of these architectures:
 
-**Simple Skill** (most common -- default to this)
+**Simple Skill** (most common, default to this)
 - Single SKILL.md with step-by-step instructions
 - Optional references/ for domain knowledge
 - Optional scripts/ for validation

--- a/plugins/ai-firstify/skills/ai-firstify/references/mode-reengineer.md
+++ b/plugins/ai-firstify/skills/ai-firstify/references/mode-reengineer.md
@@ -12,7 +12,7 @@ First, perform the full audit (read references/mode-audit.md). Then execute fixe
 - Scan for embedded agent patterns (read references/anti-patterns.md for detection)
 - For each found: propose replacement with Claude Code skills + sub-agents
 - After user approval, remove agent infrastructure code
-- Remember: "deployed an agent in a web app that nobody used because it was too complex and had too little context -- switched to Claude Code and it worked 10 times better"
+- Remember: "deployed an agent in a web app that nobody used because it was too complex and had too little context. Switched to Claude Code and it worked 10 times better"
 
 ## Phase 3: Skill Extraction
 - Identify repeated workflows (scripts run multiple times, similar prompt patterns, recurring data transformations)

--- a/plugins/ai-firstify/skills/ai-firstify/references/patterns.md
+++ b/plugins/ai-firstify/skills/ai-firstify/references/patterns.md
@@ -4,7 +4,7 @@
 
 **Summary:** Minimal prompt, maximum freedom. Good for inspiration and gauging difficulty.
 
-**Description:** Give a minimal prompt and let the AI run freely. No constraints, no detailed specifications -- just an idea and maximum creative freedom. One-shotting also works as a difficulty gauge: if the AI nails it in one shot, the task was straightforward. If it struggles, you need more specificity.
+**Description:** Give a minimal prompt and let the AI run freely. No constraints, no detailed specifications. Just an idea and maximum creative freedom. One-shotting also works as a difficulty gauge: if the AI nails it in one shot, the task was straightforward. If it struggles, you need more specificity.
 
 **When to use:**
 - Inspiration and exploration
@@ -30,7 +30,7 @@
 
 **Summary:** Code + data + skills in one Git repo. The agent sees everything.
 
-**Description:** Keep all related code, data, skills, and configuration in a single Git repository. The AI works best when everything is in one place -- it can see the full picture and make changes that span code and content.
+**Description:** Keep all related code, data, skills, and configuration in a single Git repository. The AI works best when everything is in one place. It can see the full picture and make changes that span code and content.
 
 **When to use:**
 - Any project with code AND content/data
@@ -147,7 +147,7 @@ my-project/
 **Example:**
 ```bash
 #!/bin/bash
-# scripts/validate.sh -- Validates content against rules
+# scripts/validate.sh: Validates content against rules
 FILE="$1"
 if [ -z "$FILE" ]; then echo "Usage: validate.sh <file>"; exit 1; fi
 # Check specific rules...

--- a/plugins/ai-firstify/skills/ai-firstify/references/principles.md
+++ b/plugins/ai-firstify/skills/ai-firstify/references/principles.md
@@ -4,7 +4,7 @@
 
 **Summary:** You are the pilot. AI is your co-pilot. Your name is on everything it produces.
 
-**Description:** Think of yourself as a pilot. The AI is your autopilot -- it handles a lot of the flying, but you are always responsible for the plane and everyone on it. Whether the AI wrote the email, generated the report, or built the tool -- your name is on it. This applies especially to automated systems. If you build something that runs unattended and it makes mistakes, that is on you -- even if the AI caused the error.
+**Description:** Think of yourself as a pilot. The AI is your autopilot. It handles a lot of the flying, but you are always responsible for the plane and everyone on it. Whether the AI wrote the email, generated the report, or built the tool, your name is on it. This applies especially to automated systems. If you build something that runs unattended and it makes mistakes, that is on you, even if the AI caused the error.
 
 **When it applies:** Always. Every interaction with AI tools. Especially when outputs are shared with others or when automated systems run without human oversight.
 
@@ -31,7 +31,7 @@
 
 **Summary:** Define narrow goals. Avoid complexity creep from vibe coding. One task at a time.
 
-**Description:** LLMs perform worse when given too many tasks at once. They are like a brilliant but easily distracted junior colleague -- give them one clear task and they will excel. Pile on five things and quality drops everywhere. The empty folder approach: start each significant task in a fresh, empty folder.
+**Description:** LLMs perform worse when given too many tasks at once. They are like a brilliant but easily distracted junior colleague. Give them one clear task and they will excel. Pile on five things and quality drops everywhere. The empty folder approach: start each significant task in a fresh, empty folder.
 
 **When it applies:** Every time you give instructions to an agent. When designing skills. When scoping projects.
 
@@ -59,7 +59,7 @@
 
 **Summary:** Build for yourself before others. Use it daily. Then share what works.
 
-**Description:** Do not build tools for others until you have built them for yourself. When you use your own tool daily, you discover what actually matters and what is unnecessary fluff. Usage is not a good metric for impact -- a Pokemon game has lots of usage but doesn't solve a business problem.
+**Description:** Do not build tools for others until you have built them for yourself. When you use your own tool daily, you discover what actually matters and what is unnecessary fluff. Usage is not a good metric for impact. A Pokemon game has lots of usage but doesn't solve a business problem.
 
 **When it applies:** Starting any new project. Deciding whether to share a tool. Prioritizing features.
 
@@ -114,7 +114,7 @@
 
 **Summary:** Use Claude Code. It improves automatically. Your custom agent won't.
 
-**Description:** You already have an agent with tools, research, and coding abilities. Building agent infrastructure in your applications is almost never the right choice. Your custom agent will never be as smart, bulletproof, or flexible as maintained agents like Claude Code. As models improve, Claude Code improves automatically -- your custom agent stays stuck in time.
+**Description:** You already have an agent with tools, research, and coding abilities. Building agent infrastructure in your applications is almost never the right choice. Your custom agent will never be as smart, bulletproof, or flexible as maintained agents like Claude Code. As models improve, Claude Code improves automatically. Your custom agent stays stuck in time.
 
 > **Important:** Sub-agents WITHIN Claude Code (e.g., using the Agent tool, TeamCreate, or sub-agent patterns in skills) are fine and encouraged. "Don't build your own agent" means don't build a web app or deployed service with an embedded LLM agent. Using Claude Code's built-in multi-agent capabilities is the recommended approach.
 
@@ -172,7 +172,7 @@
 
 **Summary:** Use voice. Be generous with context. Detailed prompts beat short ones.
 
-**Description:** Removing ambiguity and giving more depth to your prompts works wonders. Provide ample documentation, additional links, etc. Use voice transcription to give complete and nuanced input. The times of over-engineering prompts are over -- just be clear and detailed.
+**Description:** Removing ambiguity and giving more depth to your prompts works wonders. Provide ample documentation, additional links, etc. Use voice transcription to give complete and nuanced input. The times of over-engineering prompts are over. Just be clear and detailed.
 
 **When it applies:** Writing prompts. Creating skills. Describing requirements.
 

--- a/plugins/ai-firstify/skills/ai-firstify/references/project-structure.md
+++ b/plugins/ai-firstify/skills/ai-firstify/references/project-structure.md
@@ -14,8 +14,8 @@
 - Data: [Markdown with YAML frontmatter / SQLite / etc.]
 
 ## Key Files
-- [filename] -- [what it does]
-- [filename] -- [what it does]
+- [filename]: [what it does]
+- [filename]: [what it does]
 
 ## Conventions
 - [File naming convention]
@@ -28,7 +28,7 @@
 - [Data handling rules]
 
 ## Skills
-- /[skill-name] -- [what it does]
+- /[skill-name]: [what it does]
 
 ## Tone
 - [Writing style for generated content]

--- a/plugins/ai-firstify/skills/ai-firstify/references/skill-architecture.md
+++ b/plugins/ai-firstify/skills/ai-firstify/references/skill-architecture.md
@@ -20,28 +20,28 @@ Step-by-step prescriptive workflow:
 4. Run scripts/validate.sh to check the output
 5. Save the result to [specific location]
 
-## References (example -- adapt to your skill)
-- references/style-guide.md -- detailed style rules
-- references/examples.md -- example outputs
+## References (example, adapt to your skill)
+- references/style-guide.md: detailed style rules
+- references/examples.md: example outputs
 
 ## Tools
-- scripts/validate.sh -- validates output against rules
-- scripts/read-all.sh -- reads existing content for context
+- scripts/validate.sh: validates output against rules
+- scripts/read-all.sh: reads existing content for context
 ```
 
 ### Best Practices
 
-- **Keep SKILL.md lean** -- under 100 lines. Put detailed guidance in references/
-- **Be prescriptive** -- numbered steps, specific actions, clear outputs
-- **Use progressive disclosure** -- SKILL.md links to references/ for depth
-- **Name skills clearly** -- the name becomes the slash command
-- **Include frontmatter** -- name and description are required for slash command registration
+- **Keep SKILL.md lean** (under 100 lines). Put detailed guidance in references/
+- **Be prescriptive**: numbered steps, specific actions, clear outputs
+- **Use progressive disclosure**: SKILL.md links to references/ for depth
+- **Name skills clearly**: the name becomes the slash command
+- **Include frontmatter**: name and description are required for slash command registration
 
 ### When to Create scripts/ vs references/
 
-- **scripts/** -- Deterministic operations: validation, data reading, formatting, date/time
-- **references/** -- Knowledge: style guides, examples, templates, domain context
-- **Neither** -- Simple instructions that the agent handles natively
+- **scripts/**: Deterministic operations: validation, data reading, formatting, date/time
+- **references/**: Knowledge: style guides, examples, templates, domain context
+- **Neither**: Simple instructions that the agent handles natively
 
 ---
 
@@ -55,7 +55,7 @@ SKILL.md (lean, ~50-100 lines)
        └── references/examples.md (detailed, with full examples)
 ```
 
-> **Note:** The file names above (style-guide.md, examples.md) are illustrative. Name your reference files to match your skill's domain -- e.g., references/assessment-rubric.md, references/api-docs.md, etc.
+> **Note:** The file names above (style-guide.md, examples.md) are illustrative. Name your reference files to match your skill's domain (e.g., references/assessment-rubric.md, references/api-docs.md, etc.).
 
 The agent loads SKILL.md first (cheap). Only loads reference files when needed for the current step (on-demand). This saves tokens and keeps context focused.
 
@@ -68,7 +68,7 @@ The agent loads SKILL.md first (cheap). Only loads reference files when needed f
 | Scope | One specific project | All your projects |
 | Sharing | Shared via git repo | Personal only |
 | Examples | Content studio writer, project-specific validator | Memo writer, ai-firstify, code review |
-| When to promote | After proving useful across 3+ projects | -- |
+| When to promote | After proving useful across 3+ projects | - |
 
 **Start project-level.** Promote to user-level when the skill is proven useful across multiple projects.
 
@@ -89,9 +89,9 @@ Don't create skills speculatively. Wait for the pattern to emerge.
 ## Sharing and Packaging Skills
 
 Skills are just folders with text files. To share:
-1. **Zip the folder** -- `zip -r my-skill.zip .claude/skills/my-skill/`
-2. **Push to GitLab** -- include .claude/skills/ in your repo
-3. **Copy directly** -- recipients paste into their .claude/skills/
+1. **Zip the folder**: `zip -r my-skill.zip .claude/skills/my-skill/`
+2. **Push to GitLab**: include .claude/skills/ in your repo
+3. **Copy directly**: recipients paste into their .claude/skills/
 
 Treat shared skills as deployed products:
 - Version them (track changes in git)
@@ -143,7 +143,7 @@ Main agent --> splits 50 items into groups of 10 -->
 
 ### Nested Agents
 
-Agent spawns agent spawns agent. Use sparingly -- one level of nesting covers most cases.
+Agent spawns agent spawns agent. Use sparingly. One level of nesting covers most cases.
 
 ```
 Main agent --> spawns research agent -->

--- a/plugins/content-studio/hooks/ensure-content-studio.sh
+++ b/plugins/content-studio/hooks/ensure-content-studio.sh
@@ -27,7 +27,7 @@ if [ -n "$FOUND_PORT" ]; then
   exit 0
 fi
 
-# Not running — start it in the background
+# Not running, start it in the background
 cd "$CONTENT_STUDIO_DIR" || exit 0
 
 nohup npm run dev > /tmp/content-studio.log 2>&1 &
@@ -43,6 +43,6 @@ for i in $(seq 1 25); do
   sleep 1
 done
 
-# Timed out — don't block the session
+# Timed out, don't block the session
 echo '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"Content Studio startup was attempted but may still be loading. Check http://localhost:3000 or run: cd content-studio && npm run dev"}}'
 exit 0

--- a/plugins/content-studio/skills/setup-content-studio/references/repo-setup.md
+++ b/plugins/content-studio/skills/setup-content-studio/references/repo-setup.md
@@ -28,14 +28,14 @@ cp <plugin-path>/hooks/ensure-content-studio.sh .claude/hooks/
 
 Use the templates in the plugin's `templates/` directory as starting points:
 
-1. **`CLAUDE.md`** -- Adapt from `templates/CLAUDE.md`:
+1. **`CLAUDE.md`**: Adapt from `templates/CLAUDE.md`:
    - Replace `{{AUTHOR_NAME}}` with the person's name
    - Set content types to match what was decided
    - Update key concepts to match identified themes
    - Update skill commands available
    - Remove any content types not needed
 
-2. **`references/professional-profile.md`** -- Create from `templates/references/professional-profile.md`:
+2. **`references/professional-profile.md`**: Create from `templates/references/professional-profile.md`:
    - Current role and company
    - Education and background
    - Key achievements
@@ -44,28 +44,28 @@ Use the templates in the plugin's `templates/` directory as starting points:
    - Key topics
    - Personal philosophy (from their posts)
 
-3. **`guidelines/linkedin.md`** -- Adapt from `templates/guidelines/linkedin.md`:
+3. **`guidelines/linkedin.md`**: Adapt from `templates/guidelines/linkedin.md`:
    - Core voice & positioning (their focus area, tone, authority)
    - Key concepts (their 4-7 recurring themes with example angles)
    - Style essentials (what works for them, what to avoid)
    - Length guidelines (based on their actual post lengths)
    - Hook strategies (based on their actual high-performing hooks)
 
-4. **`guidelines/opinion.md`** if opinion pieces are a content type -- adapt from `templates/guidelines/opinie.md`:
+4. **`guidelines/opinion.md`** if opinion pieces are a content type: adapt from `templates/guidelines/opinie.md`:
    - Replace `{{OPINION_LANGUAGE}}` with the chosen language (e.g., "Dutch (Nederlands)", "English", "French")
    - Adapt language-specific examples and vocabulary to match
 
 ## 6c. Create Skills
 
 Create skills in `.claude/skills/` for each content type. At minimum:
-- `write-linkedin-post/SKILL.md` -- Always include this
-- `brainstorm-linkedin/SKILL.md` -- Always include this
-- `analyze-performance/SKILL.md` -- Always include this
+- `write-linkedin-post/SKILL.md`: Always include this
+- `brainstorm-linkedin/SKILL.md`: Always include this
+- `analyze-performance/SKILL.md`: Always include this
 
 Add if relevant:
-- `write-blog-post/SKILL.md` -- If blog posts are a content type
-- `write-opinion/SKILL.md` -- If opinion pieces are a content type
-- `brainstorm-opinion/SKILL.md` -- If opinion pieces cross-pollinate from LinkedIn
+- `write-blog-post/SKILL.md`: If blog posts are a content type
+- `write-opinion/SKILL.md`: If opinion pieces are a content type
+- `brainstorm-opinion/SKILL.md`: If opinion pieces cross-pollinate from LinkedIn
 
 Each skill must reference the new person's name, their style guide, and their professional profile.
 

--- a/plugins/people-management/.claude-plugin/plugin.json
+++ b/plugins/people-management/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "people-management",
   "version": "1.2.0",
-  "description": "AI-augmented management tooling for people managers. Surfaces the right context at the right time -- before meetings, during 1:1 prep, when triaging messages, or reviewing customer status. Adapts to your org's performance and management frameworks. Augments managers, never automates.",
+  "description": "AI-augmented management tooling for people managers. Surfaces the right context at the right time: before meetings, during 1:1 prep, when triaging messages, or reviewing customer status. Adapts to your org's performance and management frameworks. Augments managers, never automates.",
   "author": { "name": "TechWolf" },
   "keywords": ["management", "1:1", "performance", "team-health", "meeting-prep"]
 }

--- a/plugins/people-management/CLAUDE.md
+++ b/plugins/people-management/CLAUDE.md
@@ -6,7 +6,7 @@ AI-augmented management tooling. See `README.md` for philosophy and details.
 
 | Command | What it does |
 |---------|--------------|
-| `/setup` | Interactive onboarding -- run this first |
+| `/setup` | Interactive onboarding, run this first |
 | `/meeting-prep` | Pre-meeting briefing from all sources |
 | `/one-on-one-prep` | Deep 1:1 preparation (org's performance framework) |
 | `/triage-messages` | Batch message triage by urgency |
@@ -17,12 +17,12 @@ AI-augmented management tooling. See `README.md` for philosophy and details.
 
 ## Key References
 
-- `references/operating-principles.md` -- shared principles all skills follow
-- `references/performance-framework.md` -- how skills use the performance framework (configured during setup)
-- `references/management-framework.md` -- how skills use the management framework (configured during setup)
-- `references/values-guide.md` -- how org values are used across skills
+- `references/operating-principles.md`: shared principles all skills follow
+- `references/performance-framework.md`: how skills use the performance framework (configured during setup)
+- `references/management-framework.md`: how skills use the management framework (configured during setup)
+- `references/values-guide.md`: how org values are used across skills
 
 ## Runtime Data
 
-- `manager-context/` -- persisted team context (created by `/setup`, gitignored)
-- `outputs/` -- skill outputs (gitignored)
+- `manager-context/`: persisted team context (created by `/setup`, gitignored)
+- `outputs/`: skill outputs (gitignored)

--- a/plugins/people-management/README.md
+++ b/plugins/people-management/README.md
@@ -4,18 +4,18 @@ AI-augmented management tooling for people managers.
 
 ## Philosophy
 
-**Augment, never automate.** This plugin surfaces context so managers can make better decisions -- it never acts on their behalf. Every output is a draft for human review. Management is about human judgment, trust, and relationships. AI provides leverage on information-gathering so managers spend more energy on the human side.
+**Augment, never automate.** This plugin surfaces context so managers can make better decisions. It never acts on their behalf. Every output is a draft for human review. Management is about human judgment, trust, and relationships. AI provides leverage on information-gathering so managers spend more energy on the human side.
 
 ## Skills
 
 | Skill | What it does |
 |-------|--------------|
 | **Setup** | Interactive onboarding (10 phases): discovers team, frameworks, terminology, goals, values, ways of working. Configures output preferences, triage rules, review calendar, and skill rhythm. Run this first. |
-| **Meeting Prep** | Gathers all relevant context before any meeting -- attendees, topics, previous notes, action items |
+| **Meeting Prep** | Gathers all relevant context before any meeting: attendees, topics, previous notes, action items |
 | **Triage Messages** | Batch-processes Slack and email, categorises by urgency using your custom triage rules (VIPs, hot channels) |
 | **1:1 Prep** | Deep-dive preparation for 1:1s with direct reports, anchored in your org's performance framework |
 | **Customer Status** | Synthesised view of account health and activity for customer-facing teams |
-| **Priority Planner** | Identifies highest-leverage actions for the day/week with goal alignment reflection -- maps activities against OKRs, surfaces drift |
+| **Priority Planner** | Identifies highest-leverage actions for the day/week with goal alignment reflection. Maps activities against OKRs, surfaces drift |
 | **Team Health** | Periodic check through two lenses: development (growth, goals, performance) and wellbeing (energy, connection, celebration) |
 | **Performance Cycle** | Evidence gathering for review cycles, organised along your org's performance framework dimensions |
 
@@ -26,27 +26,27 @@ AI-augmented management tooling for people managers.
 3. Run `/setup` to begin interactive onboarding
 
 Setup covers 10 phases:
-1. **Team discovery** -- team structure, terminology, goals, ways of working, customers
-2. **Performance & management frameworks** -- your org's performance dimensions, rating scale, management competencies
-3. **Organizational values** -- your org's core values and what signals to look for
-4. **Output preferences** -- language, tone, file format, folder structure, naming
-5. **Manager's own context** -- your OKRs, who you report to, upward priorities
-6. **Triage rules** -- VIP people, hot channels, deprioritise list, privacy boundaries
-7. **Review calendar** -- cycle dates, calibration, promotion windows
-8. **Skill preferences** -- 1:1 style, suggested rhythm for all skills
-9. **Staleness check** -- flags stale data for validation
-10. **Persist & wrap up** -- saves all context, summary, suggested first skills
+1. **Team discovery**: team structure, terminology, goals, ways of working, customers
+2. **Performance & management frameworks**: your org's performance dimensions, rating scale, management competencies
+3. **Organizational values**: your org's core values and what signals to look for
+4. **Output preferences**: language, tone, file format, folder structure, naming
+5. **Manager's own context**: your OKRs, who you report to, upward priorities
+6. **Triage rules**: VIP people, hot channels, deprioritise list, privacy boundaries
+7. **Review calendar**: cycle dates, calibration, promotion windows
+8. **Skill preferences**: 1:1 style, suggested rhythm for all skills
+9. **Staleness check**: flags stale data for validation
+10. **Persist & wrap up**: saves all context, summary, suggested first skills
 
 ## Required Connectors
 
-- **Slack** -- message search, channel reading, user profiles
-- **Notion** -- performance docs, goals, OKRs, team pages
-- **Google Drive** -- meeting notes, 1:1 docs, strategy docs
-- **Gmail** -- email context and triage
-- **Google Calendar** -- upcoming meetings, attendee lists
+- **Slack**: message search, channel reading, user profiles
+- **Notion**: performance docs, goals, OKRs, team pages
+- **Google Drive**: meeting notes, 1:1 docs, strategy docs
+- **Gmail**: email context and triage
+- **Google Calendar**: upcoming meetings, attendee lists
 
 ## Grounded In
 
-- **Your organization's frameworks** -- performance and management frameworks configured during setup, with sensible defaults if your org doesn't have formal ones
-- **Your organization's values** -- configured during setup, used as a lens across 1:1 prep, team health, and performance reviews
-- **AI-first design principles** -- narrow scope, human-in-the-loop, progressive disclosure
+- **Your organization's frameworks**: performance and management frameworks configured during setup, with sensible defaults if your org doesn't have formal ones
+- **Your organization's values**: configured during setup, used as a lens across 1:1 prep, team health, and performance reviews
+- **AI-first design principles**: narrow scope, human-in-the-loop, progressive disclosure

--- a/plugins/people-management/references/ai-first-principles.md
+++ b/plugins/people-management/references/ai-first-principles.md
@@ -5,7 +5,7 @@ These principles guide how every skill in this plugin is designed.
 ## Core Principles
 
 ### 1. You Are Responsible
-The human is always accountable. AI surfaces information and proposes -- it never decides or acts autonomously. Every output is a draft for human review. In management context: the manager makes the call, the tool provides leverage.
+The human is always accountable. AI surfaces information and proposes. It never decides or acts autonomously. Every output is a draft for human review. In management context: the manager makes the call, the tool provides leverage.
 
 ### 2. Narrow Scope
 Each skill does ONE thing well. No "do everything" commands. A meeting prep skill preps meetings. A triage skill triages. Users invoke what they need, when they need it. Resist the temptation to combine skills into mega-prompts.

--- a/plugins/people-management/references/management-framework.md
+++ b/plugins/people-management/references/management-framework.md
@@ -6,9 +6,9 @@ How this plugin uses your org's management framework. The actual framework is co
 
 During `/setup` Phase 2, the plugin discovers or helps you define:
 
-- **Management dimensions** -- what your org expects from managers (e.g., "Results + People", a competency model, or something custom)
-- **Competencies per dimension** -- the specific skills or behaviours expected
-- **How managers are evaluated** -- separate track, same as ICs, or informal
+- **Management dimensions:** what your org expects from managers (e.g., "Results + People", a competency model, or something custom)
+- **Competencies per dimension:** the specific skills or behaviours expected
+- **How managers are evaluated:** separate track, same as ICs, or informal
 
 If your org doesn't have a formal management framework, setup provides sensible defaults.
 

--- a/plugins/people-management/references/operating-principles.md
+++ b/plugins/people-management/references/operating-principles.md
@@ -4,27 +4,27 @@ Shared principles that apply to all People Manager skills. Every skill should re
 
 ## Augment, Never Automate
 
-Every output is a draft for human review. Management is about human judgment, trust, and relationships. AI provides leverage on information-gathering -- it never decides, prescribes, or acts on the manager's behalf.
+Every output is a draft for human review. Management is about human judgment, trust, and relationships. AI provides leverage on information-gathering. It never decides, prescribes, or acts on the manager's behalf.
 
 ## Data Scope
 
 - All channels, documents, emails, and DMs the manager is part of are fair game.
 - **Never** surface DMs between other people that don't include the manager.
 - When using DM content, flag it as `(from DM)` so the manager knows it's sensitive context not visible to the team.
-- Wellbeing signals are especially sensitive -- surface gently, as conversation starters, never as conclusions.
+- Wellbeing signals are especially sensitive. Surface gently, as conversation starters, never as conclusions.
 
 ## Signals, Not Diagnoses
 
 - Never say "this person is disengaged" or "this person is struggling."
 - Always frame as "signal worth exploring" or "pattern to check in on."
-- Decreased activity could mean many things -- present observations, let the manager interpret.
+- Decreased activity could mean many things. Present observations, let the manager interpret.
 - Baseline matters: a quiet person being quiet isn't a signal. A usually active person going quiet might be.
 
 ## Evidence Over Opinion
 
 - Every claim should link back to where you found it. Don't synthesise without attribution.
-- Recency matters -- prioritise recent information and flag anything older than ~2 months.
-- Absence of evidence is not evidence of absence -- especially for values and behaviours best observed in person.
+- Recency matters. Prioritise recent information and flag anything older than ~2 months.
+- Absence of evidence is not evidence of absence, especially for values and behaviours best observed in person.
 
 ## Connector Unavailability
 
@@ -32,7 +32,7 @@ If an MCP connector (Slack, Notion, Gmail, Google Drive, Google Calendar) is una
 1. Note which connector is unavailable
 2. Proceed with the data you can access from other connectors
 3. Flag the gap in your output so the manager knows what's missing
-4. Never silently skip a data source -- always tell the manager what you couldn't check
+4. Never silently skip a data source. Always tell the manager what you couldn't check
 
 ## Source Everything
 

--- a/plugins/people-management/references/performance-framework.md
+++ b/plugins/people-management/references/performance-framework.md
@@ -6,12 +6,12 @@ How this plugin uses your org's performance framework. The actual framework is c
 
 During `/setup` Phase 2, the plugin discovers or helps you define:
 
-- **Framework dimensions** -- what your org evaluates (e.g., "What + How", "Impact + Growth", "Results + Behaviours", or something else entirely)
-- **Sub-dimensions** -- the specific areas within each dimension
-- **Rating scale** -- how performance is rated (descriptive labels, numbered scale, etc.)
-- **Promotion readiness labels** -- how your org tracks promotion readiness (if applicable)
-- **Review cadence** -- when reviews happen and what type
-- **Goal cadence** -- how often goals are set and reviewed
+- **Framework dimensions:** what your org evaluates (e.g., "What + How", "Impact + Growth", "Results + Behaviours", or something else entirely)
+- **Sub-dimensions:** the specific areas within each dimension
+- **Rating scale:** how performance is rated (descriptive labels, numbered scale, etc.)
+- **Promotion readiness labels:** how your org tracks promotion readiness (if applicable)
+- **Review cadence:** when reviews happen and what type
+- **Goal cadence:** how often goals are set and reviewed
 
 If your org doesn't have a formal framework, setup provides sensible defaults you can use or adjust.
 
@@ -27,11 +27,11 @@ If your org doesn't have a formal framework, setup provides sensible defaults yo
 ## Evidence Gathering Guidelines
 
 When preparing reviews, skills look for evidence across:
-1. **Goal tracking systems** -- Notion pages, OKR docs
-2. **Project deliverables** -- shipped features, completed milestones, docs produced
-3. **Peer recognition** -- Slack shoutouts, feedback from collaborators
-4. **Customer/stakeholder feedback** -- visible in project channels, email threads
-5. **Development activities** -- courses, workshops, mentoring, scope expansion
+1. **Goal tracking systems:** Notion pages, OKR docs
+2. **Project deliverables:** shipped features, completed milestones, docs produced
+3. **Peer recognition:** Slack shoutouts, feedback from collaborators
+4. **Customer/stakeholder feedback:** visible in project channels, email threads
+5. **Development activities:** courses, workshops, mentoring, scope expansion
 
 **What digital signals CAN show:** Goal completion, project delivery, peer recognition, scope changes, activity patterns.
 

--- a/plugins/people-management/references/values-guide.md
+++ b/plugins/people-management/references/values-guide.md
@@ -15,9 +15,9 @@ Each skill references your org's values differently:
 
 | Skill | How values are used |
 |-------|-------------------|
-| 1:1 Prep | Values snapshot -- scan for signals related to each value, suggest conversation threads |
-| Team Health | Values as a lens alongside performance -- are people living the values? |
-| Performance Cycle | Values evidence gathering -- "how" someone delivered, organised by value |
+| 1:1 Prep | Values snapshot: scan for signals related to each value, suggest conversation threads |
+| Team Health | Values as a lens alongside performance: are people living the values? |
+| Performance Cycle | Values evidence gathering: "how" someone delivered, organised by value |
 | Priority Planner | Values inform what gets prioritised beyond urgency |
 
 ## Defining Good Value Signals
@@ -26,10 +26,10 @@ For each of your org's values, consider:
 - **What does it look like in Slack?** (e.g., collaboration value → helping others in channels, cross-team activity)
 - **What does it look like in meetings?** (e.g., transparency value → sharing context, raising issues early)
 - **What does it look like in work output?** (e.g., quality value → iteration, attention to detail, peer feedback)
-- **What's hard to see digitally?** (e.g., empathy, presence, trust-building -- flag these for manager's own observation)
+- **What's hard to see digitally?** (e.g., empathy, presence, trust-building, flag these for manager's own observation)
 
 ## Important Notes
 
 - **Values evidence is hardest to gather digitally.** Many values are best observed in person. Always caveat that the manager's direct observations carry more weight.
-- **Values are conversation threads, not checklists.** Don't force every value into every 1:1 or health check -- surface values where there's a real signal.
+- **Values are conversation threads, not checklists.** Don't force every value into every 1:1 or health check. Surface values where there's a real signal.
 - **Absence of digital evidence ≠ absence of the behaviour.** Flag gaps honestly.

--- a/plugins/people-management/skills/customer-status/SKILL.md
+++ b/plugins/people-management/skills/customer-status/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: customer-status
-description: Synthesised view of account health and activity for managers overseeing customer-facing teams (Sales, CS, Professional Services, Presales). Scans project channels, email threads, and Notion pages to surface status, risks, and upcoming milestones -- without requiring the manager to trawl through individual channels. Supports proactive account management.
+description: Synthesised view of account health and activity for managers overseeing customer-facing teams (Sales, CS, Professional Services, Presales). Scans project channels, email threads, and Notion pages to surface status, risks, and upcoming milestones, without requiring the manager to trawl through individual channels. Supports proactive account management.
 ---
 
 # Customer Status Overview
@@ -23,9 +23,9 @@ If any MCP connector is unavailable, follow the connector unavailability protoco
 ### 1. Load Context
 
 Read from `manager-context/`:
-- `sources.md` -- customer/project channels, account mappings
-- `manager-profile.md` -- team members and their account assignments
-- `team/` -- individual team member profiles and project assignments
+- `sources.md`: customer/project channels, account mappings
+- `manager-profile.md`: team members and their account assignments
+- `team/`: individual team member profiles and project assignments
 
 If no manager-context exists:
 ```
@@ -84,9 +84,9 @@ Read `references/output-template.md` for the full output template structure.
 ### 6. Sub-Agent Review
 
 Spawn a sub-agent to review the customer status overview with fresh eyes. The reviewer should:
-- Check that **health signal assessments are evidence-based** -- every red/yellow rating should cite specific signals, not just absence of activity.
-- Verify that **silence is not over-interpreted** -- a quiet channel on a stable account is not the same as a quiet channel on an active delivery.
-- Check for **team member workload signals** -- if one person owns many flagged accounts, note it.
+- Check that **health signal assessments are evidence-based**: every red/yellow rating should cite specific signals, not just absence of activity.
+- Verify that **silence is not over-interpreted**: a quiet channel on a stable account is not the same as a quiet channel on an active delivery.
+- Check for **team member workload signals**: if one person owns many flagged accounts, note it.
 - Flag any accounts where the evidence is thin enough that the health signal might be misleading.
 
 Incorporate the reviewer's feedback before presenting the final overview.
@@ -108,4 +108,4 @@ Additional notes specific to this skill:
 - **Don't alarm unnecessarily.** Silence on a channel might mean things are running smoothly. Combine multiple signals before flagging red.
 - **Recency matters.** Flag any account where project docs haven't been updated in >2 weeks on active projects.
 - **Respect customer confidentiality.** Summarise, don't reproduce customer communications verbatim. When surfacing DM content, flag it as `(from DM)`.
-- **Team member context.** If a team member owns multiple accounts, note that -- they might be spread thin.
+- **Team member context.** If a team member owns multiple accounts, note that, they might be spread thin.

--- a/plugins/people-management/skills/customer-status/references/output-template.md
+++ b/plugins/people-management/skills/customer-status/references/output-template.md
@@ -1,4 +1,4 @@
-# Customer Status -- [Date]
+# Customer Status: [Date]
 Team: [Manager's team name]
 
 ## Summary
@@ -11,7 +11,7 @@ Team: [Manager's team name]
 ## 🔴 Needs Attention
 ### [Account Name]
 **Owner:** [team member] | **Channel:** #[channel] | **Phase:** [delivery phase]
-**Signal:** [1-2 sentences explaining why this is flagged -- with links]
+**Signal:** [1-2 sentences explaining why this is flagged, with links]
 **Last activity:** [date/time]
 **Suggested action:** [e.g., "Check in with [name] about the blocker they raised on [date]"]
 

--- a/plugins/people-management/skills/meeting-prep/SKILL.md
+++ b/plugins/people-management/skills/meeting-prep/SKILL.md
@@ -5,13 +5,13 @@ description: Comprehensive pre-meeting briefing that gathers all relevant contex
 
 # Meeting Prep
 
-> **Principle: "Narrow scope, high impact."** One meeting, one thorough brief. No guessing -- only sourced context.
+> **Principle: "Narrow scope, high impact."** One meeting, one thorough brief. No guessing, only sourced context.
 
 Gathers context from all connected sources for a specific upcoming meeting and produces a structured briefing.
 
 ## When to Use
 
-- Before any meeting (1:1s have their own skill -- use `/prep-one-on-one` instead)
+- Before any meeting (1:1s have their own skill, use `/prep-one-on-one` instead)
 - When the manager says "prep me for [meeting]", "what do I need to know for [meeting]"
 - Can be invoked for the next upcoming meeting or a specific one by name/time
 

--- a/plugins/people-management/skills/meeting-prep/references/output-template.md
+++ b/plugins/people-management/skills/meeting-prep/references/output-template.md
@@ -16,8 +16,8 @@
 [Summary with sources]
 
 ## Open Items from Last Meeting
-- [ ] [Action item] -- assigned to [name], status: [done/pending/unknown]
-- [ ] [Action item] -- assigned to [name], status: [done/pending/unknown]
+- [ ] [Action item], assigned to [name], status: [done/pending/unknown]
+- [ ] [Action item], assigned to [name], status: [done/pending/unknown]
 
 ## Suggested Talking Points
 Based on what I've found, you might want to:

--- a/plugins/people-management/skills/one-on-one-prep/SKILL.md
+++ b/plugins/people-management/skills/one-on-one-prep/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: one-on-one-prep
-description: "Deep-dive preparation for 1:1 meetings with direct reports. Surfaces recent work, wins, friction, wellbeing signals, and development goal progress -- anchored in the org's performance framework, organizational values, and management best practices. Produces a prep sheet with suggested conversation topics, not a script."
+description: "Deep-dive preparation for 1:1 meetings with direct reports. Surfaces recent work, wins, friction, wellbeing signals, and development goal progress, anchored in the org's performance framework, organizational values, and management best practices. Produces a prep sheet with suggested conversation topics, not a script."
 ---
 
 # 1:1 Prep
@@ -13,7 +13,7 @@ Deep-dive preparation for 1:1 meetings with a specific direct report, anchored i
 
 - Before any 1:1 meeting with a direct report
 - When the manager says "prep my 1:1 with [name]", "what should I discuss with [name]"
-- Can be invoked with just a name -- the skill finds the relevant context
+- Can be invoked with just a name, the skill finds the relevant context
 
 ## Instructions
 
@@ -28,8 +28,8 @@ If no name is specified, check the calendar for the next upcoming 1:1 meeting an
 If ambiguous:
 ```
 Which team member? Your upcoming 1:1s are:
-- [Name] -- [day] at [time]
-- [Name] -- [day] at [time]
+- [Name], [day] at [time]
+- [Name], [day] at [time]
 ```
 
 Load the team member's profile from `manager-context/team/[name].md` for:
@@ -63,7 +63,7 @@ Compile into a "recent activity" summary.
 
 ### 3. Detect Friction or Concerns
 
-Look for signals (NOT diagnoses -- signals for the manager to explore):
+Look for signals (NOT diagnoses, signals for the manager to explore):
 
 **Slack:**
 - Repeated blockers or unanswered questions
@@ -78,20 +78,20 @@ Look for signals (NOT diagnoses -- signals for the manager to explore):
 **Important:** Frame these as *conversation starters*, not assessments:
 ```
 💡 Potential topics to explore (signals, not conclusions):
-- [Name] asked about [topic] in #channel 3 times this week without a clear resolution -- might be a blocker worth discussing
-- [Name]'s activity in #project-channel has been lower than usual -- could be fine, but worth checking in
+- [Name] asked about [topic] in #channel 3 times this week without a clear resolution, might be a blocker worth discussing
+- [Name]'s activity in #project-channel has been lower than usual, could be fine, but worth checking in
 ```
 
 ### 4. Values & Wellbeing Check
 
-Scan for signals related to the organization's values (from `manager-context/values.md`) -- these give the manager conversation threads beyond just goals and deliverables.
+Scan for signals related to the organization's values (from `manager-context/values.md`). These give the manager conversation threads beyond just goals and deliverables.
 
 If no values are configured, focus on these universal management dimensions:
 
 **Wellbeing & Energy:**
 - Late-night or weekend Slack activity (potential overwork)
 - Calendar density (back-to-back days, no focus time)
-- Tone in recent messages -- enthusiasm vs. fatigue (soft signal only)
+- Tone in recent messages: enthusiasm vs. fatigue (soft signal only)
 - Have they taken time off recently?
 
 **Team Connection & Collaboration:**
@@ -112,7 +112,7 @@ If no values are configured, focus on these universal management dimensions:
 
 If organizational values are configured, map these dimensions to the specific values and use value names in the output.
 
-Compile into a brief values snapshot (not a scorecard -- conversation prompts):
+Compile into a brief values snapshot (not a scorecard, conversation prompts):
 
 ```
 Values Snapshot:
@@ -121,7 +121,7 @@ Values Snapshot:
 ...
 ```
 
-_Only include values/dimensions where there's a meaningful signal -- don't force all of them every time._
+_Only include values/dimensions where there's a meaningful signal. Don't force all of them every time._
 
 ### 5. Check Development Goals
 
@@ -145,11 +145,11 @@ See the "Evidence Gathering Guidelines" section in `../../references/performance
 
 ```
 📋 Development Goal Status:
-- Goal 1: "[goal text]" -- [status: on track / needs attention / no update since [date]]
-- Goal 2: "[goal text]" -- [status]
-- Development area: "[area]" -- [any evidence of progress or attention]
+- Goal 1: "[goal text]", [status: on track / needs attention / no update since [date]]
+- Goal 2: "[goal text]", [status]
+- Development area: "[area]", [any evidence of progress or attention]
 
-⏰ Last goal update: [date] -- [flag if >6 weeks old]
+⏰ Last goal update: [date], [flag if >6 weeks old]
 ```
 
 ### 6. Pull Previous 1:1 Notes
@@ -166,8 +166,8 @@ Extract:
 ```
 📝 From last 1:1 ([date]):
 Open items:
-- [ ] [Manager] to [action] -- [status: done/pending/unknown]
-- [ ] [Team member] to [action] -- [status: done/pending/unknown]
+- [ ] [Manager] to [action], [status: done/pending/unknown]
+- [ ] [Team member] to [action], [status: done/pending/unknown]
 Parked topics: [if any]
 ```
 
@@ -179,7 +179,7 @@ Read `references/output-template.md` for the full output template structure.
 
 Spawn a sub-agent to review the prep sheet with fresh eyes. The reviewer should:
 - Check that **wellbeing signals are framed as conversation starters**, not assessments or diagnoses.
-- Check that the **values snapshot** only includes values with meaningful signals -- not forcing all values every time.
+- Check that the **values snapshot** only includes values with meaningful signals, not forcing all values every time.
 - Verify that **wins lead the document** and the tone is constructive, not surveillance-like.
 - Flag any phrasing that crosses from observation ("posted after 22:00 three times") into interpretation ("seems burned out").
 - Check that evidence gaps are noted where data is thin, rather than padded with weak signals.
@@ -197,8 +197,8 @@ Here's your prep for your 1:1 with [name]. Anything you'd like me to dig deeper 
 Read `../../references/operating-principles.md` for shared operating principles (data scope, DM flagging, signals vs diagnoses, connector unavailability).
 
 Additional notes specific to this skill:
-- **Wins first.** Always lead with recognition opportunities -- this sets the tone.
+- **Wins first.** Always lead with recognition opportunities. This sets the tone.
 - **Goals are the backbone.** If goals are missing or stale, flag it prominently. Great 1:1s keep development goals alive.
-- **Framework + values alignment.** Suggested questions should map to the org's performance framework dimensions or organizational values. Don't force all values every time -- only surface values where there's a real signal.
+- **Framework + values alignment.** Suggested questions should map to the org's performance framework dimensions or organizational values. Don't force all values every time, only surface values where there's a real signal.
 - **Values are conversation threads, not checklists.** The values snapshot helps managers notice things beyond deliverables. A 1:1 that only covers goals misses the human. A 1:1 that only covers feelings misses the growth. Both.
 - **Don't script the conversation.** Provide prompts and context, not a talk track.

--- a/plugins/people-management/skills/one-on-one-prep/references/output-template.md
+++ b/plugins/people-management/skills/one-on-one-prep/references/output-template.md
@@ -8,8 +8,8 @@
 (Recognition to give: these are great conversation openers)
 
 ## What They've Been Working On
-- [Project/activity 1] -- [brief context]
-- [Project/activity 2] -- [brief context]
+- [Project/activity 1]: [brief context]
+- [Project/activity 2]: [brief context]
 
 ## Topics to Explore
 Based on signals from the past [N] days:
@@ -21,7 +21,7 @@ Based on signals from the past [N] days:
 |-------------------|--------|-------------------|
 | [Value from manager-context/values.md] | [observation] | [question if relevant] |
 
-_Only include values where there's a meaningful signal -- don't force all every time. Skip this section entirely if no values were configured._
+_Only include values where there's a meaningful signal. Don't force all every time. Skip this section entirely if no values were configured._
 
 ## Development Goals
 | Goal | Status | Last Updated | Framework Dimension |
@@ -29,7 +29,7 @@ _Only include values where there's a meaningful signal -- don't force all every 
 | [goal] | [on track / needs attention] | [date] | [dimension from org's framework] |
 
 ## Open Items from Last 1:1
-- [ ] [item] -- [who owns it, status]
+- [ ] [item], [who owns it, status]
 
 ## Suggested Questions
 Aligned with the org's performance framework dimensions and organizational values:

--- a/plugins/people-management/skills/performance-cycle/SKILL.md
+++ b/plugins/people-management/skills/performance-cycle/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: performance-cycle
-description: "Evidence gathering for performance review cycles. Gathers goal completion evidence, peer feedback, development progress, scope changes, and values alignment -- organised along the org's performance framework dimensions, with organizational values as the 'how' lens. Surfaces evidence gaps. Never suggests ratings -- only organises evidence for the manager's judgment."
+description: "Evidence gathering for performance review cycles. Gathers goal completion evidence, peer feedback, development progress, scope changes, and values alignment, organised along the org's performance framework dimensions, with organizational values as the 'how' lens. Surfaces evidence gaps. Never suggests ratings, only organises evidence for the manager's judgment."
 ---
 
 # Performance Cycle Assistant
@@ -49,10 +49,10 @@ For the target team member, read from `manager-context/team/[name].md`:
 - Their projects and responsibilities
 
 Also load:
-- `manager-context/performance-framework.md` -- for org-specific framework dimensions and rating descriptors (falls back to `../../references/performance-framework.md` defaults)
-- `manager-context/management-framework.md` -- for org-specific management dimensions (falls back to `../../references/management-framework.md` defaults)
-- `../../references/values-guide.md` -- for values definitions and signal guidance
-- `manager-context/values.md` -- for the organization's specific values
+- `manager-context/performance-framework.md`: org-specific framework dimensions and rating descriptors (falls back to `../../references/performance-framework.md` defaults)
+- `manager-context/management-framework.md`: org-specific management dimensions (falls back to `../../references/management-framework.md` defaults)
+- `../../references/values-guide.md`: values definitions and signal guidance
+- `manager-context/values.md`: the organization's specific values
 
 ### 3. Gather Evidence Along Each Dimension
 
@@ -74,7 +74,7 @@ For dimensions that are hardest to assess digitally (e.g., behavioural growth, l
 
 ### 4. Gather Values Evidence
 
-Values are the "how" -- how this person delivered their results and showed up for the team. Search for evidence across the organization's values (from `manager-context/values.md`). See `../../references/values-guide.md` for guidance on finding value signals.
+Values are the "how": how this person delivered their results and showed up for the team. Search for evidence across the organization's values (from `manager-context/values.md`). See `../../references/values-guide.md` for guidance on finding value signals.
 
 For each value defined in `manager-context/values.md`, search for evidence using the signal guidance stored there. Common evidence sources by value type:
 
@@ -115,7 +115,7 @@ Search Slack for recognition this person received during the review period:
 For each dimension, assess evidence strength:
 - **Strong evidence:** Multiple sources corroborate
 - **Some evidence:** 1-2 data points
-- **Gap:** No evidence found -- manager needs to gather this manually
+- **Gap:** No evidence found, manager needs to gather this manually
 
 ### 7. Produce the Evidence Summary
 
@@ -130,15 +130,15 @@ If preparing for the whole team, produce individual evidence summaries for each 
 ```
 Here's the evidence I gathered for [name]'s review. I've flagged gaps where you'll want to add your own observations.
 
-Remember: this is evidence gathering only. Rating decisions and promotion assessments are yours to make based on the full picture -- including things I can't see.
+Remember: this is evidence gathering only. Rating decisions and promotion assessments are yours to make based on the full picture, including things I can't see.
 ```
 
 ### 10. Sub-Agent Review
 
 Spawn a sub-agent to review the evidence summary with fresh eyes. The reviewer should:
-- Check for **recency bias** -- is most evidence from the last few weeks, or spread across the review period?
-- Check for **dimension imbalance** -- are some dimensions well-evidenced while others are thin? Flag under-covered areas.
-- Check for **interpretive language** -- flag any phrasing that crosses from evidence ("shipped X on time") into interpretation ("demonstrated strong execution").
+- Check for **recency bias**: is most evidence from the last few weeks, or spread across the review period?
+- Check for **dimension imbalance**: are some dimensions well-evidenced while others are thin? Flag under-covered areas.
+- Check for **interpretive language**: flag any phrasing that crosses from evidence ("shipped X on time") into interpretation ("demonstrated strong execution").
 - Verify evidence gaps are honestly flagged, not papered over with weak data.
 - Check that values evidence is presented as "examples I found", not "the full picture."
 

--- a/plugins/people-management/skills/performance-cycle/references/output-template.md
+++ b/plugins/people-management/skills/performance-cycle/references/output-template.md
@@ -1,5 +1,5 @@
 # Performance Review Prep: [Name]
-Review period: [start] -- [end]
+Review period: [start] to [end]
 Role: [role] | Level: [level] | Manager: [manager]
 Last review rating: [if known]
 
@@ -21,7 +21,7 @@ _This dimension is hardest to assess from digital signals. Your 1:1 observations
 
 [Same structure as above, one section per sub-dimension]
 
-## Values -- How They Showed Up
+## Values: How They Showed Up
 
 _Values are how results were delivered. This section helps paint the full picture beyond what and how much._
 
@@ -30,7 +30,7 @@ _Values are how results were delivered. This section helps paint the full pictur
 | [Value from manager-context/values.md] | [evidence] | [Strong / Some / Gap] |
 
 **Values highlights:**
-- [1-2 strongest examples with links -- moments that exemplify this person's character]
+- [1-2 strongest examples with links, moments that exemplify this person's character]
 
 **Values development areas:**
 - [Any patterns worth discussing]
@@ -38,11 +38,11 @@ _Values are how results were delivered. This section helps paint the full pictur
 This section is only included if organizational values were configured during setup.
 
 ## Peer Recognition Highlights
-- "[quote/summary]" -- from [person] in #[channel] on [date]
+- "[quote/summary]", from [person] in #[channel] on [date]
 - [additional recognition]
 
 ## Evidence Gaps
-Areas where I found limited or no evidence -- you may want to gather more context:
+Areas where I found limited or no evidence. You may want to gather more context:
 - [ ] [Dimension]: [what's missing and where to look]
 - [ ] [Dimension]: [what's missing]
 
@@ -62,7 +62,7 @@ Before finalising the review, consider:
 
 # Batch Mode: Team Review Prep
 
-# Team Review Prep -- [Cycle Name]
+# Team Review Prep: [Cycle Name]
 
 ## Evidence Readiness
 | Name | [Dimension 1] Evidence | [Dimension 2] Evidence | Values Evidence | Gaps to Fill |

--- a/plugins/people-management/skills/priority-planner/SKILL.md
+++ b/plugins/people-management/skills/priority-planner/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: priority-planner
-description: Helps managers cut through noise and identify their highest-leverage actions for the day or week. Aggregates signals from calendar, triage, team context, and OKRs/goals. Presents a suggested focus list grouped by urgency, importance, and investment -- the manager reviews and adjusts. Supports effective execution and prioritisation.
+description: Helps managers cut through noise and identify their highest-leverage actions for the day or week. Aggregates signals from calendar, triage, team context, and OKRs/goals. Presents a suggested focus list grouped by urgency, importance, and investment. The manager reviews and adjusts. Supports effective execution and prioritisation.
 ---
 
 # Priority Planner
 
-> **Principle: "You are responsible."** The skill proposes, the manager decides. This is not a task manager -- it's a thinking partner for prioritisation.
+> **Principle: "You are responsible."** The skill proposes, the manager decides. This is not a task manager. It's a thinking partner for prioritisation.
 
 Aggregates signals from multiple sources to surface the manager's highest-leverage actions.
 
@@ -28,7 +28,7 @@ Ask or infer whether this is a daily or weekly plan:
 
 ### 2. Load Goals
 
-Before gathering signals, load the manager's goals -- these are the lens through which everything gets prioritised.
+Before gathering signals, load the manager's goals. These are the lens through which everything gets prioritised.
 
 **From `manager-context/manager-goals.md`:**
 - The manager's own OKRs and goals
@@ -76,21 +76,21 @@ Pull from multiple sources:
 
 Group everything into three categories (inspired by Eisenhower):
 
-**🔴 Urgent -- Time-Sensitive Decisions**
+**🔴 Urgent: Time-Sensitive Decisions**
 Things where someone is blocked or a deadline is imminent:
 - Decisions only the manager can make
 - Escalations that need resolution today
 - Deadlines within 24-48 hours
 - Framework: Execution
 
-**🟡 Important -- High-Impact Work**
+**🟡 Important: High-Impact Work**
 Things that move OKRs and team goals forward:
 - Strategic work (planning, decision-making, alignment)
 - Cross-functional alignment needed
 - Customer-related actions that affect account health
 - Framework: Delegation & Execution
 
-**🟢 Invest -- Development & Strategic Thinking**
+**🟢 Invest: Development & Strategic Thinking**
 Things that compound over time but rarely feel urgent:
 - 1:1 preparation and development conversations
 - Team health check-ins
@@ -105,7 +105,7 @@ Read `references/output-template.md` for the full output template structure.
 ### 6. Present and Iterate
 
 ```
-Here's a suggested priority plan. This is a starting point -- adjust based on your judgment. Want me to:
+Here's a suggested priority plan. This is a starting point. Adjust based on your judgment. Want me to:
 - Move anything between categories?
 - Add something I missed?
 - Prep for any of these items?

--- a/plugins/people-management/skills/priority-planner/references/output-template.md
+++ b/plugins/people-management/skills/priority-planner/references/output-template.md
@@ -1,41 +1,41 @@
-# Priority Plan -- [Date/Week]
+# Priority Plan: [Date/Week]
 
 ## 🔴 Urgent (do today)
-1. **[Action]** -- [1-line why, with source link]
+1. **[Action]**: [1-line why, with source link]
    _[Who's waiting, deadline]_
-2. **[Action]** -- [why]
+2. **[Action]**: [why]
 
 ## 🟡 Important (this week)
-1. **[Action]** -- [1-line why, with source link]
+1. **[Action]**: [1-line why, with source link]
    _[Connects to OKR: "[OKR text]"]_
-2. **[Action]** -- [why]
+2. **[Action]**: [why]
 
 ## 🟢 Invest (make time for)
-1. **[Action]** -- [1-line why]
+1. **[Action]**: [1-line why]
    _[Framework: People Development]_
-2. **[Action]** -- [why]
+2. **[Action]**: [why]
 
 ## 🎯 Goal Alignment Check
 Map today's/this week's activities against the manager's goals to surface where energy is going vs. where it should go.
 
 | Goal / OKR | Status | This [day/week]'s activities that advance it | Gap? |
 |-------------|--------|----------------------------------------------|------|
-| [OKR 1] | [on track / behind / at risk] | [matching actions from above, or " -- " if none] | [yes/no] |
+| [OKR 1] | [on track / behind / at risk] | [matching actions from above, or "none" if none] | [yes/no] |
 | [OKR 2] | [status] | [matching actions] | [yes/no] |
 | [OKR 3] | [status] | [matching actions] | [yes/no] |
 
 **Reflection:**
 - **Well-covered:** [goals that have clear activity this period]
-- **Underserved:** [goals with no matching activity -- might need deliberate time]
-- **Drift risk:** [areas consuming significant time that don't connect to any goal -- worth questioning whether this is the right use of energy]
+- **Underserved:** [goals with no matching activity, might need deliberate time]
+- **Drift risk:** [areas consuming significant time that don't connect to any goal, worth questioning whether this is the right use of energy]
 
-💡 _[1-2 sentences of honest, direct reflection. E.g., "Most of your day is spent on urgent operational items. None of your top 3 OKRs have dedicated time this week -- consider blocking focus time for [specific goal]." or "Good alignment -- your 🟡 items directly advance OKR 2 and 3. OKR 1 could use attention next week."]_
+💡 _[1-2 sentences of honest, direct reflection. E.g., "Most of your day is spent on urgent operational items. None of your top 3 OKRs have dedicated time this week, consider blocking focus time for [specific goal]." or "Good alignment, your 🟡 items directly advance OKR 2 and 3. OKR 1 could use attention next week."]_
 
 ## Calendar Fit
 Here's how this maps to your day/week:
-- [Time block] -- Free: could use for [suggested urgent/important item]
-- [Meeting] -- Prep needed? [yes/no, link to /prep-meeting if yes]
-- [1:1 with Name] -- Prep available? [yes/no, link to /prep-one-on-one if no]
+- [Time block]: Free, could use for [suggested urgent/important item]
+- [Meeting]: Prep needed? [yes/no, link to /prep-meeting if yes]
+- [1:1 with Name]: Prep available? [yes/no, link to /prep-one-on-one if no]
 
 ## What I'd Deprioritise
 Based on what's on your plate, these could wait:

--- a/plugins/people-management/skills/setup/SKILL.md
+++ b/plugins/people-management/skills/setup/SKILL.md
@@ -5,7 +5,7 @@ description: "Interactive onboarding that discovers team structure, terminology,
 
 # Setup
 
-> **Principle: "You are responsible."** This skill discovers and proposes -- the manager validates and decides what's accurate.
+> **Principle: "You are responsible."** This skill discovers and proposes. The manager validates and decides what's accurate.
 
 Interactive onboarding that builds the foundation every other skill relies on. Crawls connected sources, extracts context, and validates with the manager before saving.
 
@@ -14,11 +14,11 @@ If any MCP connector is unavailable, follow the connector unavailability protoco
 ## Prerequisites
 
 Ensure these MCP connectors are available:
-- **Slack** -- team channels, messages, terminology
-- **Notion** -- performance docs, goals, team pages
-- **Google Drive** -- 1:1 docs, meeting notes, strategy docs
-- **Gmail** -- communication patterns
-- **Google Calendar** -- recurring meetings, team rhythms
+- **Slack**: team channels, messages, terminology
+- **Notion**: performance docs, goals, team pages
+- **Google Drive**: 1:1 docs, meeting notes, strategy docs
+- **Gmail**: communication patterns
+- **Google Calendar**: recurring meetings, team rhythms
 
 If any connector is missing, note it and proceed with what's available. Flag gaps at the end.
 
@@ -47,7 +47,7 @@ Present defaults (language, tone, file format, folder structure) and let the man
 Persist: `manager-context/output-preferences.md`
 
 ### Phase 5: Manager's Own Context
-Capture upward context -- OKRs, who they report to, key deadlines.
+Capture upward context: OKRs, who they report to, key deadlines.
 
 Persist: `manager-context/manager-goals.md`
 
@@ -85,6 +85,6 @@ When called with `--refresh`:
 
 Read `../../references/operating-principles.md` for shared principles (data scope, DM flagging, connector unavailability).
 
-- **Never assume -- always validate.** If something looks like a team member but you're not sure, ask.
+- **Never assume, always validate.** If something looks like a team member but you're not sure, ask.
 - **Flag gaps explicitly.** "I couldn't find X" is more useful than silently skipping it.
 - **Stale data is worse than no data.** Always check recency and flag anything older than ~2 months.

--- a/plugins/people-management/skills/setup/references/context-templates.md
+++ b/plugins/people-management/skills/setup/references/context-templates.md
@@ -1,6 +1,6 @@
 # Manager Context File Templates
 
-Templates for all files persisted during manager setup. Each template shows the expected structure -- fill in validated data from discovery phases.
+Templates for all files persisted during manager setup. Each template shows the expected structure. Fill in validated data from discovery phases.
 
 ## `manager-context/output-preferences.md`
 
@@ -11,7 +11,7 @@ Templates for all files persisted during manager setup. Each template shows the 
 
 ## General Style
 - Language: English
-- Tone: Professional, concise -- bullet points over prose
+- Tone: Professional, concise, bullet points over prose
 - Detail level: Moderate (summaries with source links)
 - Emoji: Yes (for visual scanning in triage/priorities)
 
@@ -94,14 +94,14 @@ Templates for all files persisted during manager setup. Each template shows the 
 ### [Dimension 1 Name, e.g., Results]
 [Description]
 
-- **[Competency]** -- [what it looks like]
-- **[Competency]** -- [what it looks like]
+- **[Competency]**: [what it looks like]
+- **[Competency]**: [what it looks like]
 
 ### [Dimension 2 Name, e.g., People]
 [Description]
 
-- **[Competency]** -- [what it looks like]
-- **[Competency]** -- [what it looks like]
+- **[Competency]**: [what it looks like]
+- **[Competency]**: [what it looks like]
 
 ## How Managers Are Evaluated
 - [Separate management track / same framework as ICs / informal]
@@ -129,7 +129,7 @@ Templates for all files persisted during manager setup. Each template shows the 
 - [Goal 3]
 
 ## Upcoming Milestones
-- [milestone] -- [date]
+- [milestone]: [date]
 
 ## Notes
 - [Any context about what's being measured, org priorities, etc.]
@@ -142,7 +142,7 @@ Templates for all files persisted during manager setup. Each template shows the 
 
 **Last updated:** [date]
 
-## VIP -- Always Surface
+## VIP: Always Surface
 | Who | Why |
 |-----|-----|
 | [name] | [manager / key stakeholder / customer champion] |
@@ -195,7 +195,7 @@ Templates for all files persisted during manager setup. Each template shows the 
 
 ## 1:1 Style
 - Format: [structured / free-flow / hybrid]
-- Always include: [goals check, wins, blockers, development -- whatever they said]
+- Always include: [goals check, wins, blockers, development, whatever they said]
 - Share prep with report: [yes / no]
 - Notes: [any other preferences]
 

--- a/plugins/people-management/skills/setup/references/discovery-phases.md
+++ b/plugins/people-management/skills/setup/references/discovery-phases.md
@@ -1,4 +1,4 @@
-# Discovery Phases -- Detailed Instructions
+# Discovery Phases: Detailed Instructions
 
 Detailed crawl instructions, conversation prompts, and validation formats for each setup phase.
 
@@ -29,7 +29,7 @@ Search for the manager's team across sources:
 - Pages with the manager's name or team name
 
 **Google Calendar:**
-- Recurring 1:1 meetings -- attendees are likely direct reports
+- Recurring 1:1 meetings (attendees are likely direct reports)
 - Team syncs, standups, regular meetings
 
 **Gmail:**
@@ -41,14 +41,14 @@ For each person, gather: full name, Slack handle, role/title, how they were disc
 
 Present findings. If connectors were available, show how each person was discovered. If connectors were unavailable, ask the manager to provide the team list directly.
 
-For each team member, also ask for their **Slack handle** -- this is needed for searching messages and mapping activity later.
+For each team member, also ask for their **Slack handle**, which is needed for searching messages and mapping activity later.
 
 ```
 I found these people who appear to be your direct reports:
 
-1. [Name] -- @[slack-handle], [role], found via [1:1 calendar + Slack #team-channel]
-2. [Name] -- @[slack-handle], [role], found via [Slack DMs + Notion team page]
-3. [Name] -- @[slack-handle], [role], found via [Slack channel only -- unsure if direct report]
+1. [Name], @[slack-handle], [role], found via [1:1 calendar + Slack #team-channel]
+2. [Name], @[slack-handle], [role], found via [Slack DMs + Notion team page]
+3. [Name], @[slack-handle], [role], found via [Slack channel only, unsure if direct report]
 
 Are these correct? Anyone missing? Anyone who shouldn't be on this list?
 For anyone I'm missing a Slack handle, what is it?
@@ -95,9 +95,9 @@ For each team member, search:
 
 Report per person:
 ```
-✅ [Name] -- Found goals in Notion, 1:1 doc in Drive, last review [date]
-⚠️ [Name] -- Found 1:1 doc but NO goals. Where do you track these?
-❌ [Name] -- Couldn't find any performance data. Where should I look?
+✅ [Name]: Found goals in Notion, 1:1 doc in Drive, last review [date]
+⚠️ [Name]: Found 1:1 doc but NO goals. Where do you track these?
+❌ [Name]: Couldn't find any performance data. Where should I look?
 ```
 
 If goals are missing, explicitly ask where they're documented.
@@ -112,7 +112,7 @@ I couldn't search your tools, so I need a few things to make the skills useful:
 4. **For each team member, do you know their current development areas or goals?**
    - [Name]: [goals / development focus / "will gather in 1:1"]
 
-Even rough answers help -- I'll fill in the details when connectors become available.
+Even rough answers help. I'll fill in the details when connectors become available.
 ```
 
 ### 1.6 Discover Ways of Working
@@ -157,8 +157,8 @@ For customer-facing teams, also discover:
 Present:
 ```
 Active accounts/projects:
-- [Customer] -- [team member] is primary, channel: #proj-[name]
-- [Project] -- Internal, [team member] is leading
+- [Customer]: [team member] is primary, channel: #proj-[name]
+- [Project]: Internal, [team member] is leading
 
 Any accounts I'm missing?
 ```
@@ -167,7 +167,7 @@ Any accounts I'm missing?
 
 ## Phase 2: Performance & Management Frameworks
 
-Discover how the org evaluates individual performance and management effectiveness. This is critical -- the performance framework shapes how 1:1 prep, team health, and performance cycle skills organise their output.
+Discover how the org evaluates individual performance and management effectiveness. This is critical. The performance framework shapes how 1:1 prep, team health, and performance cycle skills organise their output.
 
 ### 2.1 Crawl for Existing Framework Docs
 
@@ -177,7 +177,7 @@ Before asking the manager, search for existing documentation:
 
 **Google Drive:** Search for docs matching: "performance review template", "review guide", "career framework", "leveling guide", "management expectations".
 
-**Slack:** Search for recent messages mentioning: "review cycle", "calibration", "promotion", "performance review" -- these often link to framework docs.
+**Slack:** Search for recent messages mentioning: "review cycle", "calibration", "promotion", "performance review", as these often link to framework docs.
 
 For each document found, extract:
 - Framework dimension names and descriptions
@@ -193,8 +193,8 @@ If framework docs were found, present what was extracted:
 I found your org's performance framework! Here's what I extracted:
 
 **Performance dimensions:**
-1. [Dimension name] -- [description, sub-dimensions]
-2. [Dimension name] -- [description, sub-dimensions]
+1. [Dimension name]: [description, sub-dimensions]
+2. [Dimension name]: [description, sub-dimensions]
 
 **Rating scale:** [extracted labels]
 **Promotion tracking:** [extracted labels / not found]
@@ -205,21 +205,21 @@ Is this accurate? Anything missing or outdated?
 
 If NO framework docs were found, walk through building it:
 ```
-I couldn't find a documented performance framework. Let's set one up -- I'll ask a few questions and you can tell me what your org uses. If you're unsure on anything, I have sensible defaults.
+I couldn't find a documented performance framework. Let's set one up. I'll ask a few questions and you can tell me what your org uses. If you're unsure on anything, I have sensible defaults.
 
 **1. How does your org evaluate performance?**
 Most orgs use 2-3 dimensions. Common patterns:
-- **Results + Growth** -- what someone delivered AND how they're developing
-- **What + How** -- outcomes AND behaviours/values
-- **Single dimension** -- just overall performance rating
+- **Results + Growth:** what someone delivered AND how they're developing
+- **What + How:** outcomes AND behaviours/values
+- **Single dimension:** just overall performance rating
 
-What dimensions does your org use? (If unsure, I'll use "Impact" and "Growth" as defaults -- you can change these anytime.)
+What dimensions does your org use? (If unsure, I'll use "Impact" and "Growth" as defaults, you can change these anytime.)
 ```
 
 Wait for the manager's answer. Then continue:
 
 ```
-**2. Rating scale** -- how are people rated in reviews?
+**2. Rating scale:** how are people rated in reviews?
 Common patterns:
 - Descriptive labels (e.g., "Exceeds Expectations / Meets / Below")
 - Numbered scale (e.g., 1-5)
@@ -230,7 +230,7 @@ What does your org use?
 ```
 
 ```
-**3. Promotion readiness** -- does your org track this separately?
+**3. Promotion readiness:** does your org track this separately?
 Common patterns:
 - Labels like "Ready Now / Ready Soon / Not Yet"
 - Integrated into the rating (e.g., top rating = promotion-ready)
@@ -240,7 +240,7 @@ What does your org use? (Fine to skip if not applicable.)
 ```
 
 ```
-**4. Review cadence** -- when do formal reviews happen?
+**4. Review cadence:** when do formal reviews happen?
 - Annual (once a year)
 - Bi-annual (twice a year, e.g., summer + winter)
 - Quarterly
@@ -250,7 +250,7 @@ And are there lighter check-ins between full reviews?
 ```
 
 ```
-**5. Goal cadence** -- how often are goals set and reviewed?
+**5. Goal cadence:** how often are goals set and reviewed?
 - Quarterly (OKRs or similar)
 - Half-yearly
 - Annually
@@ -264,12 +264,12 @@ For each answer, confirm understanding and note any sub-dimensions or nuances th
 If management-specific docs were found in 2.1, present them. Otherwise:
 
 ```
-**6. Management expectations** -- does your org have a formal model for what makes a good manager?
+**6. Management expectations:** does your org have a formal model for what makes a good manager?
 
 Common patterns:
 - **Two-dimensional:** driving results AND developing people
 - **Competency model:** specific skills like delegation, communication, hiring, coaching
-- **No formal model** -- that's fine, we'll use sensible defaults (Results + People)
+- **No formal model:** that's fine, we'll use sensible defaults (Results + People)
 
 What does your org expect from managers? Are managers evaluated separately or on the same framework as ICs?
 ```
@@ -302,7 +302,7 @@ Wait for confirmation. Then persist to `manager-context/performance-framework.md
 
 ## Phase 3: Organizational Values
 
-Values tell skills *how* results should be delivered. They provide conversation threads beyond goals and deliverables -- especially valuable in 1:1 prep, team health, and performance reviews.
+Values tell skills *how* results should be delivered. They provide conversation threads beyond goals and deliverables, especially valuable in 1:1 prep, team health, and performance reviews.
 
 ### 3.1 Crawl for Values Documentation
 
@@ -320,9 +320,9 @@ If values docs were found, extract value names, descriptions, and any associated
 ```
 I found your org's values! Here's what I extracted:
 
-1. **[Value Name]** -- [description from doc]
-2. **[Value Name]** -- [description from doc]
-3. **[Value Name]** -- [description from doc]
+1. **[Value Name]:** [description from doc]
+2. **[Value Name]:** [description from doc]
+3. **[Value Name]:** [description from doc]
 
 Is this the current list? Any that are missing or outdated?
 ```
@@ -332,15 +332,15 @@ If NO values docs were found:
 I couldn't find documented company values. Does your organization have defined core values?
 
 If yes:
-1. What are they? (just list the names -- I'll help flesh them out)
+1. What are they? (just list the names, I'll help flesh them out)
 2. Where are they documented? (Notion page, handbook, website, etc.)
 
-If no -- that's fine. We can skip the values lens in skills, or you can define informal team values. You can always add values later by running /setup --refresh.
+If no, that's fine. We can skip the values lens in skills, or you can define informal team values. You can always add values later by running /setup --refresh.
 ```
 
 ### 3.3 Define Signals Per Value
 
-For each value, help the manager define what to look for. This is the key step -- generic value names are useless without signals.
+For each value, help the manager define what to look for. This is the key step. Generic value names are useless without signals.
 
 For each value, ask:
 ```
@@ -356,12 +356,12 @@ Let's make "[Value Name]" actionable for the skills. For each question, give me 
    (e.g., "we ask for examples of each value" or "it's part of the 'How' rating")
 
 4. **What's hard to see digitally?**
-   (e.g., empathy in person, trust-building, tone of voice -- these I'll flag for your own observation)
+   (e.g., empathy in person, trust-building, tone of voice, these I'll flag for your own observation)
 ```
 
 If the manager has many values (5+), offer to batch:
 ```
-You have [N] values -- want me to go through each one, or would you rather give me a quick summary of what signals matter most and I'll fill in the rest?
+You have [N] values. Want me to go through each one, or would you rather give me a quick summary of what signals matter most and I'll fill in the rest?
 ```
 
 ### 3.4 Validate & Persist
@@ -386,7 +386,7 @@ Persist to `manager-context/values.md`. Read `references/context-templates.md` f
 
 Present defaults and let the manager adjust:
 ```
-How should I produce and save outputs? Defaults -- adjust anything:
+How should I produce and save outputs? Defaults (adjust anything):
 
 **Style:** English, professional/concise, moderate detail, emoji for visual scanning
 **File format:** Markdown (.md)
@@ -422,10 +422,10 @@ Persist to `manager-context/manager-goals.md`.
 ```
 Let's set up your triage rules:
 
-1. **VIP people** -- whose messages always bubble to the top?
-2. **Hot channels or topics** -- channels/keywords that always mean urgent?
-3. **Deprioritise** -- anything to push to the bottom?
-4. **Privacy boundaries** -- channels, people, or topics to skip entirely?
+1. **VIP people:** whose messages always bubble to the top?
+2. **Hot channels or topics:** channels/keywords that always mean urgent?
+3. **Deprioritise:** anything to push to the bottom?
+4. **Privacy boundaries:** channels, people, or topics to skip entirely?
 ```
 
 Persist to `manager-context/triage-rules.md`. The triage-messages and priority-planner skills must read and apply these rules.
@@ -481,10 +481,10 @@ Flag anything stale:
 ```
 Staleness alerts:
 
-- [Name]'s goals were last updated 4 months ago -- still current?
-- The "Q4 OKRs" page hasn't been edited since November -- have new OKRs been set?
-- [Name] hasn't been active in #[channel] for 3 weeks -- still on the project?
-- Your 1:1 with [Name] was cancelled 3 times in a row -- intentional?
+- [Name]'s goals were last updated 4 months ago. Still current?
+- The "Q4 OKRs" page hasn't been edited since November. Have new OKRs been set?
+- [Name] hasn't been active in #[channel] for 3 weeks. Still on the project?
+- Your 1:1 with [Name] was cancelled 3 times in a row. Intentional?
 ```
 
 Ask the manager to confirm or update each flagged item.

--- a/plugins/people-management/skills/team-health/SKILL.md
+++ b/plugins/people-management/skills/team-health/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: team-health
-description: "Periodic check on team dynamics, engagement signals, and development trajectory for all direct reports. Surfaces patterns across the team -- who might need more challenge, who might need more support, who hasn't had a 1:1 recently. Uses two universal lenses: performance & growth, and wellbeing & connection. Outputs are prompts for reflection, not diagnoses."
+description: "Periodic check on team dynamics, engagement signals, and development trajectory for all direct reports. Surfaces patterns across the team: who might need more challenge, who might need more support, who hasn't had a 1:1 recently. Uses two universal lenses: performance & growth, and wellbeing & connection. Outputs are prompts for reflection, not diagnoses."
 ---
 
 # Team Health Check
@@ -23,9 +23,9 @@ If any MCP connector is unavailable, follow the connector unavailability protoco
 ### 1. Load Team Context
 
 Read from `manager-context/`:
-- `manager-profile.md` -- full list of direct reports
-- `team/` -- individual profiles with goals, projects, last review dates
-- `sources.md` -- channels and data locations per team member
+- `manager-profile.md`: full list of direct reports
+- `team/`: individual profiles with goals, projects, last review dates
+- `sources.md`: channels and data locations per team member
 
 If context is missing, note it and work with available sources.
 
@@ -52,13 +52,13 @@ For each direct report, gather data from the last 14 days (or since last health 
 
 **Workload Signals (Calendar + Slack):**
 - Meeting load (heavy/normal/light for their role)
-- Are they in channels/meetings outside their usual scope? (scope expansion -- could be good or concerning)
+- Are they in channels/meetings outside their usual scope? (scope expansion, could be good or concerning)
 
 **Wellbeing & Connection Signals (Slack + Calendar):**
 - Energy & wellbeing: late-night messages, weekend activity, signs of overwork
 - Connection: are they participating in non-work channels (#random, social threads, team celebrations)?
 - Celebration: have they been recognised or praised recently? Have they celebrated others?
-- Tone: are their messages upbeat, neutral, or showing signs of frustration/fatigue? (use as a soft signal only -- never diagnose)
+- Tone: are their messages upbeat, neutral, or showing signs of frustration/fatigue? (use as a soft signal only, never diagnose)
 - Fun & enjoyment: any signs of passion, enthusiasm, or joy in their work (shipping excitement, sharing wins, volunteering for things)?
 
 ### 3. Synthesise Per Person
@@ -66,23 +66,23 @@ For each direct report, gather data from the last 14 days (or since last health 
 For each team member, produce a brief profile covering both lenses:
 
 ```
-### [Name] -- [Role]
+### [Name]: [Role]
 
 **🎯 Development & Performance:**
-**Activity:** [Normal / Increased / Decreased] -- [1-line evidence]
+**Activity:** [Normal / Increased / Decreased], [1-line evidence]
 **Recent wins:** [list any, or "None surfaced"]
-**Goals:** [last updated date] -- [current / stale]
-**Development focus:** [area from goals] -- [evidence of progress / no visible progress]
-**Growth signals:** [scope expansion, new skills, leadership behaviours -- or "None"]
+**Goals:** [last updated date], [current / stale]
+**Development focus:** [area from goals], [evidence of progress / no visible progress]
+**Growth signals:** [scope expansion, new skills, leadership behaviours, or "None"]
 
 **🫂 Wellbeing & Connection:**
-**Energy:** [Balanced / High output / Signs of overwork] -- [evidence, e.g., "messages after 22:00 on 3 nights"]
+**Energy:** [Balanced / High output / Signs of overwork], [evidence, e.g., "messages after 22:00 on 3 nights"]
 **Connection:** [Active in social channels / Quiet / Only work-related activity]
-**Celebrated/been celebrated:** [yes -- details / not recently]
-**Tone:** [Positive / Neutral / Worth checking in] -- [soft signal only]
+**Celebrated/been celebrated:** [yes, details / not recently]
+**Tone:** [Positive / Neutral / Worth checking in], [soft signal only]
 
-**Last 1:1:** [date] -- [on track / overdue]
-**Signals to explore:** [friction, blockers, wellbeing patterns -- or "None"]
+**Last 1:1:** [date], [on track / overdue]
+**Signals to explore:** [friction, blockers, wellbeing patterns, or "None"]
 ```
 
 ### 4. Surface Team-Level Patterns
@@ -110,7 +110,7 @@ Read `references/output-template.md` for the full output template structure.
 ### 6. Present
 
 ```
-Here's your team health check. These are signals for your reflection -- you know your people better than any tool.
+Here's your team health check. These are signals for your reflection. You know your people better than any tool.
 
 Want me to prep a 1:1 for anyone specific?
 ```
@@ -118,11 +118,11 @@ Want me to prep a 1:1 for anyone specific?
 ### 7. Sub-Agent Review
 
 Spawn a sub-agent to review the health check with fresh eyes. The reviewer should:
-- Check that **both lenses** (Development & Performance and Wellbeing & Connection) are meaningfully covered -- neither should be thin or skipped.
-- Check for **baseline awareness** -- are signals calibrated against known baselines, or is normal behaviour being flagged?
+- Check that **both lenses** (Development & Performance and Wellbeing & Connection) are meaningfully covered. Neither should be thin or skipped.
+- Check for **baseline awareness**: are signals calibrated against known baselines, or is normal behaviour being flagged?
 - Verify that language stays in "signal" territory, never crossing into diagnosis ("seems disengaged", "is struggling").
-- Check that **celebration and recognition** are given adequate weight -- not just problem-flagging.
-- Flag any team member who appears to have very thin data -- the manager should know where the blind spots are.
+- Check that **celebration and recognition** are given adequate weight, not just problem-flagging.
+- Flag any team member who appears to have very thin data. The manager should know where the blind spots are.
 
 Incorporate the reviewer's feedback before presenting the final health check to the manager.
 
@@ -132,7 +132,7 @@ Read `../../references/operating-principles.md` for shared operating principles 
 
 Additional notes specific to this skill:
 - **Celebrate first.** Lead with wins, recognition, and positive energy. Wellbeing & Connection starts with seeing the good.
-- **Both lenses, every time.** Don't skip Wellbeing & Connection when the team is performing well -- high performance without care leads to burnout. Don't skip Development & Performance when someone is struggling -- care without growth isn't enough.
-- **Goals are the anchor for growth.** The most actionable Development & Performance insight is usually about development goals -- are they current? Is there visible progress?
-- **Connection is the anchor for care.** The most actionable Wellbeing & Connection insight is usually about belonging -- does this person feel seen, celebrated, and connected?
+- **Both lenses, every time.** Don't skip Wellbeing & Connection when the team is performing well. High performance without care leads to burnout. Don't skip Development & Performance when someone is struggling. Care without growth isn't enough.
+- **Goals are the anchor for growth.** The most actionable Development & Performance insight is usually about development goals: are they current? Is there visible progress?
+- **Connection is the anchor for care.** The most actionable Wellbeing & Connection insight is usually about belonging: does this person feel seen, celebrated, and connected?
 - **Don't run too frequently.** Weekly or biweekly is ideal. Daily health checks would over-index on noise.

--- a/plugins/people-management/skills/team-health/references/output-template.md
+++ b/plugins/people-management/skills/team-health/references/output-template.md
@@ -1,13 +1,13 @@
-# Team Health Check -- [Date]
+# Team Health Check: [Date]
 Team: [N] direct reports | Period: last 14 days
 
 ## 🌟 Highlight
-[1-2 sentences on the most notable positive observation -- a win to celebrate, growth to recognise, or care to acknowledge]
+[1-2 sentences on the most notable positive observation: a win to celebrate, growth to recognise, or care to acknowledge]
 
 ## Per-Person Summary
 | Name | Activity | Energy | Last 1:1 | Goals | Flags |
 |------|----------|--------|----------|-------|-------|
-| [name] | ✅ Normal | ✅ Balanced | Mar 10 | Current | -- |
+| [name] | ✅ Normal | ✅ Balanced | Mar 10 | Current | (none) |
 | [name] | ⬆️ High | ⚠️ Late nights | Mar 8 | Current | 🌟 Scope expansion, Check energy |
 | [name] | ⬇️ Low | ✅ Balanced | Feb 24 | Stale (8w) | ⚠️ Overdue 1:1, stale goals |
 
@@ -15,15 +15,15 @@ Team: [N] direct reports | Period: last 14 days
 
 ### Development Goals
 - ✅ [N] team members have current goals
-- ⚠️ [Names] have goals last updated [date] -- time for a refresh
+- ⚠️ [Names] have goals last updated [date], time for a refresh
 
 ### Growth & Performance
 - 🌟 [Names] showing growth signals: [scope expansion, leadership, new skills]
-- ⚠️ [Names] showing decreased engagement -- worth exploring
+- ⚠️ [Names] showing decreased engagement, worth exploring
 
 ### 1:1 Cadence
 - ✅ [N] team members are on cadence
-- ⚠️ [Names] are overdue -- last 1:1 was [date]
+- ⚠️ [Names] are overdue, last 1:1 was [date]
 
 ## Wellbeing & Connection
 
@@ -34,20 +34,20 @@ Team: [N] direct reports | Period: last 14 days
 
 ### Connection & Belonging
 - ✅ [Names] active in social/team channels
-- ⚠️ [Names] only visible in work contexts -- may be fine, but worth a check-in
+- ⚠️ [Names] only visible in work contexts, may be fine, but worth a check-in
 - 💡 How connected does the team feel right now? Any new joiners who might need extra inclusion?
 
 ### Celebration
 - 🎉 [Names] received recognition this period
-- ⚠️ [Names] haven't been recognised recently -- consider acknowledging their work
+- ⚠️ [Names] haven't been recognised recently, consider acknowledging their work
 - 💡 Is the team celebrating enough? Wins, milestones, personal moments?
 
 ## Suggested Actions
 Based on these signals:
-1. **[Name]** -- [action, e.g., "Recognise their work on [project] in the team channel"] _(Wellbeing)_
-2. **[Name]** -- [action, e.g., "Check in on energy levels -- they've been online late 4 nights this week"] _(Wellbeing)_
-3. **[Name]** -- [action, e.g., "Schedule a 1:1 to refresh development goals"] _(Development & Performance)_
-4. **[Name]** -- [action, e.g., "Explore whether they're ready for more scope"] _(Development & Performance)_
+1. **[Name]**: [action, e.g., "Recognise their work on [project] in the team channel"] _(Wellbeing)_
+2. **[Name]**: [action, e.g., "Check in on energy levels, they've been online late 4 nights this week"] _(Wellbeing)_
+3. **[Name]**: [action, e.g., "Schedule a 1:1 to refresh development goals"] _(Development & Performance)_
+4. **[Name]**: [action, e.g., "Explore whether they're ready for more scope"] _(Development & Performance)_
 
 ## Reflection Prompts
 **Development & Performance:**
@@ -57,6 +57,6 @@ Based on these signals:
 
 **Wellbeing & Connection:**
 - Who on my team might need me to just ask "how are you, really?"
-- Am I celebrating enough -- not just big wins, but effort and progress?
+- Am I celebrating enough, not just big wins, but effort and progress?
 - Is anyone carrying too much quietly? What would I not see in Slack?
 - When was the last time we did something fun as a team?

--- a/plugins/people-management/skills/triage-messages/SKILL.md
+++ b/plugins/people-management/skills/triage-messages/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: triage-messages
-description: Batch-processes Slack messages and emails to surface what needs the manager's attention, categorised by urgency and type. Designed for batch-responder managers who do Slack sweeps rather than staying in reactive mode. Supports effective communication and responsiveness. Never drafts replies -- only surfaces and prioritises.
+description: Batch-processes Slack messages and emails to surface what needs the manager's attention, categorised by urgency and type. Designed for batch-responder managers who do Slack sweeps rather than staying in reactive mode. Supports effective communication and responsiveness. Never drafts replies, only surfaces and prioritises.
 ---
 
 # Triage Messages
@@ -11,7 +11,7 @@ Scans unread Slack messages and recent emails, categorises them by urgency and t
 
 ## When to Use
 
-- Morning routine -- catch up on what happened overnight
+- Morning routine: catch up on what happened overnight
 - After a block of focus time or meetings
 - When the manager says "what did I miss?", "catch me up", "triage my messages"
 - Can be scoped to a time window: "triage since yesterday", "triage last 2 hours"
@@ -22,7 +22,7 @@ If any MCP connector is unavailable, follow the connector unavailability protoco
 
 ### 1. Determine Time Window
 
-Default: since the manager's last likely check-in (use calendar to estimate -- if they were in back-to-back meetings for 3 hours, scan those 3 hours).
+Default: since the manager's last likely check-in (use calendar to estimate, if they were in back-to-back meetings for 3 hours, scan those 3 hours).
 
 If specified: use the provided time window.
 
@@ -38,10 +38,10 @@ What time period should I triage? Options:
 ### 2. Load Manager Context
 
 Read from `manager-context/` (if available):
-- `manager-profile.md` -- to know who the direct reports are (their messages get higher priority)
-- `terminology.md` -- to decode internal shorthand in messages
-- `team/` -- to understand team members' projects and responsibilities
-- `sources.md` -- to know which customer/project channels to monitor
+- `manager-profile.md`: to know who the direct reports are (their messages get higher priority)
+- `terminology.md`: to decode internal shorthand in messages
+- `team/`: to understand team members' projects and responsibilities
+- `sources.md`: to know which customer/project channels to monitor
 
 ### 3. Scan Slack
 

--- a/plugins/people-management/skills/triage-messages/references/output-template.md
+++ b/plugins/people-management/skills/triage-messages/references/output-template.md
@@ -1,9 +1,9 @@
-# Message Triage -- [Date], [Time Window]
+# Message Triage: [Date], [Time Window]
 
 ## 🔴 Needs Your Decision ([count])
 | Priority | From | Channel/Subject | Summary | Link |
 |----------|------|-----------------|---------|------|
-| 1 | [name] | #[channel] | [1-line summary -- what they need from you] | [link] |
+| 1 | [name] | #[channel] | [1-line summary: what they need from you] | [link] |
 
 ## 🟡 Team Member Needs ([count])
 | From | Channel/Subject | Summary | Link |


### PR DESCRIPTION
## Summary

- Replaces all ` -- ` (double dashes used as typographic separators) with proper punctuation across 39 files
- Uses colons for definitions/descriptions, periods for clause breaks, commas for lighter connections
- Does not touch CLI flags (like `--question-col`) or code syntax
- Also fixes the two remaining em dashes in `ensure-content-studio.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)