### PR TITLE
Add Google Antigravity install target + marketplace manifest (v1.7.0)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,60 @@
+{
+  "name": "techwolf-ai-first",
+  "interface": {
+    "displayName": "TechWolf AI-First"
+  },
+  "metadata": {
+    "description": "AI-first skills and tools from TechWolf's ai-first.techwolf.ai training program"
+  },
+  "plugins": [
+    {
+      "name": "content-studio",
+      "source": { "source": "local", "path": "./plugins/content-studio" },
+      "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" },
+      "category": "Content & Marketing",
+      "description": "Content studio for managing thought leadership content with a visual editor, agent skills, and utility scripts."
+    },
+    {
+      "name": "ai-firstify",
+      "source": { "source": "local", "path": "./plugins/ai-firstify" },
+      "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" },
+      "category": "Development & Architecture",
+      "description": "AI-first project auditor and re-engineer based on the 9 design principles and 7 design patterns from the TechWolf AI-First Bootcamp"
+    },
+    {
+      "name": "people-management",
+      "source": { "source": "local", "path": "./plugins/people-management" },
+      "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" },
+      "category": "Productivity",
+      "description": "AI-augmented management tooling for people managers. Surfaces the right context at the right time. Adapts to your org's performance and management frameworks."
+    },
+    {
+      "name": "techwolf-brand-kit",
+      "source": { "source": "local", "path": "./plugins/techwolf-brand-kit" },
+      "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" },
+      "category": "Design & Branding",
+      "description": "Official TechWolf brand assets for AI-generated outputs. Provides logo files in multiple variants as SVG and PNG."
+    },
+    {
+      "name": "knowledge-base",
+      "source": { "source": "local", "path": "./plugins/knowledge-base" },
+      "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" },
+      "category": "Knowledge & Research",
+      "description": "Build and query a structured, evidence-backed knowledge base. Every answer cites literal quotes from your KB files."
+    },
+    {
+      "name": "ai-adoption",
+      "source": { "source": "local", "path": "./plugins/ai-adoption" },
+      "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" },
+      "category": "Analytics & Insights",
+      "description": "Three skills for working with your Claude history. token-doctor diagnoses where your spend goes. task-profile mines sessions into a role-level task map. session-search finds past sessions by title, cwd, time range, or content."
+    },
+    {
+      "name": "tool-build-kit",
+      "source": { "source": "local", "path": "./plugins/tool-build-kit" },
+      "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" },
+      "category": "Development & Architecture",
+      "description": "Build an MCP server the right way, end to end. Branches on audience (personal, org, public) and walks through analyze, build, deploy, scale, and distribute."
+    }
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,20 +1,23 @@
 # TechWolf AI-First Toolkit
 
-This repository publishes TechWolf AI-first plugins and skills for both Claude Code and Codex.
+This repository publishes TechWolf AI-first plugins and skills for Claude Code, Codex, and Google Antigravity.
 
 ## Repository Purpose
 
 - `plugins/<plugin>/` is the source of truth for each plugin.
-- Claude-specific plugin metadata lives in `.claude-plugin/`.
-- Codex-compatible skills live in each plugin's `skills/` directory.
-- Codex installs are managed via `./install.sh`.
+- The `skills/` directory in each plugin holds the `SKILL.md` packages, shared verbatim across all three targets (agentskills.io spec). There is no per-target skill rewrite.
+- Per-target metadata is the only thing that differs:
+  - Claude Code: `.claude-plugin/marketplace.json` (root) and `plugins/<plugin>/.claude-plugin/plugin.json`.
+  - Antigravity / vendor-neutral: `.agents/plugins/marketplace.json` (root) and `plugins/<plugin>/plugin.json` (Antigravity plugin marker).
+- Codex and Antigravity installs are both managed via `./install.sh` (Codex is the default; `--ide antigravity` installs one self-contained plugin dir per plugin into `~/.gemini/config/plugins/`, matching where Antigravity keeps its own plugins).
 
 ## Working Conventions
 
