### PR TITLE
Add knowledge-base plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,6 +27,11 @@
       "name": "techwolf-brand-kit",
       "source": "./plugins/techwolf-brand-kit",
       "description": "Official TechWolf brand assets for AI-generated outputs. Provides logo files in multiple variants as SVG and PNG."
+    },
+    {
+      "name": "knowledge-base",
+      "source": "./plugins/knowledge-base",
+      "description": "Build and query a structured, evidence-backed knowledge base. Every answer cites literal quotes from your KB files."
     }
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,3 +22,4 @@ This repository publishes TechWolf AI-first plugins and skills for both Claude C
 - The installer also manages plugin metadata, verification, and uninstall state under `~/.codex/skills/.techwolf-ai-first/`.
 - `content-studio` has a plugin-level Codex entry skill in addition to its specialized skills.
 - `people-management` has 8 skills that require `/setup` to be run first to configure org-specific frameworks and context.
+- `knowledge-base` ships three Python helper scripts (`kb-index.py`, `kb-verify.py`, `kb-validate.py`) that are copied into the user's project by `/setup-knowledge-base`. The plugin's `/kb-answer` workflow depends on `kb-verify.py` existing in the project's `scripts/` directory.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog and this project follows Semantic Versioning.
 
+## [1.4.0] - 2026-04-20
+
+### Added
+
+- `knowledge-base` plugin: evidence-backed knowledge base creator. Every `/kb-answer` reply cites literal quotes from KB files, verified against the source.
+  - 4 skills: `setup-knowledge-base`, `kb-answer`, `kb-import`, `kb-refresh`.
+  - 3 scripts: `kb-index.py` (with `--write` to regenerate `kb/index.md` between markers), `kb-verify.py` (strict pass plus a normalized-match fallback for markdown and whitespace drift), `kb-validate.py` (frontmatter, category, date, and related-link health checks).
+  - Templates for setup scaffolding, a default scope, and a realistic sample entry.
+- Added `knowledge-base` to the marketplace manifest.
+- Added `knowledge-base` to the Codex installer.
+
 ## [1.3.0] - 2026-04-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TechWolf AI-First Toolkit
 
