### PR TITLE
chore: add TechWolf author attribution to ai-firstify and content-studio

### DIFF
--- a/plugins/ai-firstify/.claude-plugin/plugin.json
+++ b/plugins/ai-firstify/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "ai-firstify",
   "description": "AI-first project auditor and re-engineer based on the 9 design principles and 7 design patterns from the TechWolf AI-First Bootcamp",
-  "version": "1.1.0"
+  "version": "1.1.0",
+  "author": { "name": "TechWolf" }
 }

--- a/plugins/content-studio/.claude-plugin/plugin.json
+++ b/plugins/content-studio/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "content-studio",
   "description": "Content studio for managing thought leadership content with a visual editor, Claude Code skills, and utility scripts.",
-  "version": "1.1.0"
+  "version": "1.1.0",
+  "author": { "name": "TechWolf" }
 }


### PR DESCRIPTION
Both plugin manifests were missing `author`, which surfaced as validation warnings and would show blank attribution in the community marketplace listing. Adds `"author": { "name": "TechWolf" }` to match the other plugins. `claude plugin validate` now passes with zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)