-- Preserve the mapping between a plugin and its Codex-installed skills.
-- When changing a plugin, update both Claude-facing and Codex-facing docs if behavior changes.
-- If Codex install behavior changes, update `README.md`, plugin READMEs, and `CHANGELOG.md`.
-- Prefer adding Codex guidance under `plugins/<plugin>/codex/AGENTS.md` when plugin-specific instructions are needed.
+- Preserve the mapping between a plugin and its installed skills across all targets.
+- When adding or renaming a plugin, update **both** marketplace manifests (`.claude-plugin/marketplace.json` and `.agents/plugins/marketplace.json`) and add the per-plugin `plugin.json` marker, keeping name/version/description in sync with `.claude-plugin/plugin.json`.
+- When changing a plugin, update Claude-, Codex-, and Antigravity-facing docs if behavior changes.
+- If install behavior changes, update `README.md`, plugin READMEs, and `CHANGELOG.md`.
+- Prefer adding plugin-specific agent guidance under `plugins/<plugin>/codex/AGENTS.md` (the installer copies it into the install state dir for both Codex and Antigravity targets).
 
 ## Codex Install Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog and this project follows Semantic Versioning.
 
+## [1.7.0] - 2026-06-12
+
+### Added
+
+- Google Antigravity support. The toolkit's plugins now install into Antigravity (and the Gemini CLI) end to end, reusing the existing `SKILL.md` packages unchanged.
+  - `install.sh` gains an `--ide <codex|antigravity>` flag. `--ide antigravity` installs one self-contained dir per plugin into `~/.gemini/config/plugins/<plugin>/` (`plugin.json` + `installed_version.json` + `skills/`), matching where Antigravity keeps its own plugins. Codex remains the default (flat skills into `~/.codex/skills/`). An explicit `--target` still overrides either. All lifecycle commands (`install`, `update`, `verify`, `uninstall`, `list`) work for both targets, including the plugin-root shared-asset staging.
+  - `.agents/plugins/marketplace.json`: vendor-neutral marketplace manifest (Antigravity schema with `interface.displayName`, per-plugin `source`, `policy`, and `category`) listing all 7 plugins, so Antigravity can discover the toolkit as a plugin marketplace.
+  - `plugins/<plugin>/plugin.json`: an Antigravity plugin marker per plugin (name, version, description kept in sync with `.claude-plugin/plugin.json`).
+- README and `AGENTS.md` document the third target and the dual-manifest convention; added an Antigravity badge.
+
 ## [1.6.1] - 2026-06-10
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,8 @@ Thanks for your interest in contributing to the TechWolf AI-First Toolkit!
 ```
 plugins/
   <plugin-name>/
-    .claude-plugin/     # Plugin manifest
+    .claude-plugin/     # Claude Code plugin manifest
+    plugin.json         # Antigravity plugin marker
     skills/
       <skill-name>/
         SKILL.md        # Skill definition (agentskills.io spec)
@@ -39,7 +40,7 @@ plugins/
 
 1. Keep PRs focused: one feature or fix per PR
 2. Update relevant READMEs if your change affects usage
-3. Test your skills with Claude Code (and Codex via `./install.sh` if possible)
+3. Test your skills with Claude Code (and Codex / Google Antigravity via `./install.sh` if possible)
 4. Open a PR against `main` with a clear description of what and why
 
 ## Code Style

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # TechWolf AI-First Toolkit
 
-![MIT License](https://img.shields.io/badge/license-MIT-blue.svg) ![v1.6.1](https://img.shields.io/badge/version-1.6.1-green.svg) ![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-blueviolet.svg) ![Codex](https://img.shields.io/badge/Codex-compatible-orange.svg) ![agentskills.io](https://img.shields.io/badge/agentskills.io-spec-lightgrey.svg)
+![MIT License](https://img.shields.io/badge/license-MIT-blue.svg) ![v1.7.0](https://img.shields.io/badge/version-1.7.0-green.svg) ![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-blueviolet.svg) ![Codex](https://img.shields.io/badge/Codex-compatible-orange.svg) ![Antigravity](https://img.shields.io/badge/Antigravity-compatible-4285F4.svg) ![agentskills.io](https://img.shields.io/badge/agentskills.io-spec-lightgrey.svg)
 
-Open-source Claude Code skills and Codex skills from [TechWolf](https://techwolf.ai)'s [AI-First Bootcamp](https://ai-first.techwolf.ai).
+Open-source agent skills from [TechWolf](https://techwolf.ai)'s [AI-First Bootcamp](https://ai-first.techwolf.ai), for Claude Code, Codex, and Google Antigravity.
 
 <!-- TODO: Replace with hero GIF showing ai-firstify audit in action -->
 
@@ -26,7 +26,7 @@ claude plugin marketplace add techwolf-ai/ai-first-toolkit
 | **techwolf-brand-kit** | Official TechWolf logo assets (SVG + PNG) for AI-generated outputs | `claude plugin install techwolf-brand-kit@techwolf-ai-first` |
 | **tool-build-kit** | Build an MCP server end to end: analyze, build, deploy, scale, distribute | `claude plugin install tool-build-kit@techwolf-ai-first` |
 
-Not using Claude Code? Every skill follows the [agentskills.io](https://agentskills.io) spec and installs into Codex via [`./install.sh`](#codex).
+Not using Claude Code? Every skill follows the [agentskills.io](https://agentskills.io) spec and installs into Codex or Google Antigravity via [`./install.sh`](#codex).
 
 ## What's inside
 
@@ -137,12 +137,28 @@ Skills follow the [agentskills.io](https://agentskills.io) spec:
 
 </details>
 
+### Google Antigravity
+
+The same skills install into Antigravity, which keeps one self-contained dir per plugin under `~/.gemini/config/plugins/`. Pass `--ide antigravity`:
+
+```bash
+./install.sh install --ide antigravity                 # all plugins
+./install.sh install ai-firstify --ide antigravity     # one plugin
+./install.sh list --ide antigravity
+./install.sh uninstall ai-firstify --ide antigravity
+```
+
+Each plugin installs as `~/.gemini/config/plugins/<plugin>/` with a `plugin.json`, an `installed_version.json`, and a `skills/` directory, the same shape Antigravity uses for its own plugins. For repo-side discovery as a marketplace, Antigravity reads [`.agents/plugins/marketplace.json`](.agents/plugins/marketplace.json) (the vendor-neutral `.agents/` standard), and each plugin carries an Antigravity `plugin.json` marker at `plugins/<plugin>/plugin.json`. Skills are the same `SKILL.md` files used by Claude Code and Codex, no per-target rewrite.
+
 ## Repository structure
 
 ```
 ai-first-toolkit/
 ├── .claude-plugin/