-![MIT License](https://img.shields.io/badge/license-MIT-blue.svg) ![v1.3.0](https://img.shields.io/badge/version-1.3.0-green.svg) ![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-blueviolet.svg) ![Codex](https://img.shields.io/badge/Codex-compatible-orange.svg) ![agentskills.io](https://img.shields.io/badge/agentskills.io-spec-lightgrey.svg)
+![MIT License](https://img.shields.io/badge/license-MIT-blue.svg) ![v1.4.0](https://img.shields.io/badge/version-1.4.0-green.svg) ![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-blueviolet.svg) ![Codex](https://img.shields.io/badge/Codex-compatible-orange.svg) ![agentskills.io](https://img.shields.io/badge/agentskills.io-spec-lightgrey.svg)
 
 Open-source Claude Code skills and Codex skills from [TechWolf](https://techwolf.ai)'s [AI-First Bootcamp](https://ai-first.techwolf.ai).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TechWolf AI-First Toolkit
 
-![MIT License](https://img.shields.io/badge/license-MIT-blue.svg) ![v1.2.0](https://img.shields.io/badge/version-1.2.0-green.svg) ![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-blueviolet.svg) ![Codex](https://img.shields.io/badge/Codex-compatible-orange.svg) ![agentskills.io](https://img.shields.io/badge/agentskills.io-spec-lightgrey.svg)
+![MIT License](https://img.shields.io/badge/license-MIT-blue.svg) ![v1.3.0](https://img.shields.io/badge/version-1.3.0-green.svg) ![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-blueviolet.svg) ![Codex](https://img.shields.io/badge/Codex-compatible-orange.svg) ![agentskills.io](https://img.shields.io/badge/agentskills.io-spec-lightgrey.svg)
 
 Open-source Claude Code skills and Codex skills from [TechWolf](https://techwolf.ai)'s [AI-First Bootcamp](https://ai-first.techwolf.ai).
 
@@ -33,6 +33,15 @@ AI-augmented tooling for people managers. Surfaces the right context at the righ
 - **8 skills**: meeting prep, 1:1 prep, triage, customer status, priority planner, team health, performance cycle
 - **Framework-agnostic**: configures to your org's performance dimensions, rating scale, management competencies, and values
 
+### knowledge-base: Evidence-Backed Knowledge Base
+
+Build and query a structured knowledge base where every answer cites literal quotes from your KB files. Prevents hallucinations by grounding all responses in documented facts.
+
+- **Setup**: interactive onboarding that defines categories, scaffolds the KB structure, and populates from your existing sources (Notion, Slack, Confluence, local files)
+- **KB Answer**: answer questions with evidence-backed citations from your KB
+- **KB Import**: import knowledge from documents (Markdown, PDF, plain text) into structured entries
+- **KB Refresh**: add new sources or re-scrape existing ones to keep the KB current
+
 ### techwolf-brand-kit: Brand Assets
 
 Official TechWolf brand assets for AI-generated outputs. Ensures agents use the correct logo files instead of guessing or approximating.
@@ -49,6 +58,7 @@ claude plugin marketplace add techwolf-ai/ai-first-toolkit
 claude plugin install ai-firstify@techwolf-ai-first
 claude plugin install content-studio@techwolf-ai-first
 claude plugin install people-management@techwolf-ai-first
+claude plugin install knowledge-base@techwolf-ai-first
 claude plugin install techwolf-brand-kit@techwolf-ai-first
 ```
 
@@ -61,6 +71,7 @@ Skills follow the [agentskills.io](https://agentskills.io) spec:
 ./install.sh ai-firstify
 ./install.sh content-studio
 ./install.sh people-management
+./install.sh knowledge-base
 ./install.sh techwolf-brand-kit
 ```
 
@@ -93,7 +104,8 @@ ai-first-toolkit/
 │   ├── ai-firstify/            # Auditor & re-engineer (1 skill, 9 reference docs)
 │   ├── content-studio/         # Content pipeline (8 skills, visual editor, hooks)
 │   ├── people-management/      # Management tooling (8 skills, 5 reference docs)
-│   └── techwolf-brand-kit/              # Brand assets (logo variants in SVG + PNG)
+│   ├── knowledge-base/         # Evidence-backed KB (4 skills, templates, index + verify scripts)
+│   └── techwolf-brand-kit/     # Brand assets (logo variants in SVG + PNG)
 ├── install.sh                  # Codex skill installer
 └── README.md
 ```
@@ -103,6 +115,7 @@ Each plugin lives in `plugins/<name>/` with a `.claude-plugin/` manifest and `sk
 - [ai-firstify README](plugins/ai-firstify/README.md)
 - [content-studio README](plugins/content-studio/README.md)
 - [people-management README](plugins/people-management/README.md)
+- [knowledge-base README](plugins/knowledge-base/README.md)
 - [techwolf-brand-kit README](plugins/techwolf-brand-kit/README.md)
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ AI-augmented tooling for people managers. Surfaces the right context at the righ
 
 Build and query a structured knowledge base where every answer cites literal quotes from your KB files. Prevents hallucinations by grounding all responses in documented facts.
 
-- **Setup**: interactive onboarding that defines categories, scaffolds the KB structure, and populates from your existing sources (Notion, Slack, Confluence, local files)
+- **Setup**: interactive onboarding that defines categories (flat or nested), scaffolds the KB structure, and populates from your existing sources (Notion, Slack, Confluence, local files)
 - **KB Answer**: answer questions with evidence-backed citations from your KB
-- **KB Import**: import knowledge from documents (Markdown, PDF, plain text) into structured entries
+- **KB Import**: import knowledge from documents (Markdown, PDF, plain text) into structured entries, single-document or bulk-from-folder
 - **KB Refresh**: add new sources or re-scrape existing ones to keep the KB current
+- **KB Search**: `kb-search.py` keyword-ranked lookup across title, tags, description, and body, with category and tag filters
 
 ### techwolf-brand-kit: Brand Assets
 

--- a/plugins/knowledge-base/.claude-plugin/plugin.json
+++ b/plugins/knowledge-base/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "knowledge-base",
+  "version": "1.0.0",
+  "description": "Build and query a structured, evidence-backed knowledge base with Claude Code. Every answer cites literal quotes from your KB files to prevent hallucinations.",
+  "author": { "name": "TechWolf" },
+  "keywords": ["knowledge-base", "kb", "evidence", "citations", "rfp"]
+}

--- a/plugins/knowledge-base/.claude-plugin/plugin.json
+++ b/plugins/knowledge-base/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "knowledge-base",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Build and query a structured, evidence-backed knowledge base with Claude Code. Every answer cites literal quotes from your KB files to prevent hallucinations.",
   "author": { "name": "TechWolf" },
-  "keywords": ["knowledge-base", "kb", "evidence", "citations", "rfp"]
+  "keywords": ["knowledge-base", "kb", "evidence", "citations", "rfp", "search"]
 }

--- a/plugins/knowledge-base/.gitignore
+++ b/plugins/knowledge-base/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.DS_Store

--- a/plugins/knowledge-base/CLAUDE.md
+++ b/plugins/knowledge-base/CLAUDE.md
@@ -1,0 +1,23 @@
+# Knowledge Base Plugin
+
+Build and query a structured, evidence-backed knowledge base.
+
+## Skills
+
+| Command | What it does |
+|---------|-------------|
+| `/setup-knowledge-base` | Interactive onboarding, run this first |
+| `/kb-answer` | Evidence-backed question answering |
+| `/kb-import` | Import documents into KB entries |
+| `/kb-refresh` | Add new sources or re-scrape existing ones |
+
+## Key Files
+
+- `scripts/kb-index.py`: lists all KB files with descriptions; with `--write` regenerates `kb/index.md`'s "All Files by Category" section in place
+- `scripts/kb-verify.py`: verifies that answer citations exist in KB files; normalized-match fallback tolerates markdown/whitespace drift, `--strict` disables it
+- `scripts/kb-validate.py`: checks KB health (frontmatter, categories, dates, related-link resolution)
+- `templates/`: starter files copied into user projects during setup
+
+## Runtime Data
+
+All KB content lives in the user's project (not in this plugin directory).

--- a/plugins/knowledge-base/CLAUDE.md
+++ b/plugins/knowledge-base/CLAUDE.md
@@ -13,9 +13,10 @@ Build and query a structured, evidence-backed knowledge base.
 
 ## Key Files
 
-- `scripts/kb-index.py`: lists all KB files with descriptions; with `--write` regenerates `kb/index.md`'s "All Files by Category" section in place
-- `scripts/kb-verify.py`: verifies that answer citations exist in KB files; normalized-match fallback tolerates markdown/whitespace drift, `--strict` disables it
-- `scripts/kb-validate.py`: checks KB health (frontmatter, categories, dates, related-link resolution)
+- `scripts/kb-index.py`: lists all KB files with descriptions; `--write` regenerates `kb/index.md`'s "All Files by Category" section in place; supports nested category trees
+- `scripts/kb-verify.py`: verifies that answer citations exist in KB files; supports single-line and multi-line `> "..."` blocks; normalized-match fallback tolerates markdown/whitespace drift, `--strict` disables it
+- `scripts/kb-validate.py`: checks KB health (frontmatter, categories incl. nested, dates, related-link resolution); `--max-age N` warns on entries older than N days
+- `scripts/kb-search.py`: keyword search across title/tags/description/body with category and tag filters; `--json` for machine-readable output
 - `templates/`: starter files copied into user projects during setup
 
 ## Runtime Data

--- a/plugins/knowledge-base/README.md
+++ b/plugins/knowledge-base/README.md
@@ -57,20 +57,32 @@ Optional context profiles that customize answers. For example, a "enterprise-cus
 
 ```
 kb/
-  .kb-config.yaml       # Category definitions
+  .kb-config.yaml       # Category definitions (flat or nested)
   index.md              # Central navigation index
   scopes/               # Context profiles
     _default.yaml
-  security/             # Category directories
+  security/             # Top-level category directory
     data-encryption.md
     certifications.md
+    access/             # Nested sub-category (optional)
+      mfa.md
+      sso.md
   technical/
     product-overview.md
   ...
 scripts/
-  kb-index.py           # Lists all KB files; --write regenerates index.md
-  kb-verify.py          # Verifies answer citations (strict + normalized-match fallback)
-  kb-validate.py        # Checks frontmatter, categories, and related-link resolution
+  kb-index.py           # Lists all KB files; --write regenerates index.md (nested-aware)
+  kb-verify.py          # Verifies answer citations (single- and multi-line, strict + normalized-match fallback)
+  kb-validate.py        # Checks frontmatter, categories (incl. nested), related-link resolution; --max-age N warns on stale entries
+  kb-search.py          # Keyword search across title, tags, description, body; filter by category/tag
+```
+
+## Searching
+
+```bash
+python3 scripts/kb-search.py "encryption"
+python3 scripts/kb-search.py "MFA" --category security
+python3 scripts/kb-search.py "breach" --tag incident --limit 5
 ```
 
 ## License

--- a/plugins/knowledge-base/README.md
+++ b/plugins/knowledge-base/README.md
@@ -1,0 +1,78 @@
+# Knowledge Base Plugin
+
+Build and query a structured, evidence-backed knowledge base with Claude Code.
+
+## Why
+
+LLMs hallucinate. When answering questions about your product, company, or domain, you need answers grounded in documented facts, not general knowledge. This plugin creates a knowledge base where every answer must cite literal quotes from your KB files.
+
+## Skills
+
+| Skill | What it does |
+|-------|-------------|
+| `/setup-knowledge-base` | Interactive onboarding: define categories, scaffold the KB structure, create the index |
+| `/kb-answer` | Answer questions with evidence-backed citations from your KB |
+| `/kb-import` | Import knowledge from existing documents (Markdown, PDF, plain text) into structured KB entries |
+| `/kb-refresh` | Add new sources (Notion, Slack, Confluence, local files) or re-scrape existing ones to pick up changes |
+
+## Getting Started
+
+1. Install the plugin via Claude Code marketplace or `./install.sh knowledge-base`
+2. Run `/setup-knowledge-base` in your project
+3. Add entries to `kb/` or import existing docs with `/kb-import`
+4. Query with `/kb-answer What encryption do we use?`
+
+## How It Works
+
+### KB Entries
+
+Markdown files with YAML frontmatter, organized by category:
+
+```markdown
+---
+title: "Data Encryption"
+description: "AES-256 at rest, TLS 1.2+ in transit"
+category: security
+tags: [encryption, aes, tls]
+last_updated: "2026-04-10"
+---
+
+All data is encrypted at rest using AES-256-GCM.
+Data in transit is protected with TLS 1.2 or higher.
+```
+
+### Evidence-Grounded Answers
+
+When you ask `/kb-answer`, the skill:
+1. Navigates the KB index to find relevant files
+2. Reads the files and extracts supporting evidence
+3. Formulates an answer citing literal quotes
+4. Flags when information is missing from the KB
+
+### Scopes
+
+Optional context profiles that customize answers. For example, a "enterprise-customer" scope can emphasize security certifications while excluding self-serve pricing.
+
+## Directory Structure
+
+```
+kb/
+  .kb-config.yaml       # Category definitions
+  index.md              # Central navigation index
+  scopes/               # Context profiles
+    _default.yaml
+  security/             # Category directories
+    data-encryption.md
+    certifications.md
+  technical/
+    product-overview.md
+  ...
+scripts/
+  kb-index.py           # Lists all KB files; --write regenerates index.md
+  kb-verify.py          # Verifies answer citations (strict + normalized-match fallback)
+  kb-validate.py        # Checks frontmatter, categories, and related-link resolution
+```
+
+## License
+
+[MIT](../../LICENSE)

--- a/plugins/knowledge-base/codex/AGENTS.md
+++ b/plugins/knowledge-base/codex/AGENTS.md
@@ -15,6 +15,8 @@ Build and query a structured, evidence-backed knowledge base. Every answer cites
 - **Evidence grounding**: Answers must cite literal quotes from KB files
 - **Scopes**: Optional context profiles that customize which KB content is relevant
 - **Index**: Central navigation file for fast KB lookup
+- **Nested categories**: Categories can be flat (`security`) or nested (`security/access`) to match folder structure
+- **Search**: `scripts/kb-search.py "keyword"` ranks entries by title/tags/description/body; supports `--category` and `--tag` filters
 
 ## Getting Started
 

--- a/plugins/knowledge-base/codex/AGENTS.md
+++ b/plugins/knowledge-base/codex/AGENTS.md
@@ -1,0 +1,21 @@
+# Knowledge Base Plugin
+
+Build and query a structured, evidence-backed knowledge base. Every answer cites literal quotes from KB files.
+
+## Skills
+
+- `/setup-knowledge-base`: Interactive onboarding to create your KB structure
+- `/kb-answer`: Answer questions with evidence-backed citations from your KB
+- `/kb-import`: Import knowledge from existing documents into KB entries
+- `/kb-refresh`: Add new sources or re-scrape existing ones to pick up changes
+
+## Key Concepts
+
+- **KB entries**: Markdown files with YAML frontmatter (title, description, category, tags)
+- **Evidence grounding**: Answers must cite literal quotes from KB files
+- **Scopes**: Optional context profiles that customize which KB content is relevant
+- **Index**: Central navigation file for fast KB lookup
+
+## Getting Started
+
+Run `/setup-knowledge-base` to create your KB structure. The setup will ask what your KB is for, define categories, and scaffold the directory structure.

--- a/plugins/knowledge-base/scripts/kb-index.py
+++ b/plugins/knowledge-base/scripts/kb-index.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""List all KB files with their descriptions, grouped by category.
+
+Usage:
+    python3 scripts/kb-index.py              # print to stdout
+    python3 scripts/kb-index.py --write      # also rewrite kb/index.md in place
+    python3 scripts/kb-index.py [kb_path]    # point at a different kb/ directory
+
+With --write, the "All Files by Category" section of kb/index.md is regenerated
+between the markers:
+
+    <!-- kb-index:start -->
+    ...generated content...
+    <!-- kb-index:end -->
+
+If the markers are missing, they are appended at the end of the file.
+"""
+
+import sys
+from pathlib import Path
+
+
+START_MARKER = "<!-- kb-index:start -->"
+END_MARKER = "<!-- kb-index:end -->"
+
+
+def find_kb_path(args: list[str]) -> Path:
+    positional = [a for a in args if not a.startswith("--")]
+    if positional:
+        p = Path(positional[0])
+        if p.is_dir():
+            return p
+        print(f"Error: {p} is not a directory", file=sys.stderr)
+        sys.exit(1)
+    cwd_kb = Path.cwd() / "kb"
+    if cwd_kb.is_dir():
+        return cwd_kb
+    print("Error: no kb/ directory found in current directory.", file=sys.stderr)
+    print("Usage: python3 scripts/kb-index.py [--write] [kb_path]", file=sys.stderr)
+    sys.exit(1)
+
+
+def extract_frontmatter(filepath: Path) -> dict:
+    content = filepath.read_text(encoding="utf-8")
+    if not content.startswith("---"):
+        return {}
+    end = content.find("---", 3)
+    if end == -1:
+        return {}
+    result = {}
+    for line in content[3:end].strip().split("\n"):
+        if ":" in line:
+            key, _, value = line.partition(":")
+            key = key.strip()
+            value = value.strip().strip('"').strip("'")
+            if key in ("title", "description", "category"):
+                result[key] = value
+    return result
+
+
+def collect_entries(kb_path: Path) -> list[dict]:
+    files = []
+    for md_file in sorted(kb_path.rglob("*.md")):
+        if md_file.name in ("index.md", "README.md"):
+            continue
+        rel_path = md_file.relative_to(kb_path)
+        category = rel_path.parts[0] if len(rel_path.parts) > 1 else "root"
+        meta = extract_frontmatter(md_file)
+        files.append({
+            "path": str(rel_path),
+            "category": meta.get("category", category),
+            "title": meta.get("title", md_file.stem),
+            "description": meta.get("description", "No description"),
+        })
+    return files
+
+
+def group_by_category(files: list[dict]) -> dict:
+    by_category = {}
+    for f in files:
+        by_category.setdefault(f["category"], []).append(f)
+    for cat in by_category:
+        by_category[cat].sort(key=lambda x: x["path"])
+    return by_category
+
+
+def format_stdout(by_category: dict) -> str:
+    lines = []
+    for category in sorted(by_category):
+        lines.append(f"\n## {category}/")
+        for f in by_category[category]:
+            lines.append(f"  {f['path']}")
+            lines.append(f"    {f['description']}")
+    return "\n".join(lines).lstrip("\n")
+
+
+def format_markdown(by_category: dict) -> str:
+    lines = [START_MARKER, "", "## All Files by Category", ""]
+    for category in sorted(by_category):
+        lines.append(f"### {category}/")
+        for f in by_category[category]:
+            lines.append(f"- `{f['path']}` — {f['description']}")
+        lines.append("")
+    lines.append(END_MARKER)
+    return "\n".join(lines)
+
+
+def write_index(kb_path: Path, rendered: str) -> Path:
+    index_path = kb_path / "index.md"
+    if not index_path.exists():
+        index_path.write_text(rendered + "\n", encoding="utf-8")
+        return index_path
+    existing = index_path.read_text(encoding="utf-8")
+    if START_MARKER in existing and END_MARKER in existing:
+        before = existing.split(START_MARKER)[0].rstrip() + "\n\n"
+        after = existing.split(END_MARKER, 1)[1].lstrip("\n")
+        new = before + rendered + ("\n\n" + after if after else "\n")
+    else:
+        new = existing.rstrip() + "\n\n" + rendered + "\n"
+    index_path.write_text(new, encoding="utf-8")
+    return index_path
+
+
+def main():
+    args = sys.argv[1:]
+    write = "--write" in args
+
+    kb_path = find_kb_path(args)
+    files = collect_entries(kb_path)
+
+    if not files:
+        print("No KB entries found. Add .md files with YAML frontmatter to kb/.")
+        return
+
+    by_category = group_by_category(files)
+    print(format_stdout(by_category))
+
+    if write:
+        rendered = format_markdown(by_category)
+        index_path = write_index(kb_path, rendered)
+        print()
+        print(f"Wrote index to {index_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/knowledge-base/scripts/kb-index.py
+++ b/plugins/knowledge-base/scripts/kb-index.py
@@ -6,6 +6,10 @@ Usage:
     python3 scripts/kb-index.py --write      # also rewrite kb/index.md in place
     python3 scripts/kb-index.py [kb_path]    # point at a different kb/ directory
 
+Supports nested categories: an entry at kb/security/access/mfa.md is grouped
+under category "security/access" if its frontmatter category matches, or
+under the folder path otherwise. Nested groups render as an indented tree.
+
 With --write, the "All Files by Category" section of kb/index.md is regenerated
 between the markers:
 
@@ -58,25 +62,31 @@ def extract_frontmatter(filepath: Path) -> dict:
     return result
 
 
+def folder_category(rel_path: Path) -> str:
+    if rel_path.parent == Path("."):
+        return "root"
+    return str(rel_path.parent).replace("\\", "/")
+
+
 def collect_entries(kb_path: Path) -> list[dict]:
     files = []
     for md_file in sorted(kb_path.rglob("*.md")):
         if md_file.name in ("index.md", "README.md"):
             continue
         rel_path = md_file.relative_to(kb_path)
-        category = rel_path.parts[0] if len(rel_path.parts) > 1 else "root"
         meta = extract_frontmatter(md_file)
+        category = meta.get("category") or folder_category(rel_path)
         files.append({
-            "path": str(rel_path),
-            "category": meta.get("category", category),
+            "path": str(rel_path).replace("\\", "/"),
+            "category": category,
             "title": meta.get("title", md_file.stem),
             "description": meta.get("description", "No description"),
         })
     return files
 
 
-def group_by_category(files: list[dict]) -> dict:
-    by_category = {}
+def group_by_category(files: list[dict]) -> dict[str, list[dict]]:
+    by_category: dict[str, list[dict]] = {}
     for f in files:
         by_category.setdefault(f["category"], []).append(f)
     for cat in by_category:
@@ -87,17 +97,21 @@ def group_by_category(files: list[dict]) -> dict:
 def format_stdout(by_category: dict) -> str:
     lines = []
     for category in sorted(by_category):
-        lines.append(f"\n## {category}/")
+        depth = category.count("/")
+        pad = "  " * depth
+        lines.append(f"\n{pad}## {category}/")
         for f in by_category[category]:
-            lines.append(f"  {f['path']}")
-            lines.append(f"    {f['description']}")
+            lines.append(f"{pad}  {f['path']}")
+            lines.append(f"{pad}    {f['description']}")
     return "\n".join(lines).lstrip("\n")
 
 
 def format_markdown(by_category: dict) -> str:
     lines = [START_MARKER, "", "## All Files by Category", ""]
     for category in sorted(by_category):
-        lines.append(f"### {category}/")
+        depth = category.count("/")
+        header_level = "###" + ("#" * min(depth, 3))
+        lines.append(f"{header_level} {category}/")
         for f in by_category[category]:
             lines.append(f"- `{f['path']}` — {f['description']}")
         lines.append("")

--- a/plugins/knowledge-base/scripts/kb-search.py
+++ b/plugins/knowledge-base/scripts/kb-search.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Search the knowledge base by keyword.
+
+Ranks entries by where the keyword hits:
+  - title          (weight 5)
+  - tags           (weight 4)
+  - description    (weight 3)
+  - category/path  (weight 2)
+  - body           (weight 1, capped)
+
+Usage:
+    python3 scripts/kb-search.py "keyword"
+    python3 scripts/kb-search.py "keyword" --category security
+    python3 scripts/kb-search.py "keyword" --tag mfa
+    python3 scripts/kb-search.py "keyword" --limit 5
+    python3 scripts/kb-search.py "keyword" kb/         # custom kb path
+    python3 scripts/kb-search.py "keyword" --json      # machine-readable output
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+WEIGHTS = {"title": 5, "tags": 4, "description": 3, "path": 2, "body": 1}
+BODY_HIT_CAP = 5
+SNIPPET_CHARS = 140
+
+
+def find_kb_path(explicit: str | None) -> Path:
+    if explicit:
+        p = Path(explicit)
+        if p.is_dir():
+            return p
+        print(f"Error: {p} is not a directory", file=sys.stderr)
+        sys.exit(1)
+    cwd_kb = Path.cwd() / "kb"
+    if cwd_kb.is_dir():
+        return cwd_kb
+    print("Error: no kb/ directory found. Pass a path or cd into the project.", file=sys.stderr)
+    sys.exit(1)
+
+
+def parse_frontmatter(text: str) -> tuple[dict, list[str], str]:
+    """Return (fields, tags, body)."""
+    if not text.startswith("---"):
+        return {}, [], text
+    end = text.find("---", 3)
+    if end == -1:
+        return {}, [], text
+    block = text[3:end].strip()
+    body = text[end + 3:].lstrip("\n")
+
+    fields: dict = {}
+    tags: list[str] = []
+    for line in block.split("\n"):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if ":" not in stripped:
+            continue
+        key, _, value = stripped.partition(":")
+        key = key.strip()
+        value = value.strip()
+        if key == "tags":
+            if value.startswith("[") and value.endswith("]"):
+                tags = [t.strip().strip('"').strip("'") for t in value[1:-1].split(",") if t.strip()]
+        elif key in ("title", "description", "category", "last_updated"):
+            fields[key] = value.strip('"').strip("'")
+    return fields, tags, body
+
+
+def score_entry(query_terms: list[str], fields: dict, tags: list[str], path: str, body: str) -> tuple[int, dict]:
+    score = 0
+    hits: dict[str, list[str]] = {"title": [], "tags": [], "description": [], "path": [], "body": []}
+
+    title = fields.get("title", "").lower()
+    description = fields.get("description", "").lower()
+    category = fields.get("category", "").lower()
+    path_l = path.lower()
+    body_l = body.lower()
+    tags_l = [t.lower() for t in tags]
+
+    for term in query_terms:
+        t = term.lower()
+        if t in title:
+            score += WEIGHTS["title"]
+            hits["title"].append(term)
+        if any(t in tag for tag in tags_l):
+            score += WEIGHTS["tags"]
+            hits["tags"].append(term)
+        if t in description:
+            score += WEIGHTS["description"]
+            hits["description"].append(term)
+        if t in category or t in path_l:
+            score += WEIGHTS["path"]
+            hits["path"].append(term)
+        body_count = min(body_l.count(t), BODY_HIT_CAP)
+        if body_count:
+            score += WEIGHTS["body"] * body_count
+            hits["body"].append(term)
+
+    return score, hits
+
+
+def snippet_for(body: str, query_terms: list[str]) -> str:
+    lower = body.lower()
+    for term in query_terms:
+        idx = lower.find(term.lower())
+        if idx == -1:
+            continue
+        start = max(0, idx - SNIPPET_CHARS // 2)
+        end = min(len(body), idx + SNIPPET_CHARS // 2)
+        snippet = body[start:end].strip()
+        snippet = re.sub(r"\s+", " ", snippet)
+        prefix = "..." if start > 0 else ""
+        suffix = "..." if end < len(body) else ""
+        return f"{prefix}{snippet}{suffix}"
+    return ""
+
+
+def collect(kb_path: Path) -> list[dict]:
+    entries = []
+    for md in sorted(kb_path.rglob("*.md")):
+        if md.name in ("index.md", "README.md"):
+            continue
+        rel = md.relative_to(kb_path)
+        text = md.read_text(encoding="utf-8")
+        fields, tags, body = parse_frontmatter(text)
+        entries.append({
+            "path": str(rel),
+            "title": fields.get("title", md.stem),
+            "description": fields.get("description", ""),
+            "category": fields.get("category", str(rel.parent) if rel.parent != Path(".") else "root"),
+            "tags": tags,
+            "body": body,
+        })
+    return entries
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Search the knowledge base by keyword.")
+    parser.add_argument("query", help="Keyword(s) to search for; space-separated terms are ANDed for ranking")
+    parser.add_argument("kb_path", nargs="?", default=None, help="Path to kb/ directory (defaults to ./kb)")
+    parser.add_argument("--category", help="Restrict to this category (matches exact or nested, e.g. 'security' matches 'security/access')")
+    parser.add_argument("--tag", action="append", default=[], help="Restrict to entries tagged with this tag (repeatable)")
+    parser.add_argument("--limit", type=int, default=10, help="Max results (default 10)")
+    parser.add_argument("--json", action="store_true", help="Output JSON instead of formatted text")
+    args = parser.parse_args()
+
+    kb_path = find_kb_path(args.kb_path)
+    query_terms = [t for t in args.query.split() if t]
+    if not query_terms:
+        print("Error: empty query", file=sys.stderr)
+        sys.exit(1)
+
+    entries = collect(kb_path)
+
+    if args.category:
+        cat = args.category.lower().rstrip("/")
+        entries = [e for e in entries if e["category"].lower() == cat or e["category"].lower().startswith(cat + "/")]
+    if args.tag:
+        wanted = {t.lower() for t in args.tag}
+        entries = [e for e in entries if wanted.issubset({t.lower() for t in e["tags"]})]
+
+    scored = []
+    for e in entries:
+        score, hits = score_entry(query_terms, {"title": e["title"], "description": e["description"], "category": e["category"]}, e["tags"], e["path"], e["body"])
+        if score > 0:
+            scored.append({**e, "score": score, "hits": hits, "snippet": snippet_for(e["body"], query_terms)})
+
+    scored.sort(key=lambda x: (-x["score"], x["path"]))
+    scored = scored[: args.limit]
+
+    if args.json:
+        out = [{k: v for k, v in s.items() if k != "body"} for s in scored]
+        print(json.dumps(out, indent=2))
+        return
+
+    if not scored:
+        print(f"No results for: {args.query}")
+        if args.category or args.tag:
+            print("(filters active; drop --category / --tag to widen)")
+        return
+
+    print(f"Found {len(scored)} result(s) for: {args.query}\n")
+    for i, e in enumerate(scored, 1):
+        hit_fields = [f for f, terms in e["hits"].items() if terms]
+        print(f"[{i}] {e['title']}  ({e['score']} pts, matched: {', '.join(hit_fields)})")
+        print(f"    kb/{e['path']}  [{e['category']}]")
+        if e["description"]:
+            print(f"    {e['description']}")
+        if e["snippet"]:
+            print(f"    > {e['snippet']}")
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/knowledge-base/scripts/kb-validate.py
+++ b/plugins/knowledge-base/scripts/kb-validate.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Validate KB health.
+
+Checks every .md entry under kb/ (skipping index.md and README.md) for:
+  - YAML frontmatter present and parseable
+  - Required fields: title, description, category, last_updated
+  - category value is listed in .kb-config.yaml
+  - last_updated parses as YYYY-MM-DD
+  - related: paths resolve to existing files
+
+Exits 1 if any error is found. Warnings do not fail the run.
+
+Usage:
+    python3 scripts/kb-validate.py          # default kb/
+    python3 scripts/kb-validate.py [kb_path]
+"""
+
+import re
+import sys
+from datetime import date
+from pathlib import Path
+
+
+REQUIRED_FIELDS = ("title", "description", "category", "last_updated")
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def find_kb_path(args: list[str]) -> Path:
+    if args:
+        p = Path(args[0])
+        if p.is_dir():
+            return p
+        print(f"Error: {p} is not a directory", file=sys.stderr)
+        sys.exit(1)
+    cwd_kb = Path.cwd() / "kb"
+    if cwd_kb.is_dir():
+        return cwd_kb
+    print("Error: no kb/ directory found.", file=sys.stderr)
+    sys.exit(1)
+
+
+def parse_config_categories(kb_path: Path) -> list[str]:
+    config = kb_path / ".kb-config.yaml"
+    if not config.exists():
+        return []
+    categories = []
+    in_list = False
+    for line in config.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("categories:"):
+            in_list = True
+            continue
+        if in_list:
+            if stripped.startswith("- "):
+                categories.append(stripped[2:].strip().strip('"').strip("'"))
+            elif stripped and not line.startswith(" "):
+                break
+    return categories
+
+
+def parse_frontmatter(filepath: Path) -> tuple[dict, list[str]]:
+    """Return (fields, related_paths)."""
+    content = filepath.read_text(encoding="utf-8")
+    if not content.startswith("---"):
+        return {}, []
+    end = content.find("---", 3)
+    if end == -1:
+        return {}, []
+    block = content[3:end].strip()
+
+    fields = {}
+    related = []
+    in_related = False
+    for line in block.split("\n"):
+        stripped = line.strip()
+        if in_related:
+            if stripped.startswith("- "):
+                related.append(stripped[2:].strip().strip('"').strip("'"))
+                continue
+            if line and not line.startswith(" "):
+                in_related = False
+            else:
+                continue
+        if stripped.startswith("related:"):
+            in_related = True
+            continue
+        if ":" in stripped and not stripped.startswith("-"):
+            key, _, value = stripped.partition(":")
+            key = key.strip()
+            value = value.strip().strip('"').strip("'")
+            if value:
+                fields[key] = value
+    return fields, related
+
+
+def main():
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    kb_path = find_kb_path(args)
+
+    config_categories = parse_config_categories(kb_path)
+    errors: list[str] = []
+    warnings: list[str] = []
+    checked = 0
+
+    for md_file in sorted(kb_path.rglob("*.md")):
+        if md_file.name in ("index.md", "README.md"):
+            continue
+        checked += 1
+        rel = md_file.relative_to(kb_path)
+        fields, related = parse_frontmatter(md_file)
+
+        if not fields:
+            errors.append(f"{rel}: missing or unparseable YAML frontmatter")
+            continue
+
+        for required in REQUIRED_FIELDS:
+            if required not in fields:
+                errors.append(f"{rel}: missing required frontmatter field '{required}'")
+
+        last_updated = fields.get("last_updated", "")
+        if last_updated and not DATE_RE.match(last_updated):
+            errors.append(f"{rel}: last_updated '{last_updated}' is not YYYY-MM-DD")
+
+        category = fields.get("category", "")
+        if category and config_categories and category not in config_categories:
+            errors.append(
+                f"{rel}: category '{category}' not in .kb-config.yaml "
+                f"(allowed: {', '.join(config_categories)})"
+            )
+
+        folder_category = rel.parts[0] if len(rel.parts) > 1 else None
+        if folder_category and category and folder_category != category:
+            warnings.append(
+                f"{rel}: folder '{folder_category}' does not match frontmatter category '{category}'"
+            )
+
+        today = date.today().isoformat()
+        if last_updated and last_updated > today:
+            warnings.append(f"{rel}: last_updated '{last_updated}' is in the future")
+
+        for r in related:
+            target = kb_path / r
+            if not target.exists():
+                errors.append(f"{rel}: related link '{r}' does not resolve")
+
+    print(f"Checked {checked} entries under {kb_path}")
+    if warnings:
+        print(f"\nWarnings ({len(warnings)}):")
+        for w in warnings:
+            print(f"  - {w}")
+    if errors:
+        print(f"\nErrors ({len(errors)}):")
+        for e in errors:
+            print(f"  - {e}")
+        sys.exit(1)
+    print("\nAll entries valid.")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/knowledge-base/scripts/kb-validate.py
+++ b/plugins/knowledge-base/scripts/kb-validate.py
@@ -4,20 +4,26 @@
 Checks every .md entry under kb/ (skipping index.md and README.md) for:
   - YAML frontmatter present and parseable
   - Required fields: title, description, category, last_updated
-  - category value is listed in .kb-config.yaml
+  - category value is listed in .kb-config.yaml (supports nested paths like 'security/access')
   - last_updated parses as YYYY-MM-DD
   - related: paths resolve to existing files
+  - optional: staleness (--max-age N warns when last_updated is older than N days)
 
-Exits 1 if any error is found. Warnings do not fail the run.
+Nested categories: if frontmatter reads `category: security/access`, the entry
+must live under `kb/security/access/`. Top-level folders without a nested match
+still warn as before.
+
+Exits 1 if any error is found. Warnings (including staleness) do not fail the run.
 
 Usage:
-    python3 scripts/kb-validate.py          # default kb/
+    python3 scripts/kb-validate.py                  # default kb/
     python3 scripts/kb-validate.py [kb_path]
+    python3 scripts/kb-validate.py --max-age 90     # warn on entries older than 90 days
 """
 
 import re
 import sys
-from datetime import date
+from datetime import date, datetime, timedelta
 from pathlib import Path
 
 
@@ -93,14 +99,51 @@ def parse_frontmatter(filepath: Path) -> tuple[dict, list[str]]:
     return fields, related
 
 
+def parse_max_age(argv: list[str]) -> int | None:
+    for i, a in enumerate(argv):
+        if a == "--max-age" and i + 1 < len(argv):
+            try:
+                n = int(argv[i + 1])
+                if n > 0:
+                    return n
+            except ValueError:
+                print(f"Error: --max-age expects a positive integer, got {argv[i + 1]!r}", file=sys.stderr)
+                sys.exit(2)
+        if a.startswith("--max-age="):
+            try:
+                n = int(a.split("=", 1)[1])
+                if n > 0:
+                    return n
+            except ValueError:
+                print(f"Error: --max-age expects a positive integer", file=sys.stderr)
+                sys.exit(2)
+    return None
+
+
 def main():
-    args = [a for a in sys.argv[1:] if not a.startswith("--")]
-    kb_path = find_kb_path(args)
+    argv = sys.argv[1:]
+    max_age_days = parse_max_age(argv)
+
+    positional = []
+    skip_next = False
+    for a in argv:
+        if skip_next:
+            skip_next = False
+            continue
+        if a == "--max-age":
+            skip_next = True
+            continue
+        if a.startswith("--"):
+            continue
+        positional.append(a)
+
+    kb_path = find_kb_path(positional)
 
     config_categories = parse_config_categories(kb_path)
     errors: list[str] = []
     warnings: list[str] = []
     checked = 0
+    stale_cutoff = date.today() - timedelta(days=max_age_days) if max_age_days else None
 
     for md_file in sorted(kb_path.rglob("*.md")):
         if md_file.name in ("index.md", "README.md"):
@@ -128,15 +171,26 @@ def main():
                 f"(allowed: {', '.join(config_categories)})"
             )
 
-        folder_category = rel.parts[0] if len(rel.parts) > 1 else None
-        if folder_category and category and folder_category != category:
+        folder_path = str(rel.parent).replace("\\", "/") if rel.parent != Path(".") else ""
+        if folder_path and category and folder_path != category:
             warnings.append(
-                f"{rel}: folder '{folder_category}' does not match frontmatter category '{category}'"
+                f"{rel}: folder '{folder_path}' does not match frontmatter category '{category}'"
             )
 
         today = date.today().isoformat()
         if last_updated and last_updated > today:
             warnings.append(f"{rel}: last_updated '{last_updated}' is in the future")
+
+        if stale_cutoff and last_updated and DATE_RE.match(last_updated):
+            try:
+                parsed = datetime.strptime(last_updated, "%Y-%m-%d").date()
+                if parsed < stale_cutoff:
+                    age_days = (date.today() - parsed).days
+                    warnings.append(
+                        f"{rel}: stale — last_updated '{last_updated}' is {age_days} days old (--max-age {max_age_days})"
+                    )
+            except ValueError:
+                pass
 
         for r in related:
             target = kb_path / r

--- a/plugins/knowledge-base/scripts/kb-verify.py
+++ b/plugins/knowledge-base/scripts/kb-verify.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Verify that quoted citations exist literally in KB files.
+
+Reads an answer from stdin (or a file) and checks each citation block against
+the actual KB files. Exits with code 1 if any quote doesn't match.
+
+Two match passes:
+  1. Strict: the quote appears character-for-character in the source file.
+  2. Normalized: whitespace collapsed and markdown markers (**, *, _, `) stripped.
+     Normalized-only passes are reported as PASS (normalized) so the author knows
+     the citation works but isn't byte-exact.
+
+Usage:
+    echo "answer text" | python3 scripts/kb-verify.py
+    python3 scripts/kb-verify.py answer.md
+    python3 scripts/kb-verify.py answer.md kb/
+    python3 scripts/kb-verify.py --strict answer.md   # disable normalized fallback
+
+Citation format expected:
+    > "exact quote from the file"
+    > Source: kb/category/filename.md
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+MARKDOWN_MARKERS = re.compile(r"(\*\*|\*|__|_|`)")
+WHITESPACE = re.compile(r"\s+")
+
+
+def find_kb_path(args: list[str]) -> Path:
+    for arg in args:
+        p = Path(arg)
+        if p.is_dir() and (p / ".kb-config.yaml").exists():
+            return p
+    cwd_kb = Path.cwd() / "kb"
+    if cwd_kb.is_dir():
+        return cwd_kb
+    return Path("kb")
+
+
+def parse_citations(text: str) -> list[dict]:
+    citations = []
+    lines = text.split("\n")
+    i = 0
+    while i < len(lines):
+        line = lines[i].strip()
+        if line.startswith('> "') and line.endswith('"'):
+            quote = line[3:-1]
+            if i + 1 < len(lines):
+                source_line = lines[i + 1].strip()
+                match = re.match(r'> Source:\s*(.+)', source_line)
+                if match:
+                    citations.append({"quote": quote, "source": match.group(1).strip()})
+                    i += 2
+                    continue
+        i += 1
+    return citations
+
+
+def normalize(text: str) -> str:
+    text = MARKDOWN_MARKERS.sub("", text)
+    text = WHITESPACE.sub(" ", text)
+    return text.strip()
+
+
+def verify_citation(quote: str, source_path: Path, allow_normalized: bool) -> str:
+    """Return "strict", "normalized", or "fail"."""
+    if not source_path.exists():
+        return "missing"
+    content = source_path.read_text(encoding="utf-8")
+    if quote in content:
+        return "strict"
+    if allow_normalized and normalize(quote) in normalize(content):
+        return "normalized"
+    return "fail"
+
+
+def main():
+    args = sys.argv[1:]
+    strict = "--strict" in args
+    args = [a for a in args if a != "--strict"]
+    allow_normalized = not strict
+
+    kb_path = find_kb_path(args)
+
+    file_args = [a for a in args if Path(a).is_file()]
+    if file_args:
+        text = Path(file_args[0]).read_text(encoding="utf-8")
+    elif not sys.stdin.isatty():
+        text = sys.stdin.read()
+    else:
+        print("Usage: python3 scripts/kb-verify.py [--strict] [answer.md] [kb_path]", file=sys.stderr)
+        print("  Or pipe answer text via stdin", file=sys.stderr)
+        sys.exit(1)
+
+    citations = parse_citations(text)
+
+    if not citations:
+        print("No citations found in input.")
+        print('Expected format: > "quote"')
+        print(">  Source: kb/path/file.md")
+        sys.exit(0)
+
+    all_valid = True
+    normalized_count = 0
+    for i, c in enumerate(citations, 1):
+        source = Path(c["source"])
+        if not source.is_absolute():
+            source = Path.cwd() / source
+
+        result = verify_citation(c["quote"], source, allow_normalized)
+        if result == "strict":
+            print(f"  [{i}] PASS: {c['source']}")
+        elif result == "normalized":
+            normalized_count += 1
+            print(f"  [{i}] PASS (normalized): {c['source']}")
+            print(f"        Quote matches after stripping markdown/whitespace.")
+        elif result == "missing":
+            all_valid = False
+            print(f"  [{i}] FAIL: {c['source']} (file not found)")
+        else:
+            all_valid = False
+            print(f"  [{i}] FAIL: {c['source']} (quote not found in file)")
+            q = c["quote"]
+            print(f"        Quote: \"{q[:80]}...\"" if len(q) > 80 else f"        Quote: \"{q}\"")
+
+    print()
+    if all_valid:
+        total = len(citations)
+        if normalized_count:
+            print(f"All {total} citation(s) verified ({normalized_count} via normalized match).")
+            print("Tip: re-copy those quotes with their original markdown for byte-exact matches.")
+        else:
+            print(f"All {total} citation(s) verified.")
+    else:
+        print("FAILED: Some citations could not be verified.")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/knowledge-base/scripts/kb-verify.py
+++ b/plugins/knowledge-base/scripts/kb-verify.py
@@ -10,15 +10,25 @@ Two match passes:
      Normalized-only passes are reported as PASS (normalized) so the author knows
      the citation works but isn't byte-exact.
 
+Supports single-line and multi-line citations.
+
 Usage:
     echo "answer text" | python3 scripts/kb-verify.py
     python3 scripts/kb-verify.py answer.md
     python3 scripts/kb-verify.py answer.md kb/
     python3 scripts/kb-verify.py --strict answer.md   # disable normalized fallback
 
-Citation format expected:
-    > "exact quote from the file"
-    > Source: kb/category/filename.md
+Citation formats accepted:
+
+    Single-line:
+        > "exact quote from the file"
+        > Source: kb/category/filename.md
+
+    Multi-line (opening " on first line, closing " at the end of the last):
+        > "exact quote line 1
+        > exact quote line 2
+        > exact quote line 3"
+        > Source: kb/category/filename.md
 """
 
 import re
@@ -42,19 +52,53 @@ def find_kb_path(args: list[str]) -> Path:
 
 
 def parse_citations(text: str) -> list[dict]:
+    """Parse single-line and multi-line `> "..."` citation blocks.
+
+    Single-line: the whole quote lives on one `> "..."` line.
+    Multi-line:  opens with `> "...` on one line, continues on subsequent
+                 `> ...` lines, and closes with a `"` at the end of the last
+                 quote line. The next non-blank line must be `> Source: ...`.
+    """
     citations = []
     lines = text.split("\n")
     i = 0
     while i < len(lines):
-        line = lines[i].strip()
-        if line.startswith('> "') and line.endswith('"'):
-            quote = line[3:-1]
-            if i + 1 < len(lines):
-                source_line = lines[i + 1].strip()
-                match = re.match(r'> Source:\s*(.+)', source_line)
+        stripped = lines[i].strip()
+        if stripped.startswith('> "'):
+            rest = stripped[3:]
+            if rest.endswith('"') and len(rest) >= 1:
+                quote = rest[:-1]
+                consumed = 1
+            else:
+                parts = [rest]
+                j = i + 1
+                closed = False
+                while j < len(lines):
+                    line_j = lines[j].strip()
+                    if not line_j.startswith(">"):
+                        break
+                    inner = line_j[1:].lstrip()
+                    if inner.endswith('"'):
+                        parts.append(inner[:-1])
+                        j += 1
+                        closed = True
+                        break
+                    parts.append(inner)
+                    j += 1
+                if not closed:
+                    i += 1
+                    continue
+                quote = "\n".join(parts)
+                consumed = j - i
+
+            source_idx = i + consumed
+            while source_idx < len(lines) and not lines[source_idx].strip():
+                source_idx += 1
+            if source_idx < len(lines):
+                match = re.match(r'>\s*Source:\s*(.+)', lines[source_idx].strip())
                 if match:
                     citations.append({"quote": quote, "source": match.group(1).strip()})
-                    i += 2
+                    i = source_idx + 1
                     continue
         i += 1
     return citations

--- a/plugins/knowledge-base/skills/kb-answer/SKILL.md
+++ b/plugins/knowledge-base/skills/kb-answer/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: kb-answer
+description: |
+  Answer questions using your project's knowledge base with evidence-backed citations.
+  Every answer must cite literal quotes from KB files to prevent hallucinations.
+  Use this for any question that should be answered from documented knowledge rather than general knowledge.
+---
+
+# KB Answer Workflow
+
+Follow these steps in order for every question. For multiple independent questions, use parallel agents.
+
+## Prerequisites
+
+Check that `kb/` exists in the project root. If not, tell the user to run `/setup-knowledge-base` first.
+
+## Step 1: Navigate Using the Index
+
+**Always start by reading the KB index:**
+```
+kb/index.md
+```
+
+The index provides:
+- **Keyword Lookup**: find the right file by keyword
+- **Category overview**: all files grouped by topic
+
+If the index is empty or outdated, run the index script first:
+```bash
+python3 scripts/kb-index.py
+```
+
+### Quick Navigation
+
+1. Check the keyword lookup table for matching terms
+2. Go to the matching file(s)
+3. If no keyword match, browse the category that best fits the question
+
+## Step 2: Read Relevant Files
+
+Based on the index navigation:
+1. Read the most relevant file first
+2. Check `related:` links in the frontmatter if the file references other entries
+3. Read additional files if the first doesn't fully cover the question
+
+## Step 3: Search (if needed)
+
+If the index doesn't point to the right file, search the KB using the Grep tool with path `kb/` and the relevant keyword.
+
+## Step 4: Check Active Scope
+
+If `kb/scopes/` contains scope files beyond `_default.yaml`:
+1. Ask the user which scope applies (if not already established in this conversation)
+2. Read the active scope file
+3. Apply `in_scope`, `out_of_scope`, and `notes` to shape your answer
+
+If only `_default.yaml` exists, skip this step.
+
+## Step 5: Formulate Answer
+
+### Answer Format
+
+**Yes/No questions**: Start with "Yes" or "No", followed by 1 sentence.
+
+**Other questions**: Answer directly in 1-3 sentences. Add detail only if needed.
+
+**If format requirements are provided**: Follow them exactly.
+
+### Citation Requirements
+
+Every claim in your answer MUST be backed by a literal quote from a KB file.
+
+Format each citation as:
+
+```
+> "exact quote copied from the KB file"
+> Source: kb/category/filename.md
+```
+
+**Rules:**
+- Copy the quote character-for-character. Do not paraphrase, summarize, or rephrase.
+- If you cannot find a literal quote supporting a claim, do not make that claim.
+- **Include markdown formatting verbatim.** If the source says `**Confidential**: ...`, your quote must be `**Confidential**: ...`, not `Confidential: ...`. If the source uses bullet list dashes, include them. Missing markdown is the #1 reason `kb-verify.py` flags citations. The script has a normalized-match fallback that will PASS with a warning, but strict mode will FAIL, so always copy formatting literally.
+- For long passages, prefer quoting a single self-contained sentence rather than a multi-line block. Multi-line blocks are fragile across reformatters.
+
+### What to Avoid
+
+- Don't over-elaborate. Match answer depth to question depth.
+- Don't pad with "more details available upon request".
+- Don't start with summary phrases like "Based on our documentation...". Go straight to the answer.
+- Be honest about limitations. If something isn't in the KB, say so.
+
+### If Information is Missing
+
+1. State clearly what information is not in the KB
+2. Provide what can be answered from available info
+3. Do not make up or infer information not in the KB
+4. Suggest which KB entry should be created to cover the gap
+
+## Step 6: Verify Citations
+
+After formulating your answer, verify all citations are accurate by running:
+
+```bash
+python3 scripts/kb-verify.py <<'EOF'
+{your answer with citations}
+EOF
+```
+
+The script checks that every quoted string exists in the referenced KB file. It runs two passes:
+1. **Strict**: the quote is byte-exact (including markdown markers and whitespace).
+2. **Normalized** (fallback): markdown markers (`**`, `*`, `_`, `` ` ``) and whitespace are stripped from both sides before comparison. Reported as `PASS (normalized)`.
+
+Target strict passes. If the script reports `PASS (normalized)`, re-copy the quote with its original markdown so the next verify run is clean.
+
+- All citations PASS (strict or normalized): present the answer.
+- Any citation FAIL: re-read the source file, copy the exact text (including markdown), and verify again.
+- Use `python3 scripts/kb-verify.py --strict answer.md` when you want to guarantee byte-exact citations (e.g., before publishing to a customer).
+
+Do not present an answer with any FAIL citations.
+
+## Handling Multiple Questions
+
+**Related questions** (same topic): Group together, share file reads.
+
+**Independent questions**: Use parallel agents, each following this workflow.
+
+Example:
+```
+Q1: "What encryption do we use?"     -> security
+Q2: "Who are our customers?"         -> general
+Q3: "What's our SLA?"                -> security
+
+Group 1 (security): Q1 + Q3
+Group 2 (general): Q2
+```

--- a/plugins/knowledge-base/skills/kb-answer/SKILL.md
+++ b/plugins/knowledge-base/skills/kb-answer/SKILL.md
@@ -34,7 +34,7 @@ python3 scripts/kb-index.py
 
 1. Check the keyword lookup table for matching terms
 2. Go to the matching file(s)
-3. If no keyword match, browse the category that best fits the question
+3. If no keyword match, browse the category that best fits the question. Categories can be nested (e.g., `security/access/`) — drill down into sub-groups when a broad category has them.
 
 ## Step 2: Read Relevant Files
 
@@ -45,7 +45,19 @@ Based on the index navigation:
 
 ## Step 3: Search (if needed)
 
-If the index doesn't point to the right file, search the KB using the Grep tool with path `kb/` and the relevant keyword.
+If the index doesn't point to the right file, run the search script to rank entries by keyword across title, tags, description, category, and body:
+
+```bash
+python3 scripts/kb-search.py "your keyword"
+```
+
+Options worth knowing:
+- `--category security` restricts to a category (matches nested children like `security/access` too).
+- `--tag mfa` filters by frontmatter tag (repeatable).
+- `--limit 5` caps results.
+- `--json` for a machine-readable list (useful when chaining into another step).
+
+Fall back to the Grep tool with path `kb/` only if the search script misses a term (e.g., regex-only patterns).
 
 ## Step 4: Check Active Scope
 
@@ -81,7 +93,14 @@ Format each citation as:
 - Copy the quote character-for-character. Do not paraphrase, summarize, or rephrase.
 - If you cannot find a literal quote supporting a claim, do not make that claim.
 - **Include markdown formatting verbatim.** If the source says `**Confidential**: ...`, your quote must be `**Confidential**: ...`, not `Confidential: ...`. If the source uses bullet list dashes, include them. Missing markdown is the #1 reason `kb-verify.py` flags citations. The script has a normalized-match fallback that will PASS with a warning, but strict mode will FAIL, so always copy formatting literally.
-- For long passages, prefer quoting a single self-contained sentence rather than a multi-line block. Multi-line blocks are fragile across reformatters.
+- For long passages, prefer quoting a single self-contained sentence. When a multi-line quote is unavoidable (e.g., a bulleted list that must be cited as one block), use the multi-line form:
+  ```
+  > "first line of the quote
+  > second line
+  > last line"
+  > Source: kb/category/filename.md
+  ```
+  The verifier joins the `>` lines back into one quote and checks the whole block. Single-line blocks are still preferred for robustness.
 
 ### What to Avoid
 

--- a/plugins/knowledge-base/skills/kb-import/SKILL.md
+++ b/plugins/knowledge-base/skills/kb-import/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: kb-import
+description: |
+  Import knowledge from existing documents into structured KB entries.
+  Reads source documents (Markdown, PDF, DOCX, plain text), extracts key information,
+  and creates properly formatted KB entries with YAML frontmatter.
+---
+
+# KB Import Workflow
+
+Import knowledge from existing documents into your knowledge base.
+
+## When to Use
+
+- Adding knowledge from existing documentation
+- Converting unstructured docs into structured KB entries
+- Bulk-importing content into a new KB
+
+## Step 1: Understand the KB Structure
+
+Read the KB config to understand available categories:
+```
+kb/.kb-config.yaml
+```
+
+Read the index to see what already exists:
+```
+kb/index.md
+```
+
+## Step 2: Read the Source Document
+
+Read the source file provided by the user. Supported formats:
+- Markdown (.md)
+- PDF (.pdf, use the Read tool with page ranges for large files)
+- Plain text (.txt)
+
+## Step 3: Plan the Extraction
+
+Analyze the document and propose a plan to the user:
+
+1. How many KB entries should be created?
+2. What categories do they belong to?
+3. Suggested titles for each entry
+
+Present this as a table:
+```
+| # | Title | Category | Source Section |
+|---|-------|----------|---------------|
+| 1 | ... | ... | ... |
+```
+
+Wait for user confirmation before proceeding.
+
+## Step 4: Create KB Entries
+
+For each planned entry, create a markdown file with YAML frontmatter:
+
+```markdown
+---
+title: "Entry Title"
+description: "Brief one-liner for index lookup"
+category: {category}
+tags: [{tag1}, {tag2}]
+sources: ["{source_filename}"]
+last_updated: "{today's date}"
+related:
+  - {category}/{related-file}.md
+---
+
+## Section Title
+
+Content here. Write clear, quotable statements.
+Each fact should be a self-contained sentence that can be cited as evidence.
+```
+
+### Content Guidelines
+
+- **Preserve specifics**: Keep exact numbers, dates, names, versions
+- **One topic per entry**: Don't create catch-all files
+- **Quotable statements**: Write so that individual sentences can be cited as evidence
+- **No opinions or speculation**: Only include facts from the source document
+- **Use markdown structure**: Headers, bullet points, tables for structured data
+
+### File Naming
+
+- Use lowercase with hyphens: `data-encryption.md`, `product-overview.md`
+- Name should reflect the topic, not the source document
+
+## Step 5: Update the Index and Validate
+
+After creating entries, regenerate the index and validate:
+```bash
+python3 scripts/kb-index.py --write   # rewrite kb/index.md's "All Files by Category"
+python3 scripts/kb-validate.py        # check frontmatter, categories, related links
+```
+
+Review the stdout output to verify all new entries appear correctly. Resolve any validate errors before continuing.
+
+## Step 6: Summary
+
+Report to the user:
+- How many entries were created
+- Which categories they were placed in
+- Any information from the source document that was skipped (and why)
+- Suggestion to review entries and add `related:` links between them

--- a/plugins/knowledge-base/skills/kb-import/SKILL.md
+++ b/plugins/knowledge-base/skills/kb-import/SKILL.md
@@ -16,6 +16,11 @@ Import knowledge from existing documents into your knowledge base.
 - Converting unstructured docs into structured KB entries
 - Bulk-importing content into a new KB
 
+## Modes
+
+- **Single-document mode** (default): one source document is split into one or more KB entries. Use Steps 1 to 6 below.
+- **Bulk mode**: many source documents are ingested at once from a directory or a list of files. Use when the user points at a folder or provides a list longer than ~3 files. See [Bulk Mode](#bulk-mode) at the bottom.
+
 ## Step 1: Understand the KB Structure
 
 Read the KB config to understand available categories:
@@ -76,9 +81,10 @@ Each fact should be a self-contained sentence that can be cited as evidence.
 
 ### Content Guidelines
 
-- **Preserve specifics**: Keep exact numbers, dates, names, versions
+- **Preserve specifics**: Keep exact numbers, dates, names, versions. Keep concrete customer/product examples by name (e.g., "Acme Corp", "Globex") — they make abstract concepts tangible and shouldn't be stripped "for neutrality".
 - **One topic per entry**: Don't create catch-all files
 - **Quotable statements**: Write so that individual sentences can be cited as evidence
+- **Capture the easily-missed content types** when the source covers them: stakeholders (one entry per key person with role + ownership + contact pattern), projects (goal/owner/status), repositories (purpose/ownership). These are the most commonly skipped in first-pass imports.
 - **No opinions or speculation**: Only include facts from the source document
 - **Use markdown structure**: Headers, bullet points, tables for structured data
 
@@ -104,3 +110,49 @@ Report to the user:
 - Which categories they were placed in
 - Any information from the source document that was skipped (and why)
 - Suggestion to review entries and add `related:` links between them
+
+## Bulk Mode
+
+Use this when the user wants to ingest many documents in one go (e.g., "import everything in `~/docs/policies/`", or a list of 5+ files).
+
+### Bulk Step 1: Enumerate the source set
+
+- If the user provided a directory, list supported files in it recursively (`.md`, `.pdf`, `.txt`, `.docx`). Skip obvious noise (`.DS_Store`, `node_modules`, hidden files).
+- If the user provided a list of paths, use exactly those.
+- Present the file count and a sample (first 10) to the user. Confirm before reading anything heavy.
+
+### Bulk Step 2: Plan across the whole batch
+
+Read the frontmatter / first page of each file to get a title guess. Produce a single combined plan:
+
+```
+| # | Source file | Proposed KB entry | Category |
+|---|-------------|-------------------|----------|
+| 1 | policies/acceptable-use.pdf | security/acceptable-use.md | security |
+| 2 | policies/retention.pdf      | security/data-retention.md | security |
+| ...
+```
+
+Rules:
+- One KB entry per source file by default. Split a source into multiple entries only when it clearly covers multiple distinct topics.
+- Prefer nested categories (e.g., `security/access`) when the batch is large enough that a flat category would become unwieldy (> ~10 entries in one category).
+- Flag duplicates up front: if a planned entry already exists in the KB, mark it "UPDATE" instead of "CREATE".
+
+Wait for user confirmation on the full plan before proceeding.
+
+### Bulk Step 3: Process in parallel
+
+- For ≤ 5 files, process sequentially (easier to follow, fewer context switches).
+- For > 5 files, dispatch a subagent per file (or per small group of related files) with the import instructions, the target path from the plan, and the existing KB index as context. Collect results.
+- If any subagent fails, keep the successful entries and report the failures so the user can retry a smaller batch.
+
+### Bulk Step 4: Finalize
+
+After all files are processed:
+```bash
+python3 scripts/kb-index.py --write
+python3 scripts/kb-validate.py
+python3 scripts/kb-search.py "sanity-check-term"   # spot-check a term that should appear
+```
+
+Report: X created, Y updated, Z skipped (with reason per skip). Flag any validate warnings or errors.

--- a/plugins/knowledge-base/skills/kb-refresh/SKILL.md
+++ b/plugins/knowledge-base/skills/kb-refresh/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: kb-refresh
+description: |
+  Add new sources to your knowledge base or re-scrape existing ones to pick up changes.
+  Supports Notion, Slack, Confluence, and local files. Can be run anytime after /setup-knowledge-base.
+---
+
+# KB Refresh
+
+Add content from new sources or update existing KB entries from their original sources.
+
+## When to Use
+
+- Adding a new knowledge source (Notion page, Slack channel, etc.) after initial setup
+- Re-scraping sources to pick up recent changes
+- Importing additional documents into the KB
+
+## Prerequisites
+
+Check that `kb/` and `kb/.kb-config.yaml` exist. If not, tell the user to run `/setup-knowledge-base` first.
+
+## Step 1: Understand Current KB
+
+Read the KB config and index to understand what's already there:
+
+```
+kb/.kb-config.yaml
+kb/index.md
+```
+
+Run the index script to see the current state:
+```bash
+python3 scripts/kb-index.py
+```
+
+## Step 2: Discover Sources
+
+Ask the user (use AskUserQuestion with multiSelect):
+
+**"What sources do you want to add or refresh?"**
+- Notion pages
+- Slack channels
+- Confluence pages
+- Local files or folders
+- Other
+
+### Collect Entry Points
+
+For each selected source, ask the user for the entry point:
+
+| Source | What to ask | MCP tool |
+|--------|-------------|----------|
+| Notion | Page URL (will scrape the page and all subpages recursively) | `notion-fetch` with the page URL, then `notion-search` or `notion-get-page-descendants` for child pages |
+| Slack | Channel name(s) to extract knowledge from | `slack_read_channel` to read recent messages |
+| Confluence | Space key or page URL | `getConfluencePage` + `getConfluencePageDescendants` for recursive scraping |
+| Local files | Directory path or file paths | Read tool directly |
+
+## Step 3: Choose Processing Mode
+
+Ask the user (use AskUserQuestion):
+
+**"Process one at a time or all in parallel?"**
+- One at a time (review each before continuing)
+- All in parallel (faster, review at the end)
+
+## Step 4: Scrape and Extract
+
+For each source, launch a subagent (or process sequentially, per the user's choice):
+
+```
+You are populating a knowledge base from an external source.
+
+SOURCE: {source_type}: {url_or_path}
+
+KB CATEGORIES (place entries in the most relevant one):
+{list of categories from .kb-config.yaml}
+
+EXISTING ENTRIES (avoid duplicating these):
+{output from kb-index.py}
+
+INSTRUCTIONS:
+1. Read/scrape the source content using the appropriate tool
+2. For Notion/Confluence: follow all child pages and subpages recursively
+3. For Slack: focus on pinned messages, bookmarks, and high-signal threads (not casual chat)
+4. Split the content into distinct topics. Create one .md file per topic, not one giant file.
+5. If an existing entry covers the same topic, UPDATE it rather than creating a duplicate.
+   Read the existing file first, merge the new information, and update last_updated.
+6. For new entries, create a file in kb/{category}/ with this format:
+
+---
+title: "Topic Title"
+description: "Brief one-liner for index lookup"
+category: {category}
+tags: [{relevant}, {tags}]
+sources: ["{source_url_or_path}"]
+last_updated: "{today's date}"
+---
+
+## Content
+
+Write clear, quotable statements. Each fact should be independently citable.
+
+7. Use lowercase-with-hyphens for filenames: product-overview.md, data-encryption.md
+8. Preserve specifics: exact numbers, dates, names, versions
+9. No opinions or speculation, only facts from the source
+10. Skip content that is outdated, trivial, or not worth preserving
+
+REPORT: When done, list all files created or updated with their category and a one-line description.
+```
+
+## Step 5: Review
+
+After all sources are processed:
+1. Run `python3 scripts/kb-index.py --write` to regenerate `kb/index.md`'s "All Files by Category" section from the current KB.
+2. Run `python3 scripts/kb-validate.py` to catch missing frontmatter, bad categories, or broken `related:` links.
+3. Present a summary: X entries created, Y entries updated, from Z sources. Flag any warnings or errors from `kb-validate.py`.
+4. Ask the user if they want to add more sources or are done.

--- a/plugins/knowledge-base/skills/kb-refresh/SKILL.md
+++ b/plugins/knowledge-base/skills/kb-refresh/SKILL.md
@@ -85,6 +85,11 @@ INSTRUCTIONS:
 4. Split the content into distinct topics. Create one .md file per topic, not one giant file.
 5. If an existing entry covers the same topic, UPDATE it rather than creating a duplicate.
    Read the existing file first, merge the new information, and update last_updated.
+5a. For org-context KBs (company/team/personal knowledge, not just policy docs), actively hunt for these content types — they are the most commonly missed:
+    - **Stakeholders**: one entry per key person (role, ownership areas, how to reach them, what they care about). Without these, the KB can't answer "who should I talk to about X?".
+    - **Projects**: one entry per initiative (goal, owner, status, links). Distinct from generic "strategy" entries.
+    - **Repositories / codebases**: one entry per repo (purpose, key files, how to run, ownership).
+    - **Customer examples**: keep concrete names (e.g., "Acme Corp", "Globex") that make abstract concepts tangible. Don't strip them for anonymity unless the user asks.
 6. For new entries, create a file in kb/{category}/ with this format:
 
 ---
@@ -95,6 +100,7 @@ tags: [{relevant}, {tags}]
 sources: ["{source_url_or_path}"]
 last_updated: "{today's date}"
 ---
+
 
 ## Content
 
@@ -113,5 +119,7 @@ REPORT: When done, list all files created or updated with their category and a o
 After all sources are processed:
 1. Run `python3 scripts/kb-index.py --write` to regenerate `kb/index.md`'s "All Files by Category" section from the current KB.
 2. Run `python3 scripts/kb-validate.py` to catch missing frontmatter, bad categories, or broken `related:` links.
-3. Present a summary: X entries created, Y entries updated, from Z sources. Flag any warnings or errors from `kb-validate.py`.
-4. Ask the user if they want to add more sources or are done.
+3. Run `python3 scripts/kb-validate.py --max-age 90` (or a shorter window if the source changes faster) to surface entries that have drifted since their last refresh.
+4. Spot-check discoverability with `python3 scripts/kb-search.py "<term the refresh should have covered>"` to confirm new entries are searchable.
+5. Present a summary: X entries created, Y entries updated, from Z sources. Flag any warnings, errors, or stale entries.
+6. Ask the user if they want to add more sources or are done.

--- a/plugins/knowledge-base/skills/setup-knowledge-base/SKILL.md
+++ b/plugins/knowledge-base/skills/setup-knowledge-base/SKILL.md
@@ -49,6 +49,7 @@ scripts/
   kb-index.py
   kb-verify.py
   kb-validate.py
+  kb-search.py
 CLAUDE.md (or append to existing)
 
 Ready to proceed?
@@ -80,6 +81,8 @@ Read the template files from this plugin and adapt them for the user's project:
 7. **Read** `scripts/kb-verify.py` from this plugin. Copy to `scripts/kb-verify.py` in the user's project.
 
 8. **Read** `scripts/kb-validate.py` from this plugin. Copy to `scripts/kb-validate.py` in the user's project.
+
+9. **Read** `scripts/kb-search.py` from this plugin. Copy to `scripts/kb-search.py` in the user's project.
 
 ## Step 4: Create Project CLAUDE.md
 
@@ -120,8 +123,9 @@ If `kb-index.py` lists the entries and `kb-validate.py` reports "All entries val
 
 Tell the user:
 - What was created and where
-- How to add new entries (create .md files with YAML frontmatter in the right `kb/{category}/` folder)
+- How to add new entries (create .md files with YAML frontmatter in the right `kb/{category}/` folder; nested sub-folders like `kb/security/access/` are supported)
 - How to query the KB (`/kb-answer`)
-- How to import documents (`/kb-import`)
+- How to import documents or bulk-import a directory (`/kb-import`)
 - How to add more sources or refresh existing ones (`/kb-refresh`)
 - How to list all entries (`python3 scripts/kb-index.py`)
+- How to search (`python3 scripts/kb-search.py "keyword"`)

--- a/plugins/knowledge-base/skills/setup-knowledge-base/SKILL.md
+++ b/plugins/knowledge-base/skills/setup-knowledge-base/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: setup-knowledge-base
+description: |
+  Interactive onboarding to create a structured knowledge base. Defines categories,
+  scaffolds the directory structure, creates the index, and optionally imports initial content.
+  Run this first before using /kb-answer or /kb-import.
+---
+
+# Knowledge Base Setup
+
+Interactive setup that creates a structured, evidence-backed knowledge base in your project.
+
+## When to Use
+
+- Starting a new knowledge base from scratch
+- Adding a KB to an existing project
+
+## Step 1: Discover Purpose
+
+Ask the user (one question at a time, use AskUserQuestion):
+
+1. **What is this KB for?** (e.g., product documentation, security/compliance, company knowledge, sales enablement, internal policies)
+2. **Who will query it?** (e.g., you personally, your team, AI agents answering questions)
+3. **What categories make sense?** Suggest 3-5 based on the domain, let the user adjust.
+
+Example category suggestions by domain:
+- **Product docs**: technical, integrations, deployment, security, faq
+- **Company knowledge**: general, policies, processes, teams, faq
+- **Sales enablement**: product, competitive, customer-success, pricing, faq
+- **Security/compliance**: security, compliance, technical, general, faq
+
+## Step 2: Confirm Plan
+
+Before creating anything, present the plan to the user:
+
+```
+I'll create this structure in your project:
+
+kb/
+  .kb-config.yaml
+  index.md
+  scopes/
+    _default.yaml
+    README.md
+  {category1}/
+  {category2}/
+  {category3}/
+scripts/
+  kb-index.py
+  kb-verify.py
+  kb-validate.py
+CLAUDE.md (or append to existing)
+
+Ready to proceed?
+```
+
+Wait for user confirmation.
+
+## Step 3: Scaffold the KB
+
+Read the template files from this plugin and adapt them for the user's project:
+
+1. **Read** `templates/kb/.kb-config.yaml` from this plugin. Create `kb/.kb-config.yaml` in the user's project, replacing the placeholder categories with the ones chosen in Step 1. Replace `{{today}}` with today's date.
+
+2. **Read** `templates/kb/index.md` from this plugin. Create `kb/index.md`, adding seed keywords for each chosen category. For example, if the user chose "security" and "technical", add initial keyword entries:
+
+   ```
+   | encryption, certificates, access | security/ |
+   | API, architecture, deployment | technical/ |
+   ```
+
+3. **Read** `templates/kb/scopes/_default.yaml` from this plugin. Copy to `kb/scopes/_default.yaml`.
+
+4. **Read** `templates/kb/scopes/README.md` from this plugin. Copy to `kb/scopes/README.md`.
+
+5. Create empty directories for each chosen category: `kb/{category1}/`, `kb/{category2}/`, etc.
+
+6. **Read** `scripts/kb-index.py` from this plugin. Copy to `scripts/kb-index.py` in the user's project.
+
+7. **Read** `scripts/kb-verify.py` from this plugin. Copy to `scripts/kb-verify.py` in the user's project.
+
+8. **Read** `scripts/kb-validate.py` from this plugin. Copy to `scripts/kb-validate.py` in the user's project.
+
+## Step 4: Create Project CLAUDE.md
+
+**Read** `templates/CLAUDE.md` from this plugin. Create (or append to existing) `CLAUDE.md` in the user's project root. Replace `{{category}}` placeholders with the actual categories chosen in Step 1.
+
+## Step 5: Populate from Sources
+
+The KB structure is ready, but empty. Ask the user:
+
+**"Do you have existing knowledge sources you'd like to import? (Notion pages, Slack channels, Confluence, local files)"**
+
+- If **yes**: run `/kb-refresh` to populate the KB from those sources. It handles source discovery, scraping, and entry creation.
+- If **no** or **skip**: create one example entry in the first category to demonstrate the format. **Read** `templates/kb/example/sample-entry.md` from this plugin for the format, but write an entry relevant to the user's domain rather than copying the sample.
+
+## Step 6: Verify
+
+Run the index script to confirm everything is wired up:
+
+```bash
+python3 scripts/kb-index.py
+```
+
+Regenerate the "All Files by Category" section of `kb/index.md` from the current entries:
+
+```bash
+python3 scripts/kb-index.py --write
+```
+
+Validate KB health (frontmatter, categories, related links):
+
+```bash
+python3 scripts/kb-validate.py
+```
+
+If `kb-index.py` lists the entries and `kb-validate.py` reports "All entries valid", setup is complete.
+
+## Step 7: Summary
+
+Tell the user:
+- What was created and where
+- How to add new entries (create .md files with YAML frontmatter in the right `kb/{category}/` folder)
+- How to query the KB (`/kb-answer`)
+- How to import documents (`/kb-import`)
+- How to add more sources or refresh existing ones (`/kb-refresh`)
+- How to list all entries (`python3 scripts/kb-index.py`)

--- a/plugins/knowledge-base/templates/CLAUDE.md
+++ b/plugins/knowledge-base/templates/CLAUDE.md
@@ -1,0 +1,41 @@
+# Knowledge Base
+
+## Directory Structure
+
+- `kb/`: Knowledge base entries (git-tracked)
+- `kb/scopes/`: Context profiles for different audiences or customer segments
+- `scripts/kb-index.py`: Lists all KB files with descriptions; `--write` regenerates `kb/index.md`
+- `scripts/kb-verify.py`: Verifies that `/kb-answer` citations exist in KB files
+- `scripts/kb-validate.py`: Checks KB health (frontmatter, categories, related links)
+
+## KB Entry Format
+
+All entries use markdown with YAML frontmatter:
+
+```yaml
+---
+title: "Entry Title"
+description: "One-liner for index lookup"
+category: {{category}}
+tags: [tag1, tag2]
+sources: ["source-document.pdf"]
+last_updated: "YYYY-MM-DD"
+related:
+  - category/related-entry.md
+---
+```
+
+## Adding Knowledge
+
+1. Create a `.md` file in the appropriate `kb/{category}/` folder
+2. Add YAML frontmatter with at least title, description, category, and last_updated
+3. Write content with clear, quotable statements
+4. Run `python3 scripts/kb-index.py` to verify it appears in the index
+
+## Scopes
+
+Use scope files in `kb/scopes/` to customize answers for specific contexts. See `kb/scopes/README.md` for details.
+
+## Querying
+
+Use `/kb-answer` to ask questions. Answers will cite literal quotes from KB files.

--- a/plugins/knowledge-base/templates/CLAUDE.md
+++ b/plugins/knowledge-base/templates/CLAUDE.md
@@ -2,11 +2,12 @@
 
 ## Directory Structure
 
-- `kb/`: Knowledge base entries (git-tracked)
+- `kb/`: Knowledge base entries (git-tracked). Categories can be nested — e.g., `kb/security/access/mfa.md` with `category: security/access` in frontmatter.
 - `kb/scopes/`: Context profiles for different audiences or customer segments
-- `scripts/kb-index.py`: Lists all KB files with descriptions; `--write` regenerates `kb/index.md`
+- `scripts/kb-index.py`: Lists all KB files with descriptions; `--write` regenerates `kb/index.md` (renders nested categories as a tree)
 - `scripts/kb-verify.py`: Verifies that `/kb-answer` citations exist in KB files
-- `scripts/kb-validate.py`: Checks KB health (frontmatter, categories, related links)
+- `scripts/kb-validate.py`: Checks KB health (frontmatter, categories incl. nested, related links)
+- `scripts/kb-search.py`: Keyword search; `python3 scripts/kb-search.py "keyword" [--category X] [--tag Y]`
 
 ## KB Entry Format
 

--- a/plugins/knowledge-base/templates/kb/.kb-config.yaml
+++ b/plugins/knowledge-base/templates/kb/.kb-config.yaml
@@ -1,0 +1,6 @@
+version: "1.0"
+created: "{{today}}"
+categories:
+  - general
+  - technical
+  - faq

--- a/plugins/knowledge-base/templates/kb/.kb-config.yaml
+++ b/plugins/knowledge-base/templates/kb/.kb-config.yaml
@@ -1,6 +1,14 @@
 version: "1.0"
 created: "{{today}}"
+
+# Categories can be flat or nested (slash-separated).
+# A nested category like "security/access" means entries live under
+# kb/security/access/ and will render as a sub-group in the index.
 categories:
   - general
   - technical
   - faq
+  # Example of a nested hierarchy:
+  # - security
+  # - security/access
+  # - security/data

--- a/plugins/knowledge-base/templates/kb/example/sample-entry.md
+++ b/plugins/knowledge-base/templates/kb/example/sample-entry.md
@@ -1,0 +1,35 @@
+---
+title: "Password Policy"
+description: "Minimum length, complexity, and MFA rules for account access"
+category: security
+tags: [password, mfa, authentication]
+sources: ["Company handbook §4.2"]
+last_updated: "2026-04-20"
+related:
+  - security/access-control.md
+---
+
+## Requirements
+
+- Passwords must be a minimum of 12 characters in length.
+- Passwords must include at least one upper-case letter, one lower-case letter, one number, and one special character.
+- Passwords must not contain the user's name, username, or other easily guessable personal information.
+
+## Multi-Factor Authentication
+
+Multi-factor authentication is required for every account that accesses systems containing Confidential or Secret data, and for every user with elevated privileges.
+
+MFA must use at least two different authentication factors: something the user knows (a password), something the user possesses (a security token or mobile device), or something inherent to the user (a fingerprint).
+
+## Rotation
+
+User passwords do not need to be rotated on a schedule. Passwords for privileged accounts must be rotated every 90 days.
+
+## Why This Entry Looks Like This
+
+- Every claim is a short, self-contained, quotable sentence.
+- Specific numbers (12 characters, 90 days) are preserved; no rounding.
+- Headers group related rules so `/kb-answer` can cite the right block.
+- `related:` points to other entries that an answer on this topic would probably touch.
+
+Replace this file with a real entry from your domain, or delete it once your KB has a few real entries.

--- a/plugins/knowledge-base/templates/kb/example/sample-entry.md
+++ b/plugins/knowledge-base/templates/kb/example/sample-entry.md
@@ -1,12 +1,10 @@
 ---
 title: "Password Policy"
 description: "Minimum length, complexity, and MFA rules for account access"
-category: security
+category: general
 tags: [password, mfa, authentication]
 sources: ["Company handbook §4.2"]
 last_updated: "2026-04-20"
-related:
-  - security/access-control.md
 ---
 
 ## Requirements

--- a/plugins/knowledge-base/templates/kb/index.md
+++ b/plugins/knowledge-base/templates/kb/index.md
@@ -1,0 +1,24 @@
+# Knowledge Base Index
+
+## How to Navigate
+
+1. **Know the keyword?** Use the [Keyword Lookup](#keyword-lookup) below
+2. **Browsing by topic?** See [All Files by Category](#all-files-by-category)
+
+---
+
+## Keyword Lookup
+
+| Keyword | Go to |
+|---------|-------|
+| _Add keywords as you build your KB_ | |
+
+---
+
+<!-- kb-index:start -->
+
+## All Files by Category
+
+_Run `python3 scripts/kb-index.py --write` to regenerate this section from the current KB._
+
+<!-- kb-index:end -->

--- a/plugins/knowledge-base/templates/kb/scopes/README.md
+++ b/plugins/knowledge-base/templates/kb/scopes/README.md
@@ -1,0 +1,55 @@
+# Scopes
+
+Scopes let you customize which KB content is relevant for a specific context. For example, if you have different product lines or customer segments, a scope file tells the answering skill what to emphasize and what to exclude.
+
+## How Scopes Work
+
+1. Base answers come from the full KB
+2. When a scope is active, `in_scope` items are emphasized and `out_of_scope` items are excluded
+3. `notes` provide guidance on tone, emphasis, or talking points
+4. `overrides` replace specific answers entirely (rarely needed)
+
+## Creating a Scope
+
+Create a YAML file in this directory:
+
+```yaml
+name: "Scope Name"
+description: "When to use this scope"
+
+in_scope:
+  - "Feature or topic to emphasize"
+  - "Another relevant capability"
+
+out_of_scope:
+  - "Feature not relevant in this context"
+
+overrides: {}
+
+notes:
+  - "Guidance for answering in this context"
+  - "Talking points to hit"
+```
+
+## Example
+
+A SaaS company might have scopes for different customer segments:
+
+**enterprise-customer.yaml**
+```yaml
+name: "Enterprise Customer"
+description: "For enterprise prospects (1000+ employees)"
+
+in_scope:
+  - "SSO and SAML integration"
+  - "Custom SLA options"
+  - "Dedicated support"
+
+out_of_scope:
+  - "Self-serve pricing"
+  - "Free tier features"
+
+notes:
+  - "Emphasize security certifications"
+  - "Mention dedicated account management"
+```

--- a/plugins/knowledge-base/templates/kb/scopes/_default.yaml
+++ b/plugins/knowledge-base/templates/kb/scopes/_default.yaml
@@ -1,0 +1,13 @@
+name: "Default"
+description: "Full knowledge base, no filters applied"
+
+in_scope:
+  - "All KB content"
+
+out_of_scope: []
+
+overrides: {}
+
+notes:
+  - "This is the base scope with all content available"
+  - "Create additional scope files to customize answers for specific contexts"


### PR DESCRIPTION
Evidence-backed knowledge base with four skills (setup, answer, import, refresh) and three scripts (kb-index, kb-verify, kb-validate). Every /kb-answer reply cites literal quotes from KB files; kb-verify.py enforces this with a strict pass plus a normalized-match fallback for markdown and whitespace drift. kb-index.py --write regenerates the index between markers, and kb-validate.py checks frontmatter, categories, dates, and related-link resolution.