### PR TITLE
Add handoff skill to ai-adoption plugin (v1.2.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -36,7 +36,7 @@
     {
       "name": "ai-adoption",
       "source": "./plugins/ai-adoption",
-      "description": "Three skills for working with your Claude history. token-doctor diagnoses where your Claude Code + Cowork spend goes. task-profile mines sessions into a role-level task map with friction and tokens. session-search finds past sessions by title, cwd, time range, or full-text content."
+      "description": "Four skills for working with your Claude history. token-doctor diagnoses where your Claude Code + Cowork spend goes. task-profile mines sessions into a role-level task map with friction and tokens. session-search finds past sessions by title, cwd, time range, or full-text content. handoff writes a tight resume note so a fresh session picks up exactly where the last one stopped."
     },
     {
       "name": "tool-build-kit",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog and this project follows Semantic Versioning.
 
+## [1.9.0] - 2026-06-29
+
+### Added
+
+- `handoff` skill added to the **ai-adoption** plugin (v1.2.0). Writes a tight `HANDOFF.md` resume note at the current working directory so a fresh session can continue without replaying the conversation. Two modes: write (default) and read (`/handoff read`). Completes the session-skills family alongside session-search, task-profile, and token-doctor. Works in Claude Code and Cowork; no platform-specific dependencies.
+
 ## [1.8.0] - 2026-06-12
 
 ### Added

--- a/plugins/ai-adoption/README.md
+++ b/plugins/ai-adoption/README.md
@@ -2,11 +2,12 @@
 
 > **Host-aware.** These skills read agent session history from disk, which is per-platform. They detect the host (via the `platform` stamp `install.sh` writes, or `AI_FIRST_PLATFORM`) and route or degrade rather than scanning the wrong path. All three support **Claude Code / Cowork and Codex** (`~/.codex/sessions`); token-doctor prices Codex (gpt-5.x) usage with OpenAI list rates. **Antigravity** session analysis is unsupported: the IDE store is AEAD-encrypted at rest and the CLI store has no parseable turn/token content, so the skills print a clear "not available" message.
 
-Three skills for working with your Claude history:
+Four skills for working with your Claude history:
 
 - **`token-doctor`**, diagnose where your Claude Code + Cowork spend goes. Writes a doctor-style terminal report (length distribution, marathon share, cache rebuilds, per-project health) and offers an opt-in deep dive that fans out parallel Haiku subagents over your top sessions for habit-level recommendations.
 - **`task-profile`**, mine your Claude Code + Cowork session history into a role-level map of what you actually do with AI, ranked by frequency and friction, with the tokens beside every row.
 - **`session-search`**, find a specific past session by title, working directory, time range, or free-text content across every transcript on disk.
+- **`handoff`**, write a tight resume note at the end of a session so the next session can pick up exactly where you left off, without replaying the conversation.
 
 ## Why
 
@@ -19,6 +20,7 @@ Most teams roll out Claude without ever measuring how people actually use it. To
 | `/token-doctor` | Diagnose where Claude spend goes. Two-stage: fast terminal report + opt-in deep dive over hotspot sessions |
 | `/task-profile` | Mine sessions into a task profile with friction signals, tokens per task, AI-first coaching cards, and skill proposals |
 | `/session-search` | Find a past session by title, working directory, time range, or full-text content |
+| `/handoff` | Write a tight resume note so the next session starts from exactly where you stopped |
 
 ## Getting Started
 
@@ -26,6 +28,7 @@ Most teams roll out Claude without ever measuring how people actually use it. To
 2. Run `/token-doctor` to get an instant terminal report on where your tokens go.
 3. Run `/task-profile` for a 5-10 minute deep analysis that produces an interactive HTML explorer.
 4. Use `/session-search` any time to dig up a specific past session.
+5. Use `/handoff` at the end of any session to write a resume note; say "pick up the handoff" next session to continue.
 
 All output lands under `./out/` in your current working directory. Nothing leaves your machine.
 
@@ -127,6 +130,25 @@ Seven phases. Stage 1 is always shown; Stage 2 is opt-in.
 - Cowork desktop for the Cowork side; Cowork-side analysis is optional (Code CLI sessions work stand-alone)
 - macOS primary; Windows supported for Cowork path resolution; Linux falls back to Code-only
 
+## `handoff`
+
+Writes a tight `HANDOFF.md` resume note at the current working directory so a fresh session can continue without replaying the conversation. Two modes:
+
+- **Write** (default): `handoff`, `wrap up`, `park this session`, `save where we are`. Captures goal, what's done vs open, the single most concrete next step, decisions made, dead ends, run state (branch, tree, processes), verify command, and open questions. Appends newest-first, keeps the 3 most recent entries; replaces today's entry rather than stacking.
+- **Read**: `/handoff read`, `pick up the handoff`, `read the handoff`. Reads `HANDOFF.md` from cwd, surfaces the most recent entry's goal and Start-here steps, warns if the handoff is stale relative to git history, and asks before acting.
+
+Sample phrasings:
+
+- `handoff`
+- `wrap up`
+- `park this session`
+- `save where we are`
+- `pick up the handoff`
+- `read the handoff`
+- `/handoff read`
+
+The skill writes to the project directory, not to tool memory. If the directory is a git repo, it offers to add `HANDOFF.md` to `.gitignore` rather than staging it.
+
 ## Attribution
 
-Skill sources: `skills/token-doctor/`, `skills/task-profile/`, `skills/session-search/`. Branded with the TechWolf aquamarine + dark palette and the TechWolf logo (via `assets/logo.svg`). Swap the logo if repurposing externally, the generator falls back to a neutral glyph if the asset is missing.
+Skill sources: `skills/token-doctor/`, `skills/task-profile/`, `skills/session-search/`, `skills/handoff/`. Branded with the TechWolf aquamarine + dark palette and the TechWolf logo (via `assets/logo.svg`). Swap the logo if repurposing externally, the generator falls back to a neutral glyph if the asset is missing.

--- a/plugins/ai-adoption/plugin.json
+++ b/plugins/ai-adoption/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "ai-adoption",
-  "version": "1.1.0",
-  "description": "Three skills for working with your Claude history. token-doctor diagnoses where your spend goes. task-profile mines sessions into a role-level task map. session-search finds past sessions by title, cwd, time range, or content."
+  "version": "1.2.0",
+  "description": "Four skills for working with your Claude history. token-doctor diagnoses where your spend goes. task-profile mines sessions into a role-level task map. session-search finds past sessions by title, cwd, time range, or content. handoff writes a tight resume note so a fresh session picks up exactly where the last one stopped."
 }

--- a/plugins/ai-adoption/skills/handoff/SKILL.md
+++ b/plugins/ai-adoption/skills/handoff/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: handoff
+description: Write a session handoff at the end of a session so the next session can start from where this one stopped without rereading the whole conversation. Use when user says "handoff", "wrap up", "write a handoff", "end of session", "park this session", "save where we are", or to RESUME with "/handoff read", "pick up the handoff", "read the handoff". Writes a tight resume note (HANDOFF.md) into the working directory, not a full transcript. Scope is the current project's resume note only: not searching or summarizing past sessions, and not any project-specific "resume" command the environment may have.
+---
+
+# Handoff
+
+Capture the minimum a fresh session needs to continue this work: what it is, where it stands, the exact next action. The next session reads ONE file instead of replaying the conversation. Optimized for "start from here", not "understand everything that happened".
+
+The handoff is written to **the current working directory** (the project/folder being worked in), as `HANDOFF.md` at its root. It travels with the project, not with any tool's memory.
+
+Two modes:
+- **Write** (default): no args, or "handoff", "wrap up", "park this session", "save where we are".
+- **Read**: "/handoff read", "pick up the handoff", "read the handoff".
+
+**Scope.** Handoff only reads/writes the resume note in the current project directory. It does not search or summarize past sessions ("where did I work on X / when did I last do Y" is a different job). And a bare "resume" or "continue" may belong to a project-specific resume command rather than this skill — only fire handoff-read on the explicit phrasings above.
+
+## Write mode
+
+### 1. Reconstruct the session from THIS conversation
+
+Do NOT re-run searches or re-read source files. Pull everything from what already happened in this session:
+
+- The actual goal being worked toward (the real one, not the first ask if it shifted).
+- What got done vs. what's still open.
+- The exact next step — the single most concrete thing the next session should do first.
+- Decisions made and WHY (so the next session doesn't relitigate them).
+- Dead ends and out-of-scope lines already drawn (so the next session doesn't repeat them or wander).
+- Run state being inherited: branch, dirty/clean tree, any long-running or background processes/servers still in flight (and their ports), env set this session. If your environment exposes them, note background jobs or the model tier too.
+- How to verify "done": the command that proves the done-claims are real, and its expected result.
+- Files created/edited, commands that matter, branches/PRs, links.
+- Open questions waiting on the user.
+
+Skip the file if there's no meaningful **open next action** (a quick lookup, a finished one-off). A handoff isn't worth writing when there's nothing to start from. Offer it instead of forcing it.
+
+Never put secrets (API keys, tokens, PII) or unresolved placeholders in the file.
+
+### 2. Locate the target file
+
+- Determine the working directory (e.g. `pwd`) and state the resolved target path in your report before writing. A handoff in the wrong project is worse than none.
+- If the session's work spanned more than one directory, target the dir where the *next action* happens, and say which you chose.
+- Target: `HANDOFF.md` at the root of that directory.
+- If you reference a weekday, verify it programmatically rather than computing it in your head. The `date` flags differ across platforms: GNU/Linux `date -d 'YYYY-MM-DD' +%A`, macOS/BSD `date -j -f '%Y-%m-%d' 'YYYY-MM-DD' '+%A'`.
+
+### 3. Write the file
+
+Dense bullets, not prose. Cap each entry to ~25 lines. Template for one entry:
+
+```markdown
+# Handoff — <YYYY-MM-DD> — <one-line theme>
+<!-- ISO date: machine-parsed file, not user-facing display. Don't "fix" to DD-MM. -->
+
+status: in-progress | blocked: <waiting on what> | ready-to-ship
+branch: <branch> @ <short-sha> | tree: clean/dirty | running: <none / processes or servers still up>
+
+## Goal
+<one or two lines: what we are actually trying to achieve>
+
+## Where it stands
+- <bullet: done>
+- <bullet: in progress>
+- <bullet: not started>
+
+## Start here (next session)
+1. <the single most concrete first action>
+2. <then this>
+3. <then this>
+
+## Verify
+- <command the next session runs to confirm it works, and the expected result>
+
+## Decisions made (don't relitigate)
+- <decision> — because <why>
+
+## Dead ends / out of scope (don't repeat)
+- <thing tried that didn't work, or a line not to cross>
+
+## Open questions
+- <question blocking progress, or none>
+
+## Artifacts
+- <file path / branch / PR / command / link>
+```
+
+Drop any section that's empty rather than leaving a placeholder.
+
+**Appending to an existing file:** read it and split into entries on each `# Handoff —` H1 (that header is the only delimiter — do not split on `---`). Write the new entry first, then the previous entries, newest-first. If the most recent existing entry has today's date, REPLACE it instead of stacking. Keep the 3 newest entries, drop the rest. After writing, re-read and confirm the entry count.
+
+### 4. Report inline
+
+Print the handoff in chat (it's the deliverable, the file is the durable copy) and end with the path. Offer to start the next step now if it's actionable.
+
+## Read mode
+
+1. Read `HANDOFF.md` from the current working directory. If it's not there, say so and check one level up / common subfolders before giving up. If more than one is found, prefer the one in cwd and say which you used.
+2. Read only that file. Do NOT replay the conversation history or re-derive context from source.
+3. Pick the entry. Default to the TOP (most recent). If there's more than one entry, list their dates + themes and confirm which thread to resume rather than auto-picking.
+4. **Flag staleness.** Surface the entry's date. If a git repo has commits newer than that date (`git log -1 --format=%cd`), or the date is well in the past, warn that the handoff may be stale before acting on it.
+5. **Read back before acting** (the highest-evidence error-reducer in human handoffs): restate the Goal and the **Start here** step 1 in one line, then surface Where it stands and Start here as a numbered list.
+6. Ask: "Want me to pick up at step 1?" and proceed if yes. If the work reads as already landed, offer to clear the stale handoff instead.
+
+## Notes
+
+- This is for cross-SESSION continuity within a project. A handoff is disposable: once the work lands, it's stale. Don't treat it as permanent documentation, and don't let it grow into architecture/design docs.
+- `HANDOFF.md` lives in the project. If it's a git repo, check whether the file is already tracked (`git ls-files HANDOFF.md`). Default to keeping it out of version control: if there's a `.gitignore`, offer to add `HANDOFF.md` in the same step. Never stage or commit it without asking.
+- Keep it honest: if a step failed, say so in "Where it stands", and anchor every "done" to the Verify command. A handoff that overstates progress wastes the next session's time.
+- The whole value is the **Start here** block. If you write nothing else well, write that.
+```


### PR DESCRIPTION
## What

Adds `handoff` as the fourth skill in the `ai-adoption` plugin, bumping it from v1.1.0 to v1.2.0.

Changed files:
- `plugins/ai-adoption/skills/handoff/SKILL.md` — new skill (copied verbatim from the reviewed source)
- `plugins/ai-adoption/plugin.json` — version bump 1.1.0 → 1.2.0, description updated to mention four skills
- `.claude-plugin/marketplace.json` — ai-adoption entry description updated to mention handoff
- `plugins/ai-adoption/README.md` — handoff section added matching the format of the existing three skills
- `CHANGELOG.md` — v1.9.0 entry added

## Why

Cross-session continuity was the missing piece in the session-skills family. `session-search` finds past sessions, `task-profile` maps what you do with AI, and `token-doctor` diagnoses spend — but nothing helped you resume an in-flight session without replaying the conversation. `handoff` closes that gap: it writes a tight `HANDOFF.md` resume note at the end of a session and reads it back at the start of the next one. Works in Claude Code and Cowork, no platform-specific dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiiKvjBfv8rhxeU5hdX1z7