-│   └── marketplace.json        # Marketplace manifest
+│   └── marketplace.json        # Claude Code marketplace manifest
+├── .agents/
+│   └── plugins/
+│       └── marketplace.json    # Antigravity / vendor-neutral marketplace manifest
 ├── plugins/
 │   ├── ai-firstify/            # Auditor & re-engineer (1 skill, 9 reference docs)
 │   ├── content-studio/         # Content pipeline (8 skills, visual editor, hooks)
@@ -151,11 +167,11 @@ ai-first-toolkit/
 │   ├── ai-adoption/            # Claude history analytics (3 skills: token-doctor, task-profile, session-search)
 │   ├── techwolf-brand-kit/     # Brand assets (logo variants in SVG + PNG)
 │   └── tool-build-kit/         # MCP server builder (1 skill: build-mcp, 6 reference files)
-├── install.sh                  # Codex skill installer
+├── install.sh                  # Codex + Antigravity skill installer
 └── README.md
 ```
 
-Each plugin lives in `plugins/<name>/` with a `.claude-plugin/` manifest and `skills/` directory containing `SKILL.md` files. See individual plugin READMEs for details:
+Each plugin lives in `plugins/<name>/` with a `.claude-plugin/` manifest, an Antigravity `plugin.json` marker, and a `skills/` directory of `SKILL.md` files shared across all targets. See individual plugin READMEs for details:
 
 - [ai-firstify README](plugins/ai-firstify/README.md)
 - [content-studio README](plugins/content-studio/README.md)

--- a/install.sh
+++ b/install.sh
@@ -1,23 +1,47 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-TARGET="${HOME}/.codex/skills"
+IDE="codex"
+TARGET=""
 ACTION="install"
 PLUGIN=""
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 STATE_DIR_NAME=".techwolf-ai-first"
 
+# Default install dir per IDE. An explicit --target overrides either.
+#   codex:       ~/.codex/skills        flat per-skill dirs: <target>/<skill>/
+#   antigravity: ~/.gemini/config/plugins  one dir per plugin, preserving the
+#                plugin shape Antigravity expects:
+#                  <target>/<plugin>/plugin.json
+#                  <target>/<plugin>/installed_version.json
+#                  <target>/<plugin>/skills/<skill>/SKILL.md
+# Skills are staged identically in both (plugin-root shared assets copied next to
+# each SKILL.md); only the surrounding directory shape differs.
+default_target_for_ide() {
+  case "$1" in
+    codex) echo "${HOME}/.codex/skills" ;;
+    antigravity) echo "${HOME}/.gemini/config/plugins" ;;
+    *) echo "" ;;
+  esac
+}
+
 usage() {
   cat <<'EOF'
 Usage:
-  ./install.sh [install|update|uninstall|verify|list] [plugin] [--target <dir>]
+  ./install.sh [install|update|uninstall|verify|list] [plugin] [--ide <codex|antigravity>] [--target <dir>]
+
+Targets:
+  --ide codex        Install into ~/.codex/skills (default)
+  --ide antigravity  Install into ~/.gemini/config/plugins (Antigravity)
+  --target <dir>     Override the install dir for either IDE
 
 Examples:
   ./install.sh
   ./install.sh content-studio
   ./install.sh install ai-firstify
+  ./install.sh install ai-firstify --ide antigravity
   ./install.sh update content-studio
-  ./install.sh uninstall content-studio
+  ./install.sh uninstall content-studio --ide antigravity
   ./install.sh verify
   ./install.sh --target /tmp/codex-skills
 EOF
@@ -51,9 +75,37 @@ plugin_guide_src() {
   echo "${SCRIPT_DIR}/plugins/${plugin_name}/codex/AGENTS.md"
 }
 
+# Where a plugin's files live under TARGET. Codex flattens skills directly into
+# TARGET; Antigravity keeps one self-contained dir per plugin.
+plugin_install_root() {
+  local plugin_name="$1"
+  if [[ "$IDE" == "antigravity" ]]; then
+    echo "${TARGET}/${plugin_name}"
+  else
+    echo "${TARGET}"
+  fi
+}
+
+# Where a single skill's payload lands.
+skill_install_dir() {
+  local plugin_name="$1"
+  local skill_name="$2"
+  if [[ "$IDE" == "antigravity" ]]; then
+    echo "${TARGET}/${plugin_name}/skills/${skill_name}"
+  else
+    echo "${TARGET}/${skill_name}"
+  fi
+}
+
 plugin_state_dir() {
   local plugin_name="$1"
-  echo "${TARGET}/${STATE_DIR_NAME}/plugins/${plugin_name}"
+  if [[ "$IDE" == "antigravity" ]]; then
+    # Keep state inside the plugin dir so it is removed with the plugin and does
+    # not pollute ~/.gemini/config/plugins with a non-plugin entry.
+    echo "${TARGET}/${plugin_name}/${STATE_DIR_NAME}"
+  else
+    echo "${TARGET}/${STATE_DIR_NAME}/plugins/${plugin_name}"
+  fi
 }
 
 skill_source_dir() {
@@ -153,6 +205,24 @@ install_plugin() {
   echo "Installing ${plugin_name} v${version} to ${TARGET}"
   mkdir -p "$TARGET"
 
+  # Antigravity expects one self-contained dir per plugin (plugin.json +
+  # installed_version.json + skills/). Reset it and write the plugin-level files
+  # before staging skills, mirroring how Antigravity ships its own plugins.
+  if [[ "$IDE" == "antigravity" ]]; then
+    local plugin_root
+    plugin_root="$(plugin_install_root "$plugin_name")"
+    rm -rf "$plugin_root"
+    mkdir -p "${plugin_root}/skills"
+    local marker_src="${SCRIPT_DIR}/plugins/${plugin_name}/plugin.json"
+    if [[ -f "$marker_src" ]]; then
+      cp "$marker_src" "${plugin_root}/plugin.json"
+    else
+      printf '{\n  "name": "%s",\n  "version": "%s"\n}\n' \
+        "$(json_escape "$plugin_name")" "$(json_escape "$version")" > "${plugin_root}/plugin.json"
+    fi
+    printf '{"version": "%s"}\n' "$(json_escape "$version")" > "${plugin_root}/installed_version.json"
+  fi
+
   # Write manifest first so interrupted installs can be cleaned up
   write_plugin_manifest "$plugin_name" "$version"
 
@@ -162,10 +232,12 @@ install_plugin() {
     local skill_name
     local dest
     skill_name="$(basename "$skill_dir")"
-    dest="${TARGET}/${skill_name}"
+    dest="$(skill_install_dir "$plugin_name" "$skill_name")"
 
-    # Check for ownership conflict with another plugin
-    if [[ -f "${dest}/.techwolf-plugin.json" ]]; then
+    # Codex flattens all plugins into one dir, so guard against two plugins
+    # claiming the same skill name. Antigravity isolates each plugin in its own
+    # dir, so there is no cross-plugin collision to check.
+    if [[ "$IDE" != "antigravity" && -f "${dest}/.techwolf-plugin.json" ]]; then
       local existing_owner
       existing_owner="$(grep -F '"plugin":' "${dest}/.techwolf-plugin.json" | sed 's/.*"plugin":[[:space:]]*"\([^"]*\)".*/\1/' || true)"
       if [[ -n "$existing_owner" && "$existing_owner" != "$plugin_name" ]]; then
@@ -219,8 +291,22 @@ verify_plugin() {
 
   version="$(plugin_version "$plugin_name")"
 
+  if [[ "$IDE" == "antigravity" ]]; then
+    local plugin_root
+    plugin_root="$(plugin_install_root "$plugin_name")"
+    if [[ ! -f "${plugin_root}/plugin.json" ]]; then
+      echo "  Missing plugin.json for ${plugin_name} at ${plugin_root}"
+      failures=$((failures + 1))
+    fi
+    if [[ ! -f "${plugin_root}/installed_version.json" ]]; then
+      echo "  Missing installed_version.json for ${plugin_name} at ${plugin_root}"
+      failures=$((failures + 1))
+    fi
+  fi
+
   for skill_name in $(skill_names_for_plugin "$plugin_name"); do
-    local dest="${TARGET}/${skill_name}"
+    local dest
+    dest="$(skill_install_dir "$plugin_name" "$skill_name")"
     checked=$((checked + 1))
 
     if [[ ! -f "${dest}/SKILL.md" ]]; then
@@ -269,6 +355,19 @@ verify_plugin() {
 uninstall_plugin() {
   local plugin_name="$1"
   local state_dir
+
+  # Antigravity keeps the whole plugin in one dir, so removing it is enough.
+  if [[ "$IDE" == "antigravity" ]]; then
+    local plugin_root
+    plugin_root="$(plugin_install_root "$plugin_name")"
+    if [[ ! -d "$plugin_root" ]]; then
+      echo "No install found for ${plugin_name} under ${plugin_root}"
+      return 1
+    fi
+    rm -rf "$plugin_root"
+    echo "Uninstalled ${plugin_name} (removed ${plugin_root})"
+    return 0
+  fi
 
   state_dir="$(plugin_state_dir "$plugin_name")"
   if [[ ! -f "${state_dir}/manifest.txt" ]]; then
@@ -359,6 +458,22 @@ while [[ $# -gt 0 ]]; do
       ACTION="$1"
       shift
       ;;
+    --ide)
+      if [[ $# -lt 2 ]]; then
+        echo "Error: --ide requires a value (codex|antigravity)" >&2
+        usage
+        exit 1
+      fi
+      case "$2" in
+        codex|antigravity) IDE="$2" ;;
+        *)
+          echo "Error: unknown --ide '$2' (expected codex|antigravity)" >&2
+          usage
+          exit 1
+          ;;
+      esac
+      shift 2
+      ;;
     --target)
       if [[ $# -lt 2 ]]; then
         echo "Error: --target requires a value" >&2
@@ -383,6 +498,12 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+# Resolve the install dir: an explicit --target wins, otherwise fall back to the
+# IDE default. Done after parsing so --ide and --target work in any order.
+if [[ -z "$TARGET" ]]; then
+  TARGET="$(default_target_for_ide "$IDE")"
+fi
 
 run_for_selected_plugins
 

--- a/plugins/ai-adoption/plugin.json
+++ b/plugins/ai-adoption/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "ai-adoption",
+  "version": "1.0.0",
+  "description": "Three skills for working with your Claude history. token-doctor diagnoses where your spend goes. task-profile mines sessions into a role-level task map. session-search finds past sessions by title, cwd, time range, or content."
+}

--- a/plugins/ai-firstify/README.md
+++ b/plugins/ai-firstify/README.md
@@ -32,6 +32,22 @@ For Codex, this plugin installs:
 
 The installer also writes plugin metadata into the installed skill directory and copies a Codex guidance file into `~/.codex/skills/.techwolf-ai-first/plugins/ai-firstify/`.
 
+### Google Antigravity
+
+```bash
+./install.sh ai-firstify --ide antigravity
+```
+
+Update, uninstall, or verify:
+
+```bash
+./install.sh update ai-firstify --ide antigravity
+./install.sh uninstall ai-firstify --ide antigravity
+./install.sh verify ai-firstify --ide antigravity
+```
+
+This installs the plugin as `~/.gemini/config/plugins/ai-firstify/` (`plugin.json` + `installed_version.json` + `skills/`), the same layout Antigravity uses for its own plugins.
+
 ## Usage
 
 The skill triggers automatically when you ask Claude Code to:

--- a/plugins/ai-firstify/plugin.json
+++ b/plugins/ai-firstify/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "ai-firstify",
+  "version": "1.1.0",
+  "description": "AI-first project auditor and re-engineer based on the 9 design principles and 7 design patterns from the TechWolf AI-First Bootcamp"
+}

--- a/plugins/content-studio/README.md
+++ b/plugins/content-studio/README.md
@@ -61,6 +61,24 @@ For Codex, this plugin installs:
 
 The installer also writes plugin metadata into each installed skill directory and copies a Codex guidance file into `~/.codex/skills/.techwolf-ai-first/plugins/content-studio/`.
 
+### Google Antigravity
+
+From the repository root:
+
+```bash
+./install.sh content-studio --ide antigravity
+```
+
+Update, uninstall, or verify:
+
+```bash
+./install.sh update content-studio --ide antigravity
+./install.sh uninstall content-studio --ide antigravity
+./install.sh verify content-studio --ide antigravity
+```
+
+This installs the plugin as `~/.gemini/config/plugins/content-studio/` (`plugin.json` + `installed_version.json` + `skills/`), the same layout Antigravity uses for its own plugins.
+
 ### 2. Set Up for a Person
 
 Run the setup skill to create a personalized content studio:

--- a/plugins/content-studio/plugin.json
+++ b/plugins/content-studio/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "content-studio",
+  "version": "1.1.1",
+  "description": "Content studio for managing thought leadership content with a visual editor, agent skills, and utility scripts."
+}

--- a/plugins/knowledge-base/plugin.json
+++ b/plugins/knowledge-base/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "knowledge-base",
+  "version": "1.1.1",
+  "description": "Build and query a structured, evidence-backed knowledge base. Every answer cites literal quotes from your KB files."
+}

--- a/plugins/people-management/plugin.json
+++ b/plugins/people-management/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "people-management",
+  "version": "1.2.1",
+  "description": "AI-augmented management tooling for people managers. Surfaces the right context at the right time. Adapts to your org's performance and management frameworks."
+}

--- a/plugins/techwolf-brand-kit/plugin.json
+++ b/plugins/techwolf-brand-kit/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "techwolf-brand-kit",
+  "version": "1.0.0",
+  "description": "Official TechWolf brand assets for AI-generated outputs. Provides logo files in multiple variants as SVG and PNG."
+}

--- a/plugins/tool-build-kit/plugin.json
+++ b/plugins/tool-build-kit/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "tool-build-kit",
+  "version": "1.6.0",
+  "description": "Build an MCP server the right way, end to end. Branches on audience (personal, org, public) and walks through analyze, build, deploy, scale, and distribute."
+}


### PR DESCRIPTION
## What

Makes the toolkit's plugins installable in **Google Antigravity**, reusing the existing `SKILL.md` packages unchanged. Antigravity becomes the third install target alongside Claude Code and Codex.

## Why

Antigravity (Google's agentic IDE) has a real plugin model: it keeps plugins under `~/.gemini/config/plugins/<plugin>/`, each a self-contained dir with `plugin.json` + `installed_version.json` + `skills/`. Our skills already follow the agentskills.io `SKILL.md` spec, so this is a packaging + installer + manifest change, not a content rewrite.

## Changes

- **`install.sh`**: new `--ide <codex|antigravity>` flag.
  - `--ide antigravity` installs one self-contained dir per plugin into `~/.gemini/config/plugins/<plugin>/` (`plugin.json` + `installed_version.json` + `skills/<skill>/`), the same layout Antigravity uses for its own plugins.
  - Codex stays the default (flat skills into `~/.codex/skills/`). `--target` still overrides either.
  - `install` / `update` / `verify` / `uninstall` / `list` all work for both targets, including plugin-root shared-asset staging.
- **`.agents/plugins/marketplace.json`**: vendor-neutral / Antigravity marketplace manifest listing all 7 plugins.
- **`plugins/<name>/plugin.json`**: Antigravity plugin markers for all 7 plugins (name/version/description synced to `.claude-plugin/plugin.json`).
- **Docs**: README (three-target quick start + Antigravity badge + structure), `AGENTS.md`, `CONTRIBUTING.md`, and the `ai-firstify` + `content-studio` plugin READMEs.
- **CHANGELOG**: `1.7.0`.

## Verification

Tested end to end on a real Antigravity install: all 7 plugins install, verify, and list under `~/.gemini/config/plugins/` sitting in the same shape next to Antigravity's own plugins (google-antigravity-sdk, chrome-devtools-plugin, android-cli-plugin). Codex install path confirmed unchanged.

```
./install.sh install --ide antigravity     # all 7 -> ~/.gemini/config/plugins
./install.sh list --ide antigravity
./install.sh uninstall ai-firstify --ide antigravity
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)