### PR TITLE
Fix Codex installs of plugin-root shared assets (v1.6.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog and this project follows Semantic Versioning.
 
+## [1.6.1] - 2026-06-10
+
+### Fixed
+
+- Codex installs now stage plugin-root shared asset directories (`scripts/`, `templates/`, and any other non-framework plugin-root dir) into each skill so skills that read them "from this plugin" resolve under Codex's flat per-skill layout. Previously `install.sh` copied only `skills/<skill>/`, so these files never reached `~/.codex/skills/`.
+  - `knowledge-base`: `setup-knowledge-base` can now read and copy its `kb-*.py` helpers and `kb/` templates in Codex (the setup flow and `kb-answer` were broken there).
+  - `content-studio`: `setup-content-studio` can now copy the bundled Next.js app, `scripts/`, and `hooks/` in Codex; `repo-setup.md` documents how `<plugin-path>` resolves in Claude Code vs Codex.
+- `people-management`: skills now reference their shared framework docs (`operating-principles.md`, `performance-framework.md`, `management-framework.md`, `values-guide.md`) via skill-relative paths instead of `../../references/`, which pointed outside the skill in Codex. The shared docs are bundled into each skill that uses them, so resolution works in both Claude Code and Codex.
+
+### Changed
+
+- `content-studio` `setup-content-studio`: the post-creation batching step now notes a sequential fallback for agents without sub-agents (e.g. Codex); output is identical.
+
 ## [1.6.0] - 2026-06-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TechWolf AI-First Toolkit
 
-![MIT License](https://img.shields.io/badge/license-MIT-blue.svg) ![v1.6.0](https://img.shields.io/badge/version-1.6.0-green.svg) ![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-blueviolet.svg) ![Codex](https://img.shields.io/badge/Codex-compatible-orange.svg) ![agentskills.io](https://img.shields.io/badge/agentskills.io-spec-lightgrey.svg)
+![MIT License](https://img.shields.io/badge/license-MIT-blue.svg) ![v1.6.1](https://img.shields.io/badge/version-1.6.1-green.svg) ![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-blueviolet.svg) ![Codex](https://img.shields.io/badge/Codex-compatible-orange.svg) ![agentskills.io](https://img.shields.io/badge/agentskills.io-spec-lightgrey.svg)
 
 Open-source Claude Code skills and Codex skills from [TechWolf](https://techwolf.ai)'s [AI-First Bootcamp](https://ai-first.techwolf.ai).
 

--- a/install.sh
+++ b/install.sh
@@ -177,6 +177,24 @@ install_plugin() {
 
     rm -rf "$dest"
     mkdir -p "$dest"
+
+    # Stage plugin-root shared asset dirs into the skill. Claude Code resolves
+    # these via the plugin root, but Codex installs each skill as a flat
+    # self-contained dir, so a skill that reads "scripts/X" or "templates/X from
+    # this plugin" needs those files alongside its own SKILL.md. We copy every
+    # plugin-root subdir except the framework dirs (skills/, codex/,
+    # .claude-plugin/), before the skill payload so skill-local files win on any
+    # name conflict.
+    local shared_src
+    for shared_src in "${SCRIPT_DIR}/plugins/${plugin_name}"/*/; do
+      [[ -d "$shared_src" ]] || continue
+      case "$(basename "$shared_src")" in
+        skills|codex|.claude-plugin) continue ;;
+      esac
+      # Strip trailing slash so cp copies the directory itself, not its contents.
+      cp -R "${shared_src%/}" "$dest/"
+    done
+
     cp -R "${skill_dir}/." "$dest/"
     write_skill_metadata "$dest" "$plugin_name" "$version" "$skill_name" "$skill_dir"
 

--- a/plugins/content-studio/.claude-plugin/plugin.json
+++ b/plugins/content-studio/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "content-studio",
   "description": "Content studio for managing thought leadership content with a visual editor, Claude Code skills, and utility scripts.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": { "name": "TechWolf" }
 }

--- a/plugins/content-studio/skills/setup-content-studio/SKILL.md
+++ b/plugins/content-studio/skills/setup-content-studio/SKILL.md
@@ -87,7 +87,7 @@ Read **references/repo-setup.md** for the full repository setup procedure, inclu
 
 Convert each example post into a YAML file. Read **references/content-format.md** for the file path convention and YAML structure.
 
-**Use parallel Task agents** to create posts in batches of 10 for efficiency.
+**If your agent supports sub-agents (e.g. Claude Code), use parallel Task agents** to create posts in batches of 10 for efficiency. Otherwise (e.g. Codex), create the posts sequentially: the output is identical, it just takes longer.
 
 ## Step 8: Install Dependencies and Verify
 

--- a/plugins/content-studio/skills/setup-content-studio/references/content-format.md
+++ b/plugins/content-studio/skills/setup-content-studio/references/content-format.md
@@ -31,4 +31,4 @@ content: |-
 ## Notes
 
 - Use approximate dates for slugs based on the post timing information provided
-- **Use parallel Task agents** to create posts in batches of 10 for efficiency
+- **If your agent supports sub-agents (e.g. Claude Code), use parallel Task agents** to create posts in batches of 10 for efficiency. Otherwise (e.g. Codex), create them sequentially: same output, just slower

--- a/plugins/content-studio/skills/setup-content-studio/references/repo-setup.md
+++ b/plugins/content-studio/skills/setup-content-studio/references/repo-setup.md
@@ -2,7 +2,9 @@
 
 ## 6a. Set Up from Plugin Template
 
-The content-studio plugin provides the generic structure. Copy it to a new repo:
+The content-studio plugin provides the generic structure. Copy it to a new repo.
+
+`<plugin-path>` is wherever this plugin's files live: in Claude Code that is the plugin root (`${CLAUDE_PLUGIN_ROOT}`); in Codex the `content-studio/`, `scripts/`, `templates/`, and `hooks/` directories are bundled alongside this skill, so `<plugin-path>` is this skill's own directory.
 
 ```bash
 # Create new repo directory

--- a/plugins/knowledge-base/.claude-plugin/plugin.json
+++ b/plugins/knowledge-base/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "knowledge-base",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Build and query a structured, evidence-backed knowledge base with Claude Code. Every answer cites literal quotes from your KB files to prevent hallucinations.",
   "author": { "name": "TechWolf" },
   "keywords": ["knowledge-base", "kb", "evidence", "citations", "rfp", "search"]

--- a/plugins/people-management/.claude-plugin/plugin.json
+++ b/plugins/people-management/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "people-management",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "AI-augmented management tooling for people managers. Surfaces the right context at the right time: before meetings, during 1:1 prep, when triaging messages, or reviewing customer status. Adapts to your org's performance and management frameworks. Augments managers, never automates.",
   "author": { "name": "TechWolf" },
   "keywords": ["management", "1:1", "performance", "team-health", "meeting-prep"]

--- a/plugins/people-management/skills/customer-status/SKILL.md
+++ b/plugins/people-management/skills/customer-status/SKILL.md
@@ -18,7 +18,7 @@ Produces a dashboard-style overview of active customer accounts and internal pro
 
 ## Instructions
 
-If any MCP connector is unavailable, follow the connector unavailability protocol in `../../references/operating-principles.md`.
+If any MCP connector is unavailable, follow the connector unavailability protocol in `references/operating-principles.md`.
 
 ### 1. Load Context
 
@@ -102,7 +102,7 @@ Here's your customer status overview. Want me to:
 
 ## Important Notes
 
-Read `../../references/operating-principles.md` for shared operating principles (data scope, DM flagging, signals vs diagnoses, connector unavailability).
+Read `references/operating-principles.md` for shared operating principles (data scope, DM flagging, signals vs diagnoses, connector unavailability).
 
 Additional notes specific to this skill:
 - **Don't alarm unnecessarily.** Silence on a channel might mean things are running smoothly. Combine multiple signals before flagging red.

--- a/plugins/people-management/skills/customer-status/references/operating-principles.md
+++ b/plugins/people-management/skills/customer-status/references/operating-principles.md
@@ -1,0 +1,41 @@
+# Operating Principles
+
+Shared principles that apply to all People Manager skills. Every skill should reference this file and follow these principles.
+
+## Augment, Never Automate
+
+Every output is a draft for human review. Management is about human judgment, trust, and relationships. AI provides leverage on information-gathering. It never decides, prescribes, or acts on the manager's behalf.
+
+## Data Scope
+
+- All channels, documents, emails, and DMs the manager is part of are fair game.
+- **Never** surface DMs between other people that don't include the manager.
+- When using DM content, flag it as `(from DM)` so the manager knows it's sensitive context not visible to the team.
+- Wellbeing signals are especially sensitive. Surface gently, as conversation starters, never as conclusions.
+
+## Signals, Not Diagnoses
+
+- Never say "this person is disengaged" or "this person is struggling."
+- Always frame as "signal worth exploring" or "pattern to check in on."
+- Decreased activity could mean many things. Present observations, let the manager interpret.
+- Baseline matters: a quiet person being quiet isn't a signal. A usually active person going quiet might be.
+
+## Evidence Over Opinion
+
+- Every claim should link back to where you found it. Don't synthesise without attribution.
+- Recency matters. Prioritise recent information and flag anything older than ~2 months.
+- Absence of evidence is not evidence of absence, especially for values and behaviours best observed in person.
+
+## Connector Unavailability
+
+If an MCP connector (Slack, Notion, Gmail, Google Drive, Google Calendar) is unavailable or returns errors:
+1. Note which connector is unavailable
+2. Proceed with the data you can access from other connectors
+3. Flag the gap in your output so the manager knows what's missing
+4. Never silently skip a data source. Always tell the manager what you couldn't check
+
+## Source Everything
+
+- Link to the specific Slack message, Notion page, Drive doc, or email thread
+- "I found X in #channel on [date]" is better than "X is happening"
+- If volume is high, summarise with representative links rather than listing every item

--- a/plugins/people-management/skills/meeting-prep/SKILL.md
+++ b/plugins/people-management/skills/meeting-prep/SKILL.md
@@ -17,7 +17,7 @@ Gathers context from all connected sources for a specific upcoming meeting and p
 
 ## Instructions
 
-If any MCP connector is unavailable, follow the connector unavailability protocol in `../../references/operating-principles.md`.
+If any MCP connector is unavailable, follow the connector unavailability protocol in `references/operating-principles.md`.
 
 ### 1. Identify the Meeting
 
@@ -114,7 +114,7 @@ Here's your prep for [meeting]. Anything you'd like me to dig deeper on?
 
 ## Important Notes
 
-Read `../../references/operating-principles.md` for shared operating principles (data scope, DM flagging, signals vs diagnoses, connector unavailability).
+Read `references/operating-principles.md` for shared operating principles (data scope, DM flagging, signals vs diagnoses, connector unavailability).
 
 Additional notes specific to this skill:
 - **Don't draft talking points as scripts.** Frame as prompts: "You might want to discuss..." not "Say this..."

--- a/plugins/people-management/skills/meeting-prep/references/operating-principles.md
+++ b/plugins/people-management/skills/meeting-prep/references/operating-principles.md
@@ -1,0 +1,41 @@
+# Operating Principles
+
+Shared principles that apply to all People Manager skills. Every skill should reference this file and follow these principles.
+
+## Augment, Never Automate
+
+Every output is a draft for human review. Management is about human judgment, trust, and relationships. AI provides leverage on information-gathering. It never decides, prescribes, or acts on the manager's behalf.
+
+## Data Scope
+
+- All channels, documents, emails, and DMs the manager is part of are fair game.
+- **Never** surface DMs between other people that don't include the manager.
+- When using DM content, flag it as `(from DM)` so the manager knows it's sensitive context not visible to the team.
+- Wellbeing signals are especially sensitive. Surface gently, as conversation starters, never as conclusions.
+
+## Signals, Not Diagnoses
+
+- Never say "this person is disengaged" or "this person is struggling."
+- Always frame as "signal worth exploring" or "pattern to check in on."
+- Decreased activity could mean many things. Present observations, let the manager interpret.
+- Baseline matters: a quiet person being quiet isn't a signal. A usually active person going quiet might be.
+
+## Evidence Over Opinion
+
+- Every claim should link back to where you found it. Don't synthesise without attribution.
+- Recency matters. Prioritise recent information and flag anything older than ~2 months.
+- Absence of evidence is not evidence of absence, especially for values and behaviours best observed in person.
+
+## Connector Unavailability
+
+If an MCP connector (Slack, Notion, Gmail, Google Drive, Google Calendar) is unavailable or returns errors:
+1. Note which connector is unavailable
+2. Proceed with the data you can access from other connectors
+3. Flag the gap in your output so the manager knows what's missing
+4. Never silently skip a data source. Always tell the manager what you couldn't check
+
+## Source Everything
+
+- Link to the specific Slack message, Notion page, Drive doc, or email thread
+- "I found X in #channel on [date]" is better than "X is happening"
+- If volume is high, summarise with representative links rather than listing every item

--- a/plugins/people-management/skills/one-on-one-prep/SKILL.md
+++ b/plugins/people-management/skills/one-on-one-prep/SKILL.md
@@ -17,7 +17,7 @@ Deep-dive preparation for 1:1 meetings with a specific direct report, anchored i
 
 ## Instructions
 
-If any MCP connector is unavailable, follow the connector unavailability protocol in `../../references/operating-principles.md`.
+If any MCP connector is unavailable, follow the connector unavailability protocol in `references/operating-principles.md`.
 
 ### 1. Identify the Team Member
 
@@ -138,7 +138,7 @@ Using the goals location from the team member's profile:
 
 **Reference the org's performance framework dimensions** (from `manager-context/performance-framework.md`). Use the org's dimension names and sub-dimensions when checking goal progress. If this file doesn't exist, ask the manager to run `/setup` first.
 
-See the "Evidence Gathering Guidelines" section in `../../references/performance-framework.md` for what to look for per dimension type:
+See the "Evidence Gathering Guidelines" section in `references/performance-framework.md` for what to look for per dimension type:
 - **Results/delivery dimensions:** goal completion, shipped work, quality feedback, business outcomes
 - **Growth/development dimensions:** learning activities, new skills applied, scope expansion, behavioural changes
 - **Collaboration/leadership dimensions:** cross-team activity, mentoring, influence in discussions
@@ -194,7 +194,7 @@ Here's your prep for your 1:1 with [name]. Anything you'd like me to dig deeper 
 
 ## Important Notes
 
-Read `../../references/operating-principles.md` for shared operating principles (data scope, DM flagging, signals vs diagnoses, connector unavailability).
+Read `references/operating-principles.md` for shared operating principles (data scope, DM flagging, signals vs diagnoses, connector unavailability).
 
 Additional notes specific to this skill:
 - **Wins first.** Always lead with recognition opportunities. This sets the tone.

--- a/plugins/people-management/skills/one-on-one-prep/references/operating-principles.md
+++ b/plugins/people-management/skills/one-on-one-prep/references/operating-principles.md
@@ -1,0 +1,41 @@
+# Operating Principles
+
+Shared principles that apply to all People Manager skills. Every skill should reference this file and follow these principles.
+
+## Augment, Never Automate
+
+Every output is a draft for human review. Management is about human judgment, trust, and relationships. AI provides leverage on information-gathering. It never decides, prescribes, or acts on the manager's behalf.
+
+## Data Scope
+
+- All channels, documents, emails, and DMs the manager is part of are fair game.
+- **Never** surface DMs between other people that don't include the manager.
+- When using DM content, flag it as `(from DM)` so the manager knows it's sensitive context not visible to the team.
+- Wellbeing signals are especially sensitive. Surface gently, as conversation starters, never as conclusions.
+
+## Signals, Not Diagnoses
+
+- Never say "this person is disengaged" or "this person is struggling."
+- Always frame as "signal worth exploring" or "pattern to check in on."
+- Decreased activity could mean many things. Present observations, let the manager interpret.
+- Baseline matters: a quiet person being quiet isn't a signal. A usually active person going quiet might be.
+
+## Evidence Over Opinion
+
+- Every claim should link back to where you found it. Don't synthesise without attribution.
+- Recency matters. Prioritise recent information and flag anything older than ~2 months.
+- Absence of evidence is not evidence of absence, especially for values and behaviours best observed in person.
+
+## Connector Unavailability
+
+If an MCP connector (Slack, Notion, Gmail, Google Drive, Google Calendar) is unavailable or returns errors:
+1. Note which connector is unavailable
+2. Proceed with the data you can access from other connectors
+3. Flag the gap in your output so the manager knows what's missing
+4. Never silently skip a data source. Always tell the manager what you couldn't check
+
+## Source Everything
+
+- Link to the specific Slack message, Notion page, Drive doc, or email thread
+- "I found X in #channel on [date]" is better than "X is happening"
+- If volume is high, summarise with representative links rather than listing every item

--- a/plugins/people-management/skills/one-on-one-prep/references/performance-framework.md
+++ b/plugins/people-management/skills/one-on-one-prep/references/performance-framework.md
@@ -1,0 +1,47 @@
+# Performance Framework
+
+How this plugin uses your org's performance framework. The actual framework is configured during `/setup` and stored in `manager-context/performance-framework.md`.
+
+## What Setup Configures
+
+During `/setup` Phase 2, the plugin discovers or helps you define:
+
+- **Framework dimensions:** what your org evaluates (e.g., "What + How", "Impact + Growth", "Results + Behaviours", or something else entirely)
+- **Sub-dimensions:** the specific areas within each dimension
+- **Rating scale:** how performance is rated (descriptive labels, numbered scale, etc.)
+- **Promotion readiness labels:** how your org tracks promotion readiness (if applicable)
+- **Review cadence:** when reviews happen and what type
+- **Goal cadence:** how often goals are set and reviewed
+
+If your org doesn't have a formal framework, setup provides sensible defaults you can use or adjust.
+
+## How Skills Use the Framework
+
+| Skill | What it loads | How it uses it |
+|-------|--------------|----------------|
+| Performance Cycle | Full framework (dimensions, ratings, cadence) | Organises evidence by dimension, checks coverage |
+| 1:1 Prep | Dimensions and sub-dimensions | Maps development goals to framework, suggests questions |
+| Team Health | Dimensions (high-level) | Checks team patterns across framework areas |
+| Priority Planner | Dimensions (high-level) | Notes which framework area an action supports |
+
+## Evidence Gathering Guidelines
+
+When preparing reviews, skills look for evidence across:
+1. **Goal tracking systems:** Notion pages, OKR docs
+2. **Project deliverables:** shipped features, completed milestones, docs produced
+3. **Peer recognition:** Slack shoutouts, feedback from collaborators
+4. **Customer/stakeholder feedback:** visible in project channels, email threads
+5. **Development activities:** courses, workshops, mentoring, scope expansion
+
+**What digital signals CAN show:** Goal completion, project delivery, peer recognition, scope changes, activity patterns.
+
+**What digital signals CANNOT show:** Quality of thinking, relationship building, leadership presence, judgment calls, cultural contribution. These require the manager's direct observation.
+
+## Evidence Patterns by Dimension Type
+
+Skills use these heuristics to know what to search for, regardless of what your org calls its dimensions:
+
+- **Results/delivery dimensions:** goal completion, shipped work, quality feedback, business outcomes
+- **Growth/development dimensions:** learning activities, new skills applied, scope expansion, behavioural changes
+- **Collaboration/leadership dimensions:** cross-team activity, mentoring, influence in discussions
+- **Behavioural/values dimensions:** see `values-guide.md`

--- a/plugins/people-management/skills/performance-cycle/SKILL.md
+++ b/plugins/people-management/skills/performance-cycle/SKILL.md
@@ -28,7 +28,7 @@ If `manager-context/performance-framework.md` doesn't exist, ask the manager to 
 
 ## Instructions
 
-If any MCP connector is unavailable, follow the connector unavailability protocol in `../../references/operating-principles.md`.
+If any MCP connector is unavailable, follow the connector unavailability protocol in `references/operating-principles.md`.
 
 ### 1. Identify Scope
 
@@ -49,9 +49,9 @@ For the target team member, read from `manager-context/team/[name].md`:
 - Their projects and responsibilities
 
 Also load:
-- `manager-context/performance-framework.md`: org-specific framework dimensions and rating descriptors (falls back to `../../references/performance-framework.md` defaults)
-- `manager-context/management-framework.md`: org-specific management dimensions (falls back to `../../references/management-framework.md` defaults)
-- `../../references/values-guide.md`: values definitions and signal guidance
+- `manager-context/performance-framework.md`: org-specific framework dimensions and rating descriptors (falls back to `references/performance-framework.md` defaults)
+- `manager-context/management-framework.md`: org-specific management dimensions (falls back to `references/management-framework.md` defaults)
+- `references/values-guide.md`: values definitions and signal guidance
 - `manager-context/values.md`: the organization's specific values
 
 ### 3. Gather Evidence Along Each Dimension
@@ -74,7 +74,7 @@ For dimensions that are hardest to assess digitally (e.g., behavioural growth, l
 
 ### 4. Gather Values Evidence
 
-Values are the "how": how this person delivered their results and showed up for the team. Search for evidence across the organization's values (from `manager-context/values.md`). See `../../references/values-guide.md` for guidance on finding value signals.
+Values are the "how": how this person delivered their results and showed up for the team. Search for evidence across the organization's values (from `manager-context/values.md`). See `references/values-guide.md` for guidance on finding value signals.
 
 For each value defined in `manager-context/values.md`, search for evidence using the signal guidance stored there. Common evidence sources by value type:
 
@@ -146,7 +146,7 @@ Incorporate the reviewer's feedback before presenting the final summary to the m
 
 ## Important Notes
 
-Read `../../references/operating-principles.md` for shared operating principles (data scope, DM flagging, signals vs diagnoses, connector unavailability).
+Read `references/operating-principles.md` for shared operating principles (data scope, DM flagging, signals vs diagnoses, connector unavailability).
 
 Additional notes specific to this skill:
 - **NEVER suggest a rating.** Not even hints. The manager decides ratings. Period.

--- a/plugins/people-management/skills/performance-cycle/references/management-framework.md
+++ b/plugins/people-management/skills/performance-cycle/references/management-framework.md
@@ -1,0 +1,31 @@
+# Management Framework
+
+How this plugin uses your org's management framework. The actual framework is configured during `/setup` and stored in `manager-context/management-framework.md`.
+
+## What Setup Configures
+
+During `/setup` Phase 2, the plugin discovers or helps you define:
+
+- **Management dimensions:** what your org expects from managers (e.g., "Results + People", a competency model, or something custom)
+- **Competencies per dimension:** the specific skills or behaviours expected
+- **How managers are evaluated:** separate track, same as ICs, or informal
+
+If your org doesn't have a formal management framework, setup provides sensible defaults.
+
+## How Skills Map to Management
+
+Skills naturally support different management areas. The mapping uses whatever dimension names your org configured during setup.
+
+| Skill | What it supports |
+|-------|-----------------|
+| Triage Messages | Communication, staying responsive to the team |
+| Meeting Prep | Execution, being prepared and driving outcomes |
+| Priority Planner | Execution + people development, balancing delivery with growth |
+| 1:1 Prep | People development, investing in individual growth |
+| Team Health | Engagement, psychological safety, team culture |
+| Performance Cycle | Performance management, fair and evidence-based reviews |
+| Customer Status | Execution, delivery oversight |
+
+## Why This Matters
+
+The management framework gives skills a lens for connecting day-to-day actions to bigger management outcomes. When a priority planner suggests an action, it can note which management dimension it supports. When a team health check surfaces a pattern, it can connect to the relevant competency.

--- a/plugins/people-management/skills/performance-cycle/references/operating-principles.md
+++ b/plugins/people-management/skills/performance-cycle/references/operating-principles.md
@@ -1,0 +1,41 @@
+# Operating Principles
+
+Shared principles that apply to all People Manager skills. Every skill should reference this file and follow these principles.
+
+## Augment, Never Automate
+
+Every output is a draft for human review. Management is about human judgment, trust, and relationships. AI provides leverage on information-gathering. It never decides, prescribes, or acts on the manager's behalf.
+
+## Data Scope
+
+- All channels, documents, emails, and DMs the manager is part of are fair game.
+- **Never** surface DMs between other people that don't include the manager.
+- When using DM content, flag it as `(from DM)` so the manager knows it's sensitive context not visible to the team.
+- Wellbeing signals are especially sensitive. Surface gently, as conversation starters, never as conclusions.
+
+## Signals, Not Diagnoses
+
+- Never say "this person is disengaged" or "this person is struggling."
+- Always frame as "signal worth exploring" or "pattern to check in on."
+- Decreased activity could mean many things. Present observations, let the manager interpret.
+- Baseline matters: a quiet person being quiet isn't a signal. A usually active person going quiet might be.
+
+## Evidence Over Opinion
+
+- Every claim should link back to where you found it. Don't synthesise without attribution.
+- Recency matters. Prioritise recent information and flag anything older than ~2 months.
+- Absence of evidence is not evidence of absence, especially for values and behaviours best observed in person.
+
+## Connector Unavailability
+
+If an MCP connector (Slack, Notion, Gmail, Google Drive, Google Calendar) is unavailable or returns errors:
+1. Note which connector is unavailable
+2. Proceed with the data you can access from other connectors
+3. Flag the gap in your output so the manager knows what's missing
+4. Never silently skip a data source. Always tell the manager what you couldn't check
+
+## Source Everything
+
+- Link to the specific Slack message, Notion page, Drive doc, or email thread
+- "I found X in #channel on [date]" is better than "X is happening"
+- If volume is high, summarise with representative links rather than listing every item

--- a/plugins/people-management/skills/performance-cycle/references/performance-framework.md
+++ b/plugins/people-management/skills/performance-cycle/references/performance-framework.md
@@ -1,0 +1,47 @@
+# Performance Framework
+
+How this plugin uses your org's performance framework. The actual framework is configured during `/setup` and stored in `manager-context/performance-framework.md`.
+
+## What Setup Configures
+
+During `/setup` Phase 2, the plugin discovers or helps you define:
+
+- **Framework dimensions:** what your org evaluates (e.g., "What + How", "Impact + Growth", "Results + Behaviours", or something else entirely)
+- **Sub-dimensions:** the specific areas within each dimension
+- **Rating scale:** how performance is rated (descriptive labels, numbered scale, etc.)
+- **Promotion readiness labels:** how your org tracks promotion readiness (if applicable)
+- **Review cadence:** when reviews happen and what type
+- **Goal cadence:** how often goals are set and reviewed
+
+If your org doesn't have a formal framework, setup provides sensible defaults you can use or adjust.
+
+## How Skills Use the Framework
+
+| Skill | What it loads | How it uses it |
+|-------|--------------|----------------|
+| Performance Cycle | Full framework (dimensions, ratings, cadence) | Organises evidence by dimension, checks coverage |
+| 1:1 Prep | Dimensions and sub-dimensions | Maps development goals to framework, suggests questions |
+| Team Health | Dimensions (high-level) | Checks team patterns across framework areas |
+| Priority Planner | Dimensions (high-level) | Notes which framework area an action supports |
+
+## Evidence Gathering Guidelines
+
+When preparing reviews, skills look for evidence across:
+1. **Goal tracking systems:** Notion pages, OKR docs
+2. **Project deliverables:** shipped features, completed milestones, docs produced
+3. **Peer recognition:** Slack shoutouts, feedback from collaborators
+4. **Customer/stakeholder feedback:** visible in project channels, email threads
+5. **Development activities:** courses, workshops, mentoring, scope expansion
+
+**What digital signals CAN show:** Goal completion, project delivery, peer recognition, scope changes, activity patterns.
+
+**What digital signals CANNOT show:** Quality of thinking, relationship building, leadership presence, judgment calls, cultural contribution. These require the manager's direct observation.
+
+## Evidence Patterns by Dimension Type
+
+Skills use these heuristics to know what to search for, regardless of what your org calls its dimensions:
+
+- **Results/delivery dimensions:** goal completion, shipped work, quality feedback, business outcomes
+- **Growth/development dimensions:** learning activities, new skills applied, scope expansion, behavioural changes
+- **Collaboration/leadership dimensions:** cross-team activity, mentoring, influence in discussions
+- **Behavioural/values dimensions:** see `values-guide.md`

--- a/plugins/people-management/skills/performance-cycle/references/values-guide.md
+++ b/plugins/people-management/skills/performance-cycle/references/values-guide.md
@@ -1,0 +1,35 @@
+# Values Guide
+
+How to use your organization's values in management skills. Values are defined during setup and stored in `manager-context/values.md`.
+
+## Why Values Matter in Management
+
+Values tell you *how* results should be delivered, not just *what* was achieved. They give managers conversation threads beyond goals and deliverables:
+- In 1:1s: values provide prompts to check in on behaviours, not just outputs
+- In team health: values surface whether the team is thriving culturally, not just performing
+- In performance reviews: values evidence shows how someone showed up, not just what they shipped
+
+## How Skills Use Values
+
+Each skill references your org's values differently:
+
+| Skill | How values are used |
+|-------|-------------------|
+| 1:1 Prep | Values snapshot: scan for signals related to each value, suggest conversation threads |
+| Team Health | Values as a lens alongside performance: are people living the values? |
+| Performance Cycle | Values evidence gathering: "how" someone delivered, organised by value |
+| Priority Planner | Values inform what gets prioritised beyond urgency |
+
+## Defining Good Value Signals
+
+For each of your org's values, consider:
+- **What does it look like in Slack?** (e.g., collaboration value → helping others in channels, cross-team activity)
+- **What does it look like in meetings?** (e.g., transparency value → sharing context, raising issues early)
+- **What does it look like in work output?** (e.g., quality value → iteration, attention to detail, peer feedback)
+- **What's hard to see digitally?** (e.g., empathy, presence, trust-building, flag these for manager's own observation)
+
+## Important Notes
+
+- **Values evidence is hardest to gather digitally.** Many values are best observed in person. Always caveat that the manager's direct observations carry more weight.
+- **Values are conversation threads, not checklists.** Don't force every value into every 1:1 or health check. Surface values where there's a real signal.
+- **Absence of digital evidence ≠ absence of the behaviour.** Flag gaps honestly.

--- a/plugins/people-management/skills/priority-planner/SKILL.md
+++ b/plugins/people-management/skills/priority-planner/SKILL.md
@@ -18,7 +18,7 @@ Aggregates signals from multiple sources to surface the manager's highest-levera
 
 ## Instructions
 
-If any MCP connector is unavailable, follow the connector unavailability protocol in `../../references/operating-principles.md`.
+If any MCP connector is unavailable, follow the connector unavailability protocol in `references/operating-principles.md`.
 
 ### 1. Determine Scope
 
@@ -113,7 +113,7 @@ Here's a suggested priority plan. This is a starting point. Adjust based on your
 
 ## Important Notes
 
-Read `../../references/operating-principles.md` for shared operating principles (data scope, DM flagging, signals vs diagnoses, connector unavailability).
+Read `references/operating-principles.md` for shared operating principles (data scope, DM flagging, signals vs diagnoses, connector unavailability).
 
 Additional notes specific to this skill:
 - **Never prescribe.** Use "I'd suggest", "Consider". The manager knows context the tool doesn't.

--- a/plugins/people-management/skills/priority-planner/references/operating-principles.md
+++ b/plugins/people-management/skills/priority-planner/references/operating-principles.md
@@ -1,0 +1,41 @@
+# Operating Principles
+
+Shared principles that apply to all People Manager skills. Every skill should reference this file and follow these principles.
+
+## Augment, Never Automate
+
+Every output is a draft for human review. Management is about human judgment, trust, and relationships. AI provides leverage on information-gathering. It never decides, prescribes, or acts on the manager's behalf.
+
+## Data Scope
+
+- All channels, documents, emails, and DMs the manager is part of are fair game.
+- **Never** surface DMs between other people that don't include the manager.
+- When using DM content, flag it as `(from DM)` so the manager knows it's sensitive context not visible to the team.
+- Wellbeing signals are especially sensitive. Surface gently, as conversation starters, never as conclusions.
+
+## Signals, Not Diagnoses
+
+- Never say "this person is disengaged" or "this person is struggling."
+- Always frame as "signal worth exploring" or "pattern to check in on."
+- Decreased activity could mean many things. Present observations, let the manager interpret.
+- Baseline matters: a quiet person being quiet isn't a signal. A usually active person going quiet might be.
+
+## Evidence Over Opinion
+
+- Every claim should link back to where you found it. Don't synthesise without attribution.
+- Recency matters. Prioritise recent information and flag anything older than ~2 months.
+- Absence of evidence is not evidence of absence, especially for values and behaviours best observed in person.
+
+## Connector Unavailability
+
+If an MCP connector (Slack, Notion, Gmail, Google Drive, Google Calendar) is unavailable or returns errors:
+1. Note which connector is unavailable
+2. Proceed with the data you can access from other connectors
+3. Flag the gap in your output so the manager knows what's missing
+4. Never silently skip a data source. Always tell the manager what you couldn't check
+
+## Source Everything
+
+- Link to the specific Slack message, Notion page, Drive doc, or email thread
+- "I found X in #channel on [date]" is better than "X is happening"
+- If volume is high, summarise with representative links rather than listing every item

--- a/plugins/people-management/skills/setup/SKILL.md
+++ b/plugins/people-management/skills/setup/SKILL.md
@@ -9,7 +9,7 @@ description: "Interactive onboarding that discovers team structure, terminology,
 
 Interactive onboarding that builds the foundation every other skill relies on. Crawls connected sources, extracts context, and validates with the manager before saving.
 
-If any MCP connector is unavailable, follow the connector unavailability protocol in `../../references/operating-principles.md`.
+If any MCP connector is unavailable, follow the connector unavailability protocol in `references/operating-principles.md`.
 
 ## Prerequisites
 
@@ -32,7 +32,7 @@ Identify the manager (name, role, teams), crawl sources for direct reports, vali
 Persist: `manager-context/manager-profile.md`, `manager-context/team/[name].md` per report, `manager-context/terminology.md`, `manager-context/sources.md`
 
 ### Phase 2: Performance & Management Frameworks
-Discover how the org evaluates performance and managers. Search for existing framework docs, then walk the manager through defining their dimensions, rating scale, promotion readiness labels, review cadence, goal cadence, and management competencies. See `../../references/performance-framework.md` and `../../references/management-framework.md` for how skills use these frameworks.
+Discover how the org evaluates performance and managers. Search for existing framework docs, then walk the manager through defining their dimensions, rating scale, promotion readiness labels, review cadence, goal cadence, and management competencies. See `references/performance-framework.md` and `references/management-framework.md` for how skills use these frameworks.
 
 Persist: `manager-context/performance-framework.md`, `manager-context/management-framework.md`
 
@@ -83,7 +83,7 @@ When called with `--refresh`:
 
 ## Important Notes
 
-Read `../../references/operating-principles.md` for shared principles (data scope, DM flagging, connector unavailability).
+Read `references/operating-principles.md` for shared principles (data scope, DM flagging, connector unavailability).
 
 - **Never assume, always validate.** If something looks like a team member but you're not sure, ask.
 - **Flag gaps explicitly.** "I couldn't find X" is more useful than silently skipping it.

--- a/plugins/people-management/skills/setup/references/discovery-phases.md
+++ b/plugins/people-management/skills/setup/references/discovery-phases.md
@@ -378,7 +378,7 @@ These will be used as a lens in 1:1 prep, team health, and performance reviews.
 Any values I should weigh more heavily? Any to skip in certain skills?
 ```
 
-Persist to `manager-context/values.md`. Read `references/context-templates.md` for the template. See `../../references/values-guide.md` for how skills use values.
+Persist to `manager-context/values.md`. Read `references/context-templates.md` for the template. See `values-guide.md` for how skills use values.
 
 ---
 

--- a/plugins/people-management/skills/setup/references/management-framework.md
+++ b/plugins/people-management/skills/setup/references/management-framework.md
@@ -1,0 +1,31 @@
+# Management Framework
+
+How this plugin uses your org's management framework. The actual framework is configured during `/setup` and stored in `manager-context/management-framework.md`.
+
+## What Setup Configures
+
+During `/setup` Phase 2, the plugin discovers or helps you define:
+
+- **Management dimensions:** what your org expects from managers (e.g., "Results + People", a competency model, or something custom)
+- **Competencies per dimension:** the specific skills or behaviours expected
+- **How managers are evaluated:** separate track, same as ICs, or informal
+
+If your org doesn't have a formal management framework, setup provides sensible defaults.
+
+## How Skills Map to Management
+
+Skills naturally support different management areas. The mapping uses whatever dimension names your org configured during setup.
+
+| Skill | What it supports |
+|-------|-----------------|
+| Triage Messages | Communication, staying responsive to the team |
+| Meeting Prep | Execution, being prepared and driving outcomes |
+| Priority Planner | Execution + people development, balancing delivery with growth |
+| 1:1 Prep | People development, investing in individual growth |
+| Team Health | Engagement, psychological safety, team culture |
+| Performance Cycle | Performance management, fair and evidence-based reviews |
+| Customer Status | Execution, delivery oversight |
+
+## Why This Matters
+
+The management framework gives skills a lens for connecting day-to-day actions to bigger management outcomes. When a priority planner suggests an action, it can note which management dimension it supports. When a team health check surfaces a pattern, it can connect to the relevant competency.

--- a/plugins/people-management/skills/setup/references/operating-principles.md
+++ b/plugins/people-management/skills/setup/references/operating-principles.md
@@ -1,0 +1,41 @@
+# Operating Principles
+
+Shared principles that apply to all People Manager skills. Every skill should reference this file and follow these principles.
+
+## Augment, Never Automate
+
+Every output is a draft for human review. Management is about human judgment, trust, and relationships. AI provides leverage on information-gathering. It never decides, prescribes, or acts on the manager's behalf.
+
+## Data Scope
+
+- All channels, documents, emails, and DMs the manager is part of are fair game.
+- **Never** surface DMs between other people that don't include the manager.
+- When using DM content, flag it as `(from DM)` so the manager knows it's sensitive context not visible to the team.
+- Wellbeing signals are especially sensitive. Surface gently, as conversation starters, never as conclusions.
+
+## Signals, Not Diagnoses
+
+- Never say "this person is disengaged" or "this person is struggling."
+- Always frame as "signal worth exploring" or "pattern to check in on."
+- Decreased activity could mean many things. Present observations, let the manager interpret.
+- Baseline matters: a quiet person being quiet isn't a signal. A usually active person going quiet might be.
+
+## Evidence Over Opinion
+
+- Every claim should link back to where you found it. Don't synthesise without attribution.
+- Recency matters. Prioritise recent information and flag anything older than ~2 months.
+- Absence of evidence is not evidence of absence, especially for values and behaviours best observed in person.
+
+## Connector Unavailability
+
+If an MCP connector (Slack, Notion, Gmail, Google Drive, Google Calendar) is unavailable or returns errors:
+1. Note which connector is unavailable
+2. Proceed with the data you can access from other connectors
+3. Flag the gap in your output so the manager knows what's missing
+4. Never silently skip a data source. Always tell the manager what you couldn't check
+
+## Source Everything
+
+- Link to the specific Slack message, Notion page, Drive doc, or email thread
+- "I found X in #channel on [date]" is better than "X is happening"
+- If volume is high, summarise with representative links rather than listing every item

--- a/plugins/people-management/skills/setup/references/performance-framework.md
+++ b/plugins/people-management/skills/setup/references/performance-framework.md
@@ -1,0 +1,47 @@
+# Performance Framework
+
+How this plugin uses your org's performance framework. The actual framework is configured during `/setup` and stored in `manager-context/performance-framework.md`.
+
+## What Setup Configures
+
+During `/setup` Phase 2, the plugin discovers or helps you define:
+
+- **Framework dimensions:** what your org evaluates (e.g., "What + How", "Impact + Growth", "Results + Behaviours", or something else entirely)
+- **Sub-dimensions:** the specific areas within each dimension
+- **Rating scale:** how performance is rated (descriptive labels, numbered scale, etc.)
+- **Promotion readiness labels:** how your org tracks promotion readiness (if applicable)
+- **Review cadence:** when reviews happen and what type
+- **Goal cadence:** how often goals are set and reviewed
+
+If your org doesn't have a formal framework, setup provides sensible defaults you can use or adjust.
+
+## How Skills Use the Framework
+
+| Skill | What it loads | How it uses it |
+|-------|--------------|----------------|
+| Performance Cycle | Full framework (dimensions, ratings, cadence) | Organises evidence by dimension, checks coverage |
+| 1:1 Prep | Dimensions and sub-dimensions | Maps development goals to framework, suggests questions |
+| Team Health | Dimensions (high-level) | Checks team patterns across framework areas |
+| Priority Planner | Dimensions (high-level) | Notes which framework area an action supports |
+
+## Evidence Gathering Guidelines
+
+When preparing reviews, skills look for evidence across:
+1. **Goal tracking systems:** Notion pages, OKR docs
+2. **Project deliverables:** shipped features, completed milestones, docs produced
+3. **Peer recognition:** Slack shoutouts, feedback from collaborators
+4. **Customer/stakeholder feedback:** visible in project channels, email threads
+5. **Development activities:** courses, workshops, mentoring, scope expansion
+
+**What digital signals CAN show:** Goal completion, project delivery, peer recognition, scope changes, activity patterns.
+
+**What digital signals CANNOT show:** Quality of thinking, relationship building, leadership presence, judgment calls, cultural contribution. These require the manager's direct observation.
+
+## Evidence Patterns by Dimension Type
+
+Skills use these heuristics to know what to search for, regardless of what your org calls its dimensions:
+
+- **Results/delivery dimensions:** goal completion, shipped work, quality feedback, business outcomes
+- **Growth/development dimensions:** learning activities, new skills applied, scope expansion, behavioural changes
+- **Collaboration/leadership dimensions:** cross-team activity, mentoring, influence in discussions
+- **Behavioural/values dimensions:** see `values-guide.md`

--- a/plugins/people-management/skills/setup/references/values-guide.md
+++ b/plugins/people-management/skills/setup/references/values-guide.md
@@ -1,0 +1,35 @@
+# Values Guide
+
+How to use your organization's values in management skills. Values are defined during setup and stored in `manager-context/values.md`.
+
+## Why Values Matter in Management
+
+Values tell you *how* results should be delivered, not just *what* was achieved. They give managers conversation threads beyond goals and deliverables:
+- In 1:1s: values provide prompts to check in on behaviours, not just outputs
+- In team health: values surface whether the team is thriving culturally, not just performing
+- In performance reviews: values evidence shows how someone showed up, not just what they shipped
+
+## How Skills Use Values
+
+Each skill references your org's values differently:
+
+| Skill | How values are used |
+|-------|-------------------|
+| 1:1 Prep | Values snapshot: scan for signals related to each value, suggest conversation threads |
+| Team Health | Values as a lens alongside performance: are people living the values? |
+| Performance Cycle | Values evidence gathering: "how" someone delivered, organised by value |
+| Priority Planner | Values inform what gets prioritised beyond urgency |
+
+## Defining Good Value Signals
+
+For each of your org's values, consider:
+- **What does it look like in Slack?** (e.g., collaboration value → helping others in channels, cross-team activity)
+- **What does it look like in meetings?** (e.g., transparency value → sharing context, raising issues early)
+- **What does it look like in work output?** (e.g., quality value → iteration, attention to detail, peer feedback)
+- **What's hard to see digitally?** (e.g., empathy, presence, trust-building, flag these for manager's own observation)
+
+## Important Notes
+
+- **Values evidence is hardest to gather digitally.** Many values are best observed in person. Always caveat that the manager's direct observations carry more weight.
+- **Values are conversation threads, not checklists.** Don't force every value into every 1:1 or health check. Surface values where there's a real signal.
+- **Absence of digital evidence ≠ absence of the behaviour.** Flag gaps honestly.

--- a/plugins/people-management/skills/team-health/SKILL.md
+++ b/plugins/people-management/skills/team-health/SKILL.md
@@ -18,7 +18,7 @@ A periodic overview of team dynamics, engagement signals, wellbeing, and develop
 
 ## Instructions
 
-If any MCP connector is unavailable, follow the connector unavailability protocol in `../../references/operating-principles.md`.
+If any MCP connector is unavailable, follow the connector unavailability protocol in `references/operating-principles.md`.
 
 ### 1. Load Team Context
 
@@ -128,7 +128,7 @@ Incorporate the reviewer's feedback before presenting the final health check to 
 
 ## Important Notes
 
-Read `../../references/operating-principles.md` for shared operating principles (data scope, DM flagging, signals vs diagnoses, connector unavailability).
+Read `references/operating-principles.md` for shared operating principles (data scope, DM flagging, signals vs diagnoses, connector unavailability).
 
 Additional notes specific to this skill:
 - **Celebrate first.** Lead with wins, recognition, and positive energy. Wellbeing & Connection starts with seeing the good.

--- a/plugins/people-management/skills/team-health/references/operating-principles.md
+++ b/plugins/people-management/skills/team-health/references/operating-principles.md
@@ -1,0 +1,41 @@
+# Operating Principles
+
+Shared principles that apply to all People Manager skills. Every skill should reference this file and follow these principles.
+
+## Augment, Never Automate
+
+Every output is a draft for human review. Management is about human judgment, trust, and relationships. AI provides leverage on information-gathering. It never decides, prescribes, or acts on the manager's behalf.
+
+## Data Scope
+
+- All channels, documents, emails, and DMs the manager is part of are fair game.
+- **Never** surface DMs between other people that don't include the manager.
+- When using DM content, flag it as `(from DM)` so the manager knows it's sensitive context not visible to the team.
+- Wellbeing signals are especially sensitive. Surface gently, as conversation starters, never as conclusions.
+
+## Signals, Not Diagnoses
+
+- Never say "this person is disengaged" or "this person is struggling."
+- Always frame as "signal worth exploring" or "pattern to check in on."
+- Decreased activity could mean many things. Present observations, let the manager interpret.
+- Baseline matters: a quiet person being quiet isn't a signal. A usually active person going quiet might be.
+
+## Evidence Over Opinion
+
+- Every claim should link back to where you found it. Don't synthesise without attribution.
+- Recency matters. Prioritise recent information and flag anything older than ~2 months.
+- Absence of evidence is not evidence of absence, especially for values and behaviours best observed in person.
+
+## Connector Unavailability
+
+If an MCP connector (Slack, Notion, Gmail, Google Drive, Google Calendar) is unavailable or returns errors:
+1. Note which connector is unavailable
+2. Proceed with the data you can access from other connectors
+3. Flag the gap in your output so the manager knows what's missing
+4. Never silently skip a data source. Always tell the manager what you couldn't check
+
+## Source Everything
+
+- Link to the specific Slack message, Notion page, Drive doc, or email thread
+- "I found X in #channel on [date]" is better than "X is happening"
+- If volume is high, summarise with representative links rather than listing every item

--- a/plugins/people-management/skills/triage-messages/SKILL.md
+++ b/plugins/people-management/skills/triage-messages/SKILL.md
@@ -18,7 +18,7 @@ Scans unread Slack messages and recent emails, categorises them by urgency and t
 
 ## Instructions
 
-If any MCP connector is unavailable, follow the connector unavailability protocol in `../../references/operating-principles.md`.
+If any MCP connector is unavailable, follow the connector unavailability protocol in `references/operating-principles.md`.
 
 ### 1. Determine Time Window
 
@@ -122,7 +122,7 @@ That's your triage for [time window]. Want me to:
 
 ## Important Notes
 
-Read `../../references/operating-principles.md` for shared operating principles (data scope, DM flagging, signals vs diagnoses, connector unavailability).
+Read `references/operating-principles.md` for shared operating principles (data scope, DM flagging, signals vs diagnoses, connector unavailability).
 
 Additional notes specific to this skill:
 - **Never draft replies.** The manager writes their own messages. This skill only surfaces and categorises.

--- a/plugins/people-management/skills/triage-messages/references/operating-principles.md
+++ b/plugins/people-management/skills/triage-messages/references/operating-principles.md
@@ -1,0 +1,41 @@
+# Operating Principles
+
+Shared principles that apply to all People Manager skills. Every skill should reference this file and follow these principles.
+
+## Augment, Never Automate
+
+Every output is a draft for human review. Management is about human judgment, trust, and relationships. AI provides leverage on information-gathering. It never decides, prescribes, or acts on the manager's behalf.
+
+## Data Scope
+
+- All channels, documents, emails, and DMs the manager is part of are fair game.
+- **Never** surface DMs between other people that don't include the manager.
+- When using DM content, flag it as `(from DM)` so the manager knows it's sensitive context not visible to the team.
+- Wellbeing signals are especially sensitive. Surface gently, as conversation starters, never as conclusions.
+
+## Signals, Not Diagnoses
+
+- Never say "this person is disengaged" or "this person is struggling."
+- Always frame as "signal worth exploring" or "pattern to check in on."
+- Decreased activity could mean many things. Present observations, let the manager interpret.
+- Baseline matters: a quiet person being quiet isn't a signal. A usually active person going quiet might be.
+
+## Evidence Over Opinion
+
+- Every claim should link back to where you found it. Don't synthesise without attribution.
+- Recency matters. Prioritise recent information and flag anything older than ~2 months.
+- Absence of evidence is not evidence of absence, especially for values and behaviours best observed in person.
+
+## Connector Unavailability
+
+If an MCP connector (Slack, Notion, Gmail, Google Drive, Google Calendar) is unavailable or returns errors:
+1. Note which connector is unavailable
+2. Proceed with the data you can access from other connectors
+3. Flag the gap in your output so the manager knows what's missing
+4. Never silently skip a data source. Always tell the manager what you couldn't check
+
+## Source Everything
+
+- Link to the specific Slack message, Notion page, Drive doc, or email thread
+- "I found X in #channel on [date]" is better than "X is happening"
+- If volume is high, summarise with representative links rather than listing every item


### PR DESCRIPTION
## Problem

`install.sh` (the Codex installer) copied only `skills/<skill>/` into `~/.codex/skills/`. Any plugin-root shared dir a skill reads "from this plugin" never reached Codex, so several skills silently broke there. Claude Code was unaffected (it never runs `install.sh`; it resolves via the plugin root).

Found while verifying all plugins still work in Codex. Three plugins hit the same root cause:

1. **knowledge-base** — `setup-knowledge-base` reads/copies `kb-index.py`, `kb-verify.py`, `kb-validate.py`, `kb-search.py` and the `kb/` templates "from this plugin". None were installed in Codex → setup and `kb-answer` (which depends on `kb-verify.py`) were broken.
2. **content-studio** — `setup-content-studio` copies the bundled Next.js app, `scripts/`, and `hooks/` from `<plugin-path>`; none were staged into Codex.
3. **people-management** — skills referenced shared framework docs via `../../references/X`, which resolves *outside* the skill (`~/.codex/references/`) in Codex's flat install.

## Fix

- **`install.sh`**: stage every plugin-root subdir except framework dirs (`skills/`, `codex/`, `.claude-plugin/`) into each installed skill, copied *before* the skill payload so skill-local files win on conflict. This is the single root-cause fix; it makes each skill self-contained under Codex's flat layout (the same way every other skill already references its own `references/`).
- **content-studio**: `repo-setup.md` now documents that `<plugin-path>` = plugin root in Claude Code and the skill's own dir in Codex (where assets are now staged). The "parallel Task agents" batching step notes a sequential fallback for agents without sub-agents (e.g. Codex) — identical output.
- **people-management**: converted the outlier `../../references/X` paths to the standard skill-relative `references/X`, and bundled the shared framework docs into each skill that cites them. Resolves in both Claude Code (skill-local copy in source) and Codex (skill payload).

## Versions

Repo 1.6.0 → 1.6.1; content-studio + knowledge-base 1.1.0 → 1.1.1; people-management 1.2.0 → 1.2.1.

## Testing

- `bash -n install.sh` clean; fresh install, idempotent re-install, and standalone `verify` all green for **all 7 plugins / 26 skills**.
- Confirmed in a clean target: `kb-*.py` + templates land under `setup-knowledge-base/`; the content-studio app (50 files) + hooks + scripts land under `setup-content-studio/`; every people-management `references/X` resolves to a real file next to its `SKILL.md`.
- Skill-local scripts preserved (no clobber); plugins without shared dirs unaffected; uninstall removes staged assets cleanly; `--target` isolation intact.

## Known follow-up

Skills still lean on Claude-only niceties (sub-agent review, `AskUserQuestion`) that gracefully degrade in Codex — these are runtime conveniences, not install breakage, and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)