### PR TITLE
Add build-plugin skill to tool-build-kit (v1.10.0)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -61,7 +61,7 @@
       "source": { "source": "local", "path": "./plugins/tool-build-kit" },
       "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" },
       "category": "Development & Architecture",
-      "description": "Build an MCP server the right way, end to end. Branches on audience (personal, org, public) and walks through analyze, build, deploy, scale, and distribute."
+      "description": "Build an MCP server and bundle your tools into a shareable plugin, end to end. Two skills: build-mcp scaffolds one server; build-plugin packages skills, hooks, agents, and MCP servers into an installable plugin and ships it via a marketplace. Both branch on audience (personal, org, public)."
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -46,7 +46,7 @@
     {
       "name": "tool-build-kit",
       "source": "./plugins/tool-build-kit",
-      "description": "Build an MCP server the right way, end to end. Branches on audience (personal, org, public) and walks through analyze, build, deploy, scale, and distribute. Builds on the mcp-builder skill."
+      "description": "Build an MCP server and bundle your tools into a shareable plugin, end to end. Two skills: build-mcp scaffolds one server; build-plugin packages skills, hooks, agents, and MCP servers into an installable plugin and ships it via a marketplace. Both branch on audience (personal, org, public)."
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog and this project follows Semantic Versioning.
 
+## [1.10.0] - 2026-07-07
+
+### Added
+
+- `build-plugin` skill in `tool-build-kit`, a sibling to `build-mcp`. Bundles many tools (skills, hooks, agents, MCP servers) into one installable Claude Code plugin and ships it via a marketplace.
+  - Establishes context first with `AskUserQuestion` (audience, then git host), then walks four phases: Analyze, Assemble, Ship, Maintain. A branch table maps each phase to the concrete move for Just-me / Team-org-GitHub / Team-org-GitLab / Public.
+  - Four on-demand references: `assemble.md` (folder layout, manifest, local `claude --plugin-dir` test), `marketplace.md` (`marketplace.json` shape, per-host `source` types, install commands, public vs private), `team-enablement.md` (project `.claude/settings.json` auto-enable, org-wide managed settings), `maintain.md` (updates, version bumps, ownership).
+
+### Changed
+
+- `tool-build-kit` plugin bumped to v1.7.0 and its description broadened to cover building an MCP server AND bundling tools into a shareable plugin (both `plugin.json` markers and both marketplace manifests updated).
+
 ## [1.9.0] - 2026-06-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TechWolf AI-First Toolkit
 
-![MIT License](https://img.shields.io/badge/license-MIT-blue.svg) ![v1.9.0](https://img.shields.io/badge/version-1.9.0-green.svg) ![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-blueviolet.svg) ![Codex](https://img.shields.io/badge/Codex-compatible-orange.svg) ![Antigravity](https://img.shields.io/badge/Antigravity-compatible-4285F4.svg) ![agentskills.io](https://img.shields.io/badge/agentskills.io-spec-lightgrey.svg)
+![MIT License](https://img.shields.io/badge/license-MIT-blue.svg) ![v1.10.0](https://img.shields.io/badge/version-1.10.0-green.svg) ![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-blueviolet.svg) ![Codex](https://img.shields.io/badge/Codex-compatible-orange.svg) ![Antigravity](https://img.shields.io/badge/Antigravity-compatible-4285F4.svg) ![agentskills.io](https://img.shields.io/badge/agentskills.io-spec-lightgrey.svg)
 
 Open-source agent skills from [TechWolf](https://techwolf.ai)'s [AI-First Bootcamp](https://ai-first.techwolf.ai), for Claude Code, Codex, and Google Antigravity.
 
@@ -25,7 +25,7 @@ claude plugin marketplace add techwolf-ai/ai-first-toolkit
 | **ai-adoption** | Claude history analytics: token-doctor and task-profile | `claude plugin install ai-adoption@techwolf-ai-first` |
 | **session-tools** | Session continuity: find past sessions, write handoff notes | `claude plugin install session-tools@techwolf-ai-first` |
 | **techwolf-brand-kit** | Official TechWolf logo assets (SVG + PNG) for AI-generated outputs | `claude plugin install techwolf-brand-kit@techwolf-ai-first` |
-| **tool-build-kit** | Build an MCP server end to end: analyze, build, deploy, scale, distribute | `claude plugin install tool-build-kit@techwolf-ai-first` |
+| **tool-build-kit** | Build an MCP server and bundle your tools into a shareable plugin, end to end | `claude plugin install tool-build-kit@techwolf-ai-first` |
 
 <a name="not-using-claude-code"></a>
 Not using Claude Code? Every skill follows the [agentskills.io](https://agentskills.io) spec and installs into Codex or Google Antigravity via [`./install.sh`](#codex). One caveat on per-platform support:
@@ -101,13 +101,12 @@ Official TechWolf brand assets for AI-generated outputs. Ensures agents use the 
 - **TechWolf Logo**: 4 variants (dark, white, mono-dark, mono-white) in SVG and PNG
 - **currentColor SVG**: inline variant that inherits color from parent CSS for themed contexts
 
-### tool-build-kit: Build an MCP Server
+### tool-build-kit: Build and Ship Tools
 
-End-to-end guide for building a Model Context Protocol server, from first questions to published distribution. Asks who the server is for before building anything, then tailors every phase to that answer.
+End-to-end guide for building an MCP server and bundling your tools into a shareable plugin, from first questions to published distribution. Two sibling skills; each asks who the work is for before building anything, then tailors every phase to that answer.
 
-- **build-mcp**: one skill, five phases (analyze, build, deploy, scale, distribute). Establishes audience (personal / org / public) and runtime (local stdio / hosted HTTP) with `AskUserQuestion` before writing a line of code. Builds on the Anthropic `mcp-builder` skill for implementation depth and adds the scope-and-distribution decision flow it lacks.
-- Branch table drives the deploy and distribute phases across five targets: personal local, org local, org hosted, public package, public hosted.
-- 6 reference files loaded on demand: transports, local deploy, marketplace distribution, scaling, Python and TypeScript quickstarts.
+- **build-mcp**: five phases (analyze, build, deploy, scale, distribute). Establishes audience (personal / org / public) and runtime (local stdio / hosted HTTP) with `AskUserQuestion` before writing a line of code. Builds on the Anthropic `mcp-builder` skill for implementation depth and adds the scope-and-distribution decision flow it lacks. Branch table drives deploy and distribute across five targets; 6 reference files loaded on demand (transports, local deploy, marketplace distribution, scaling, Python and TypeScript quickstarts).
+- **build-plugin**: four phases (analyze, assemble, ship, maintain). Bundles many tools (skills, hooks, agents, MCP servers) into one installable plugin and ships it via a marketplace. Establishes audience and git host with `AskUserQuestion`, then a branch table maps each phase across Just-me / Team-org-GitHub / Team-org-GitLab / Public. Picks up where build-mcp's distribute phase leaves off; 4 reference files loaded on demand (assemble, marketplace, team enablement, maintain).
 
 ## Quick start
 
@@ -191,7 +190,7 @@ ai-first-toolkit/
 │   ├── ai-adoption/            # Claude history analytics (2 skills: token-doctor, task-profile)
 │   ├── session-tools/          # Session continuity (2 skills: session-search, handoff)
 │   ├── techwolf-brand-kit/     # Brand assets (logo variants in SVG + PNG)
-│   └── tool-build-kit/         # MCP server builder (1 skill: build-mcp, 6 reference files)
+│   └── tool-build-kit/         # MCP + plugin builder (2 skills: build-mcp, build-plugin)
 ├── install.sh                  # Codex + Antigravity skill installer
 └── README.md
 ```

--- a/plugins/tool-build-kit/.claude-plugin/plugin.json
+++ b/plugins/tool-build-kit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tool-build-kit",
-  "description": "Build an MCP server the right way, end to end. Branches on audience (personal, org, public) and walks you through analyze, build, deploy, scale, and distribute.",
-  "version": "1.6.0",
+  "description": "Build an MCP server and bundle your tools into a shareable plugin, end to end. Two skills: build-mcp scaffolds one server; build-plugin packages skills, hooks, agents, and MCP servers into an installable plugin and ships it via a marketplace. Both branch on audience (personal, org, public).",
+  "version": "1.7.0",
   "author": { "name": "TechWolf" }
 }

--- a/plugins/tool-build-kit/README.md
+++ b/plugins/tool-build-kit/README.md
@@ -1,6 +1,11 @@
 # tool-build-kit
 
-Build an MCP server the right way, end to end. One skill, `build-mcp`, that asks who the server is for before it builds anything, then tailors every step to that answer. Builds on the Anthropic [`mcp-builder`](https://github.com/anthropics/skills) skill for implementation depth and adds the scope-and-distribution decision flow it lacks.
+Build and ship tools for Claude Code, end to end. Two sibling skills:
+
+- `build-mcp`: build one MCP server the right way, tailored to who it's for.
+- `build-plugin`: bundle many tools (skills, hooks, agents, MCP servers) into one installable plugin and distribute it via a marketplace.
+
+Both ask who the work is for before they build anything, then tailor every step to that answer. `build-mcp` builds on the Anthropic [`mcp-builder`](https://github.com/anthropics/skills) skill for implementation depth; `build-plugin` picks up where `build-mcp` leaves off, packaging a server (or any other tools) into a shareable unit.
 
 ## Install
 
@@ -12,15 +17,15 @@ claude plugin marketplace add techwolf-ai/ai-first-toolkit
 claude plugin install tool-build-kit@techwolf-ai-first
 ```
 
-## Usage
+## build-mcp
 
-The skill triggers automatically when you ask Claude Code to build an MCP server, wrap an API as a tool, make a tool for Claude, or expose a service to an agent. Or invoke it directly:
+Triggers when you ask Claude Code to build an MCP server, wrap an API as a tool, make a tool for Claude, or expose a service to an agent. Or invoke it directly:
 
 ```
 /build-mcp
 ```
 
-## The decision flow
+### The decision flow
 
 Before building, the skill uses `AskUserQuestion` to establish context:
 
@@ -30,7 +35,7 @@ Before building, the skill uses `AskUserQuestion` to establish context:
 
 That answer cascades through the five phases. A personal local server and a public hosted server share almost no steps past "build".
 
-## The five phases
+### The five phases
 
 1. **Analyze**: understand the service to wrap, pick tool boundaries, scope secrets.
 2. **Build**: scaffold and implement (delegates to `mcp-builder`).
@@ -38,7 +43,7 @@ That answer cascades through the five phases. A personal local server and a publ
 4. **Scale**: harden and operate it (substantive only for hosted servers).
 5. **Distribute**: local registration, org marketplace, or public MCP registry, gated by the audience answer.
 
-## Reference files
+### Reference files
 
 Loaded on demand by the skill:
 
@@ -47,6 +52,41 @@ Loaded on demand by the skill:
 - `distribute-marketplace.md`: plugin packaging, org marketplace, public registry
 - `scaling.md`: hosted-server statelessness, auth, versioning, security
 - `python-fastmcp.md`, `node-sdk.md`: thin quickstarts that hand off to `mcp-builder`
+
+## build-plugin
+
+Triggers when you ask Claude Code to bundle tools into one plugin, package tools for a colleague, publish a plugin to a marketplace, share your tools with your team, or ship a plugin. Or invoke it directly:
+
+```
+/build-plugin
+```
+
+Where `build-mcp` builds one MCP server, `build-plugin` bundles many tools (including MCP servers from `build-mcp`) into a single installable plugin and distributes it. When `build-mcp` reaches its Distribute phase for a team or public audience, it hands off here.
+
+### The decision flow
+
+Before assembling, the skill uses `AskUserQuestion` to establish context:
+
+1. **Audience** (asked first): just me, my team/org, or public/external.
+2. **Git host** (conditional, skipped for "Just me"): GitHub, GitLab/other, or not sure yet.
+
+Confirm the resolved tuple, then follow the branch table. A personal one-project bundle and a public team marketplace share almost nothing past "assemble".
+
+### The four phases
+
+1. **Analyze**: decide what tools go in the bundle, and name it.
+2. **Assemble**: build the plugin folder and manifest, test locally with `claude --plugin-dir`.
+3. **Ship**: marketplace repo, git host, public/private, one-click enablement for a team.
+4. **Maintain**: versions, updates, ownership, and admin controls.
+
+### Reference files
+
+Loaded on demand by the skill:
+
+- `assemble.md`: plugin folder layout, manifest fields, moving loose tools in, local `claude --plugin-dir` testing, validation
+- `marketplace.md`: `marketplace.json` shape, per-host `source` types, add/install commands, public vs private and auth
+- `team-enablement.md`: project `.claude/settings.json` auto-enable, org-wide managed-settings enforcement
+- `maintain.md`: updates, version bumps, ownership, fixes via merge request
 
 ## License
 

--- a/plugins/tool-build-kit/plugin.json
+++ b/plugins/tool-build-kit/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "tool-build-kit",
-  "version": "1.6.0",
-  "description": "Build an MCP server the right way, end to end. Branches on audience (personal, org, public) and walks through analyze, build, deploy, scale, and distribute."
+  "version": "1.7.0",
+  "description": "Build an MCP server and bundle your tools into a shareable plugin, end to end. Two skills: build-mcp scaffolds one server; build-plugin packages skills, hooks, agents, and MCP servers into an installable plugin and ships it via a marketplace. Both branch on audience (personal, org, public)."
 }

--- a/plugins/tool-build-kit/skills/build-plugin/SKILL.md
+++ b/plugins/tool-build-kit/skills/build-plugin/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: build-plugin
-description: "Bundle skills, hooks, agents, or an MCP server into one installable Claude Code plugin and ship it. Use when asked to bundle tools into one plugin, package tools for a colleague, publish a plugin to a marketplace, share my tools with my team, or ship a plugin. Asks who it's for and where it's hosted, then walks assemble, ship, enable, and maintain, tailored to that answer. Sibling to build-mcp."
+description: "Bundle skills, hooks, agents, or an MCP server into one installable Claude Code plugin and ship it. Use when asked to bundle tools into one plugin, package tools for a colleague, publish a plugin to a marketplace, share my tools with my team, or ship a plugin. Asks who it's for and where it's hosted, then walks analyze, assemble, ship, and maintain, tailored to that answer. Sibling to build-mcp."
 ---
 
 # Build Plugin
@@ -50,11 +50,11 @@ Confirm the resolved tuple back to the user in one line before proceeding (e.g. 
 
 | Phase | Just me | Team/org (GitHub) | Team/org (GitLab/other) | Public |
 |-------|---------|-------------------|-------------------------|--------|
-| **Ship** | N/A, stop here. Load via `claude --plugin-dir` or a local `.mcp.json`; no marketplace. | Marketplace repo on GitHub; entry `source: {source:"github", repo:"org/repo"}` or a relative `"./path"`. Private repo optional to keep it internal. | Marketplace repo on GitLab/Bitbucket/self-hosted; entry `source: {source:"url", url:"https://...git"}`. | Public marketplace repo; entry by host as above. Be deliberate: anyone who knows the repo can install, and plugins run arbitrary code. |
+| **Ship** | N/A, no marketplace. Load via `claude --plugin-dir`, or scaffold it in your skills dir (`claude plugin init`) to auto-load every session. | Marketplace repo on GitHub; entry `source: {source:"github", repo:"org/repo"}` or a relative `"./path"`. Private repo optional to keep it internal. | Marketplace repo on GitLab/Bitbucket/self-hosted; entry `source: {source:"url", url:"https://...git"}`. | Public marketplace repo; entry by host as above. Be deliberate: anyone who knows the repo can install, and plugins run arbitrary code. |
 | **Enable** | N/A, stop here. It is already loaded on your machine. | `/plugin marketplace add org/repo` then `/plugin install name@marketplace`; or auto-enable for the team via project `.claude/settings.json`. | `/plugin marketplace add https://gitlab.com/team/plugins.git` then `/plugin install name@marketplace`; same `.claude/settings.json` auto-enable. | Same commands; `owner/repo` shorthand is GitHub-only, others use the full URL. |
 | **Maintain** | Bump `version` in `plugin.json` for a clean update boundary; you are the only user. | `/plugin marketplace update`; one maintainer per plugin; fixes land via merge request. Org-wide enforcement via managed settings. | Same, via the GitLab/other merge-request flow. | Same, plus a public changelog and a clear versioning policy. |
 
-If a cell says "N/A, stop here" for the chosen branch, say so explicitly and move on. Do not pad it.
+If a cell says "N/A, stop here" for the chosen branch, say so explicitly and move on. Do not pad it. The **Enable** row is the team-facing half of Ship (turning the marketplace on for colleagues), not a separate phase.
 
 Reference files:
 - **references/assemble.md**: plugin folder layout, the manifest fields, moving existing `~/.claude/` tools in, local `claude --plugin-dir` testing, skill namespacing, `claude plugin validate`.
@@ -82,7 +82,7 @@ Read **references/assemble.md**. Build the folder to the layout, write the manif
 1. Create the plugin dir. Only `plugin.json` goes inside `.claude-plugin/`; `skills/`, `agents/`, `hooks/hooks.json`, and `.mcp.json` sit at the plugin ROOT.
 2. Write `.claude-plugin/plugin.json` with `name`, `description`, `version`, `author`.
 3. Move the inventoried tools in and delete the loose originals.
-4. Test: `claude --plugin-dir ./my-plugin` (it also accepts a `.zip`). Confirm every bundled tool shows up and one invokes. Validate the manifest with `claude plugin validate .`.
+4. Validate, then load-test. `claude plugin validate .` checks the manifest and layout with no login. `claude plugin details <name>` lists the skills, hooks, and servers it discovered, also login-free. `claude --plugin-dir ./my-plugin` (it also accepts a `.zip`) loads it into a live session so you can invoke a tool; that one needs you logged in.
 
 For a "Just me" bundle this is the last substantive phase: it is loaded, it works, stop.
 
@@ -106,6 +106,6 @@ Read **references/maintain.md**. Branch lightly; the mechanics are the same acro
 
 ## Done criteria
 
-- The plugin loads via `claude --plugin-dir` with no errors, every bundled tool shows up, and at least one invokes.
+- The plugin validates (`claude plugin validate`) and its tools show up (`claude plugin details`); loading it via `claude --plugin-dir` in a session invokes at least one.
 - It is on a marketplace repo the resolved audience can reach, public or private matching that audience (or, for "Just me", it is loaded locally and there is no marketplace).
 - The user can name exactly how a colleague installs it, two-command or one-click, matching the audience answer.

--- a/plugins/tool-build-kit/skills/build-plugin/SKILL.md
+++ b/plugins/tool-build-kit/skills/build-plugin/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: build-plugin
+description: "Bundle skills, hooks, agents, or an MCP server into one installable Claude Code plugin and ship it. Use when asked to bundle tools into one plugin, package tools for a colleague, publish a plugin to a marketplace, share my tools with my team, or ship a plugin. Asks who it's for and where it's hosted, then walks assemble, ship, enable, and maintain, tailored to that answer. Sibling to build-mcp."
+---
+
+# Build Plugin
+
+Bundle many tools (skills, hooks, agents, MCP servers) into one installable Claude Code plugin and distribute it. The defining move of this skill: establish who the plugin is for and where it will live with `AskUserQuestion` before assembling anything, then tailor every phase to that answer. A personal one-project bundle and a public team marketplace share almost nothing past "assemble", so branch early and commit to the branch.
+
+## How this relates to build-mcp
+
+`build-mcp` builds one MCP server: analyze a service, implement the tools, deploy, scale. `build-plugin` bundles many tools (including MCP servers produced by `build-mcp`) into a single shareable unit and distributes it. When `build-mcp` reaches its Distribute phase for a team or public audience, it hands off here: packaging into a plugin and listing it on a marketplace is this skill's job. Use `build-mcp` to make a server, then `build-plugin` to ship it alongside your skills, hooks, and agents.
+
+## The four phases
+
+1. **Analyze**: decide what tools go in the bundle, and name it.
+2. **Assemble**: build the plugin folder and manifest, test it locally with `claude --plugin-dir`.
+3. **Ship**: put it on a marketplace repo, on the right git host, public or private, with one-click enablement for a team.
+4. **Maintain**: versions, updates, ownership, and admin controls.
+
+Run them in order. The `AskUserQuestion` answers from Phase 0 gate Ship and Maintain.
+
+## Phase 0: Establish context (AskUserQuestion, do this first)
+
+Before assembling anything, branch on the user's context. Ask the **audience** question first; it is the headline decision and it cascades into everything downstream. Then ask the git host only if it is still ambiguous. Ask one question at a time.
+
+**Question 1 (always, ask first): Audience:**
+
+Use `AskUserQuestion`:
+- header: "Audience"
+- question: "Who is this plugin for? This decides where it's hosted and how it's shared."
+- options:
+  1. "Just me": personal bundle of my own tools, one machine or a couple of projects.
+  2. "My team / org": shared internally, installed by colleagues.
+  3. "Public / external": published openly for anyone to install.
+
+**Question 2 (conditional, skip for "Just me"): Git host:**
+
+Skip entirely for "Just me" (no remote needed). Ask for team or public:
+- header: "Git host"
+- question: "Where will the marketplace repo live?"
+- options:
+  1. "GitHub": unlocks the `owner/repo` shorthand and Anthropic's public directory.
+  2. "GitLab or other git host": works via the full `https://...git` URL, no GitHub mirror needed.
+  3. "Not sure yet": decide during Ship; GitHub is the smoothest default.
+
+Confirm the resolved tuple back to the user in one line before proceeding (e.g. "Bundling a team plugin of three skills plus one MCP server, hosted on a private GitHub marketplace repo"). That tuple drives the branch table below.
+
+## Branch table (the spine of this skill)
+
+| Phase | Just me | Team/org (GitHub) | Team/org (GitLab/other) | Public |
+|-------|---------|-------------------|-------------------------|--------|
+| **Ship** | N/A, stop here. Load via `claude --plugin-dir` or a local `.mcp.json`; no marketplace. | Marketplace repo on GitHub; entry `source: {source:"github", repo:"org/repo"}` or a relative `"./path"`. Private repo optional to keep it internal. | Marketplace repo on GitLab/Bitbucket/self-hosted; entry `source: {source:"url", url:"https://...git"}`. | Public marketplace repo; entry by host as above. Be deliberate: anyone who knows the repo can install, and plugins run arbitrary code. |
+| **Enable** | N/A, stop here. It is already loaded on your machine. | `/plugin marketplace add org/repo` then `/plugin install name@marketplace`; or auto-enable for the team via project `.claude/settings.json`. | `/plugin marketplace add https://gitlab.com/team/plugins.git` then `/plugin install name@marketplace`; same `.claude/settings.json` auto-enable. | Same commands; `owner/repo` shorthand is GitHub-only, others use the full URL. |
+| **Maintain** | Bump `version` in `plugin.json` for a clean update boundary; you are the only user. | `/plugin marketplace update`; one maintainer per plugin; fixes land via merge request. Org-wide enforcement via managed settings. | Same, via the GitLab/other merge-request flow. | Same, plus a public changelog and a clear versioning policy. |
+
+If a cell says "N/A, stop here" for the chosen branch, say so explicitly and move on. Do not pad it.
+
+Reference files:
+- **references/assemble.md**: plugin folder layout, the manifest fields, moving existing `~/.claude/` tools in, local `claude --plugin-dir` testing, skill namespacing, `claude plugin validate`.
+- **references/marketplace.md**: the `marketplace.json` shape, per-host `source` types, add and install commands, public vs private and auth.
+- **references/team-enablement.md**: project `.claude/settings.json` auto-enable, org-wide managed-settings enforcement.
+- **references/maintain.md**: updates, version bumps, ownership, fixes via merge request.
+
+Load only the references the current branch and phase need. Progressive disclosure.
+
+## Phase 1: Analyze
+
+Decide what goes in the bundle before you build the folder.
+
+1. **Inventory the tools.** List every skill, hook, agent, and MCP server the plugin should carry. A plugin can hold any mix; each type sits in its own place in the layout (see assemble.md).
+2. **Draw the boundary.** One plugin is one coherent unit that updates together. If two groups of tools serve different audiences or version on different clocks, that is two plugins.
+3. **Name it.** Kebab-case, distinct, describes the bundle not one tool inside it. The name becomes the skill namespace (`/my-plugin:skill`) and the marketplace entry key.
+4. **Note what already exists loose.** Tools sitting in `~/.claude/skills`, `~/.claude/agents`, or a personal `settings.json` will move into the plugin and the loose originals get deleted, so you do not run duplicates (assemble.md covers this).
+
+Deliverable: the plugin name plus a list of what it will contain. Confirm with the user before assembling.
+
+## Phase 2: Assemble
+
+Read **references/assemble.md**. Build the folder to the layout, write the manifest, then test locally.
+
+1. Create the plugin dir. Only `plugin.json` goes inside `.claude-plugin/`; `skills/`, `agents/`, `hooks/hooks.json`, and `.mcp.json` sit at the plugin ROOT.
+2. Write `.claude-plugin/plugin.json` with `name`, `description`, `version`, `author`.
+3. Move the inventoried tools in and delete the loose originals.
+4. Test: `claude --plugin-dir ./my-plugin` (it also accepts a `.zip`). Confirm every bundled tool shows up and one invokes. Validate the manifest with `claude plugin validate .`.
+
+For a "Just me" bundle this is the last substantive phase: it is loaded, it works, stop.
+
+## Phase 3: Ship
+
+Only for team or public. Read **references/marketplace.md**, and **references/team-enablement.md** for the auto-enable path. Branch on the git-host answer.
+
+1. Create the marketplace repo, or reuse an existing one. Add `.claude-plugin/marketplace.json` at its root with `name`, `owner`, and a `plugins[]` entry for this plugin.
+2. Set the entry `source` by host: relative `"./path"` if the plugin lives in the same repo, `{source:"github", repo:"owner/repo"}` for GitHub, or `{source:"url", url:"https://...git"}` for GitLab, Bitbucket, or self-hosted. There is no `gitlab` source type.
+3. Choose public vs private to match the audience. A private repo keeps a team plugin internal; a public repo is installable by anyone who knows it, running arbitrary code with the user's privileges, so make that choice deliberately.
+4. Confirm the install path a colleague runs: `/plugin marketplace add owner/repo` (GitHub shorthand) or the full `https://...git` URL for any other host, then `/plugin install name@marketplace`.
+
+## Phase 4: Maintain
+
+Read **references/maintain.md**. Branch lightly; the mechanics are the same across hosts.
+
+1. **Updates.** Users pull new versions with `/plugin marketplace update` or at startup.
+2. **Version boundary.** Bump `version` in `plugin.json` so users get a clean update boundary; omit it and Claude Code treats every commit SHA as a new version.
+3. **Ownership.** One maintainer per plugin. Fixes land via merge request, since the source is a git repo.
+4. **Org controls (team/public, admin job).** Force-install, an allowlist (`strictKnownMarketplaces`), or a denylist (`blockedMarketplaces`) live in a managed-settings file, set by an admin, not per user (team-enablement.md).
+
+## Done criteria
+
+- The plugin loads via `claude --plugin-dir` with no errors, every bundled tool shows up, and at least one invokes.
+- It is on a marketplace repo the resolved audience can reach, public or private matching that audience (or, for "Just me", it is loaded locally and there is no marketplace).
+- The user can name exactly how a colleague installs it, two-command or one-click, matching the audience answer.

--- a/plugins/tool-build-kit/skills/build-plugin/references/assemble.md
+++ b/plugins/tool-build-kit/skills/build-plugin/references/assemble.md
@@ -1,0 +1,60 @@
+# Assemble: folder, manifest, local test
+
+Build the plugin folder, write its manifest, move your loose tools in, and test it before shipping anything.
+
+## Folder layout
+
+Only `plugin.json` lives inside `.claude-plugin/`. Everything else sits at the plugin ROOT:
+
+```
+my-plugin/
+  .claude-plugin/
+    plugin.json          # the manifest, the ONLY thing inside .claude-plugin/
+  skills/
+    my-skill/
+      SKILL.md
+  agents/
+    my-agent.md
+  hooks/
+    hooks.json
+  .mcp.json              # MCP servers this plugin ships
+  README.md
+```
+
+`skills/`, `agents/`, `hooks/hooks.json`, and `.mcp.json` are auto-discovered at the plugin root. A plugin can carry any mix of these; none is required.
+
+## The manifest
+
+`.claude-plugin/plugin.json`:
+
+```json
+{
+  "name": "my-plugin",
+  "description": "One line on what the bundle does.",
+  "version": "0.1.0",
+  "author": { "name": "Your Name" }
+}
+```
+
+`name` (kebab-case) and `description` are the essentials; `version` (semver) gives users a clean update boundary; `author` is an object with `name`. Keep `name`/`version`/`description` in sync with any marketplace entry that points at this plugin.
+
+To ship MCP servers, add a `.mcp.json` at the plugin root (auto-discovered) or point `plugin.json` at one with an `mcpServers` key. Use `${CLAUDE_PLUGIN_ROOT}` for any bundled paths, since marketplace plugins are copied into `~/.claude/plugins/cache`.
+
+## Move existing tools in, delete the originals
+
+Tools you already run loose from `~/.claude/` (a skill in `~/.claude/skills`, an agent in `~/.claude/agents`, hooks in your personal `settings.json`) should move INTO the plugin folder. Then delete the loose originals, otherwise the tool loads twice and you run duplicates. After moving, the plugin is the single source for those tools.
+
+## Scaffold and validate
+
+- `claude plugin init` scaffolds a new plugin skeleton.
+- `claude plugin validate .` (or `claude plugin validate ./my-plugin`) checks the manifest and layout.
+
+## Local test
+
+```bash
+claude --plugin-dir ./my-plugin
+```
+
+Loads the plugin straight from disk, no marketplace needed. It also accepts a `.zip` of the plugin. In the session, confirm every bundled tool shows up and invoke at least one. Skills are namespaced by plugin: a skill named `my-skill` in plugin `my-plugin` is invoked as `/my-plugin:my-skill`.
+
+This local path is the whole story for a "Just me" bundle: assemble, load, verify, stop.

--- a/plugins/tool-build-kit/skills/build-plugin/references/assemble.md
+++ b/plugins/tool-build-kit/skills/build-plugin/references/assemble.md
@@ -36,7 +36,7 @@ my-plugin/
 }
 ```
 
-`name` (kebab-case) and `description` are the essentials; `version` (semver) gives users a clean update boundary; `author` is an object with `name`. Keep `name`/`version`/`description` in sync with any marketplace entry that points at this plugin.
+`name` (kebab-case) and `description` are the essentials; `version` (semver) gives users a clean update boundary; `author` is an object with `name`. Keep `name`/`description` in sync with any marketplace entry that points at this plugin, but do not repeat `version` there: `plugin.json` always wins, so a stale marketplace version is silently ignored (see maintain.md).
 
 To ship MCP servers, add a `.mcp.json` at the plugin root (auto-discovered) or point `plugin.json` at one with an `mcpServers` key. Use `${CLAUDE_PLUGIN_ROOT}` for any bundled paths, since marketplace plugins are copied into `~/.claude/plugins/cache`.
 
@@ -46,8 +46,8 @@ Tools you already run loose from `~/.claude/` (a skill in `~/.claude/skills`, an
 
 ## Scaffold and validate
 
-- `claude plugin init` scaffolds a new plugin skeleton.
-- `claude plugin validate .` (or `claude plugin validate ./my-plugin`) checks the manifest and layout.
+- `claude plugin init <name>` scaffolds a new plugin skeleton INTO your skills directory (`~/.claude/skills/<name>/`), not the current folder. A plugin living there auto-loads every session as `<name>@skills-dir`, no `--plugin-dir` flag needed, which is the smoothest path for a personal ("Just me") bundle.
+- `claude plugin validate .` (or `claude plugin validate ./my-plugin`) checks the manifest and layout. It needs no login.
 
 ## Local test
 
@@ -56,5 +56,7 @@ claude --plugin-dir ./my-plugin
 ```
 
 Loads the plugin straight from disk, no marketplace needed. It also accepts a `.zip` of the plugin. In the session, confirm every bundled tool shows up and invoke at least one. Skills are namespaced by plugin: a skill named `my-skill` in plugin `my-plugin` is invoked as `/my-plugin:my-skill`.
+
+`claude --plugin-dir` opens an interactive session, so it needs you logged in. For a quick login-free check that the plugin is well-formed and its tools are discovered, use `claude plugin validate ./my-plugin` and `claude plugin details my-plugin`.
 
 This local path is the whole story for a "Just me" bundle: assemble, load, verify, stop.

--- a/plugins/tool-build-kit/skills/build-plugin/references/maintain.md
+++ b/plugins/tool-build-kit/skills/build-plugin/references/maintain.md
@@ -8,7 +8,7 @@ Users pull new versions with `/plugin marketplace update`, or Claude Code checks
 
 ## Version boundary
 
-Set `version` (semver) in `plugin.json`. Users only get an update when you bump it, so a version bump is a clean, intentional update boundary. Omit `version` everywhere and Claude Code falls back to the git commit SHA, treating every commit as a new version, which is noisier than you usually want. When a plugin's `plugin.json` and its marketplace entry disagree, `plugin.json` wins.
+Set `version` (semver) in `plugin.json`. Users only get an update when you bump it, so a version bump is a clean, intentional update boundary. Omit `version` everywhere and Claude Code falls back to the git commit SHA, treating every commit as a new version, which is noisier than you usually want. Claude Code resolves the version from `plugin.json` first, then the marketplace entry, then the commit SHA, so do not set `version` in both places: `plugin.json` always wins, and a stale one there silently masks the value in the marketplace entry.
 
 ## Ownership
 

--- a/plugins/tool-build-kit/skills/build-plugin/references/maintain.md
+++ b/plugins/tool-build-kit/skills/build-plugin/references/maintain.md
@@ -1,0 +1,19 @@
+# Maintain: updates, versions, ownership
+
+Once a plugin is shipped, keep it updatable and owned.
+
+## Updates
+
+Users pull new versions with `/plugin marketplace update`, or Claude Code checks at startup. There is nothing to redeploy on your side beyond pushing to the marketplace repo.
+
+## Version boundary
+
+Set `version` (semver) in `plugin.json`. Users only get an update when you bump it, so a version bump is a clean, intentional update boundary. Omit `version` everywhere and Claude Code falls back to the git commit SHA, treating every commit as a new version, which is noisier than you usually want. When a plugin's `plugin.json` and its marketplace entry disagree, `plugin.json` wins.
+
+## Ownership
+
+One maintainer per plugin. Because the source is a git repo, fixes and new tools land the normal way: a merge request against the marketplace repo, reviewed and merged, then a version bump. Contributors do not need any special plugin tooling, just the git host's PR/MR flow.
+
+## Admin controls (team/org)
+
+Org-wide update and install policy (force-install, allowlist, denylist) lives in a managed-settings file set by an administrator, not per user. See `team-enablement.md`. Keep the maintainer role and the admin role distinct: the maintainer ships versions, the admin decides which marketplaces and plugins are allowed on managed machines.

--- a/plugins/tool-build-kit/skills/build-plugin/references/marketplace.md
+++ b/plugins/tool-build-kit/skills/build-plugin/references/marketplace.md
@@ -1,0 +1,55 @@
+# Marketplace: list, host, install
+
+A marketplace is a git repo with a `marketplace.json` that lists one or more plugins. Colleagues add the marketplace once, then install plugins from it.
+
+> For the plugin-packaging and marketplace mechanics shared with build-mcp, see `../../build-mcp/references/distribute-marketplace.md`. This file stays self-contained; that one goes deeper on shipping an MCP server specifically.
+
+## The manifest
+
+`.claude-plugin/marketplace.json` at the marketplace repo root:
+
+```json
+{
+  "name": "company-tools",
+  "owner": { "name": "DevTools Team", "email": "devtools@example.com" },
+  "plugins": [
+    {
+      "name": "my-plugin",
+      "source": "./plugins/my-plugin",
+      "description": "What the bundle does."
+    }
+  ]
+}
+```
+
+Required: top-level `name` (kebab-case), `owner.name`, and a `plugins[]` array. Each entry needs at least `name`, `source`, and `description`.
+
+## Source by git host
+
+The `source` field tells Claude Code where the plugin lives:
+
+- **Same repo**: a relative path string, `"./plugins/my-plugin"`.
+- **GitHub**: `{ "source": "github", "repo": "owner/repo" }`.
+- **GitLab, Bitbucket, self-hosted**: `{ "source": "url", "url": "https://gitlab.com/team/plugins.git" }`. There is NO `gitlab` source type; the generic `url` source covers every non-GitHub host.
+
+## Add and install
+
+```bash
+# GitHub: owner/repo shorthand works
+/plugin marketplace add owner/repo
+
+# Any other host: full .git URL
+/plugin marketplace add https://gitlab.com/team/plugins.git
+
+# then install a plugin from the added marketplace
+/plugin install my-plugin@company-tools
+```
+
+The `owner/repo` shorthand is GitHub-only. Every other host uses the full `https://...git` URL. Anthropic's public plugin directory is likewise a GitHub-only convenience; a GitLab marketplace works directly, no GitHub mirror needed.
+
+## Public vs private, and auth
+
+- A **private** repo keeps a team plugin internal. Public GitHub repos also work for team enablement (the team-install load path was fixed around Claude Code v2.1.195); a private repo is an option for keeping tools internal, not a requirement.
+- **Manual** `/plugin` use rides your existing git credential helper, so a private repo just works if you can already clone it.
+- **Background auto-updates** read `GITHUB_TOKEN` or `GITLAB_TOKEN` from the environment for private repos.
+- Making a marketplace **public** is a real decision: anyone who knows the repo can add and install from it, and plugins run arbitrary code with the user's privileges. Do it deliberately.

--- a/plugins/tool-build-kit/skills/build-plugin/references/marketplace.md
+++ b/plugins/tool-build-kit/skills/build-plugin/references/marketplace.md
@@ -12,6 +12,7 @@ A marketplace is a git repo with a `marketplace.json` that lists one or more plu
 {
   "name": "company-tools",
   "owner": { "name": "DevTools Team", "email": "devtools@example.com" },
+  "description": "Internal DevTools plugins.",
   "plugins": [
     {
       "name": "my-plugin",
@@ -22,7 +23,7 @@ A marketplace is a git repo with a `marketplace.json` that lists one or more plu
 }
 ```
 
-Required: top-level `name` (kebab-case), `owner.name`, and a `plugins[]` array. Each entry needs at least `name`, `source`, and `description`.
+Required: top-level `name` (kebab-case), `owner.name`, and a `plugins[]` array. Each entry needs at least `name`, `source`, and `description`. Add a top-level `description` too: without it `claude plugin validate` warns `No marketplace description provided`.
 
 ## Source by git host
 
@@ -31,25 +32,28 @@ The `source` field tells Claude Code where the plugin lives:
 - **Same repo**: a relative path string, `"./plugins/my-plugin"`.
 - **GitHub**: `{ "source": "github", "repo": "owner/repo" }`.
 - **GitLab, Bitbucket, self-hosted**: `{ "source": "url", "url": "https://gitlab.com/team/plugins.git" }`. There is NO `gitlab` source type; the generic `url` source covers every non-GitHub host.
+- **A subdirectory of a monorepo**: `{ "source": "git-subdir", "url": "https://...git", "path": "plugins/my-plugin" }`, which sparse-clones just that path. Handy when many plugins live in one repo.
 
 ## Add and install
 
+Run these at your terminal as `claude plugin ...`, or inside a Claude Code session as the `/plugin ...` slash form. The terminal form:
+
 ```bash
 # GitHub: owner/repo shorthand works
-/plugin marketplace add owner/repo
+claude plugin marketplace add owner/repo
 
 # Any other host: full .git URL
-/plugin marketplace add https://gitlab.com/team/plugins.git
+claude plugin marketplace add https://gitlab.com/team/plugins.git
 
 # then install a plugin from the added marketplace
-/plugin install my-plugin@company-tools
+claude plugin install my-plugin@company-tools
 ```
 
-The `owner/repo` shorthand is GitHub-only. Every other host uses the full `https://...git` URL. Anthropic's public plugin directory is likewise a GitHub-only convenience; a GitLab marketplace works directly, no GitHub mirror needed.
+In a session the same commands are `/plugin marketplace add ...` and `/plugin install ...`. The `owner/repo` shorthand is GitHub-only. Every other host uses the full `https://...git` URL. Anthropic's public plugin directory is likewise a GitHub-only convenience; a GitLab marketplace works directly, no GitHub mirror needed.
 
 ## Public vs private, and auth
 
-- A **private** repo keeps a team plugin internal. Public GitHub repos also work for team enablement (the team-install load path was fixed around Claude Code v2.1.195); a private repo is an option for keeping tools internal, not a requirement.
+- A **private** repo keeps a team plugin internal. Public GitHub repos work for team enablement just as well; a private repo is an option for keeping tools internal, not a requirement.
 - **Manual** `/plugin` use rides your existing git credential helper, so a private repo just works if you can already clone it.
 - **Background auto-updates** read `GITHUB_TOKEN` or `GITLAB_TOKEN` from the environment for private repos.
 - Making a marketplace **public** is a real decision: anyone who knows the repo can add and install from it, and plugins run arbitrary code with the user's privileges. Do it deliberately.

--- a/plugins/tool-build-kit/skills/build-plugin/references/team-enablement.md
+++ b/plugins/tool-build-kit/skills/build-plugin/references/team-enablement.md
@@ -1,0 +1,34 @@
+# Team enablement: one-click and org-wide
+
+Two levers past a plain marketplace: a project-level auto-enable that prompts teammates on trust, and an org-wide managed-settings enforcement that an admin controls.
+
+## Project auto-enable (one-click for teammates)
+
+Commit a `.claude/settings.json` to the project repo. Anyone who trusts the folder gets a one-click prompt to install the listed plugins.
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "company-tools": {
+      "source": { "source": "github", "repo": "org/plugins-repo" }
+    }
+  },
+  "enabledPlugins": {
+    "my-plugin@company-tools": true
+  }
+}
+```
+
+- `extraKnownMarketplaces` is an object keyed by marketplace name; the value is `{ "source": { ... } }` using the same source shapes as a marketplace entry (`github` repo, or `url` for GitLab/other).
+- `enabledPlugins` is an object keyed by `"plugin@marketplace"` with a boolean value.
+- On trusting the folder, teammates are prompted to install; they do not run the `/plugin` commands by hand.
+
+## Org-wide enforcement (admin job)
+
+For a whole org, an admin uses a managed-settings file (system-level, not per-user) to enforce policy:
+
+- **Force-install**: push plugins to every user automatically.
+- **`strictKnownMarketplaces`**: an allowlist; only these marketplaces may be added.
+- **`blockedMarketplaces`**: a denylist of marketplaces users may not add.
+
+This is an administrator action on managed machines, not something an individual sets. Flag it as such when the audience is a large org.


### PR DESCRIPTION
## Summary

Adds a **build-plugin** skill to the `tool-build-kit` plugin, a sibling to the existing `build-mcp` skill.

- `build-mcp` builds ONE MCP server. `build-plugin` bundles MANY tools (skills, hooks, agents, MCP servers, including servers produced by build-mcp) into one installable Claude Code plugin and distributes it via a marketplace. When build-mcp reaches its Distribute phase for a team or public audience, it hands off here.
- Same shape as build-mcp: establish context with `AskUserQuestion` FIRST (Q1 audience: just me / team-org / public; Q2 git host, skipped for "just me"), confirm the resolved tuple, then follow a branch table across four phases: **Analyze, Assemble, Ship, Maintain**. Phase-0 answers gate Ship and Maintain.
- Four thin, on-demand references: `assemble.md` (folder layout, manifest, local `claude --plugin-dir` test, validation), `marketplace.md` (`marketplace.json` shape, per-host `source` types, install commands, public vs private + auth), `team-enablement.md` (project `.claude/settings.json` auto-enable, org-wide managed settings), `maintain.md` (updates, version bumps, ownership, fixes via merge request).

Mirrors build-mcp's structure, density, and voice throughout (frontmatter with name+description only, orienting sentence, "How this relates to", phase list, Phase 0, branch table as the spine, per-phase reference loading, done criteria). No emojis, no em-dashes.

## Manifest / version / changelog changes

- `tool-build-kit` bumped **v1.6.0 -> v1.7.0**; description broadened to cover building an MCP server AND bundling tools into a shareable plugin, kept in sync across both `plugin.json` markers and both marketplace manifests (`.claude-plugin/marketplace.json`, `.agents/plugins/marketplace.json`).
- `tool-build-kit/README.md` rewritten to document both skills.
- Root `README.md`: version badge **1.9.0 -> 1.10.0**, refreshed tool-build-kit description + skill count.
- `CHANGELOG.md`: new `## [1.10.0] - 2026-07-07` entry (Added: build-plugin skill; Changed: tool-build-kit v1.7.0 + broadened description).

## Verification

- `claude plugin validate ./plugins/tool-build-kit` -> Validation passed.
- `claude --plugin-dir ./plugins/tool-build-kit` loads with no errors; both `build-mcp` and `build-plugin` skills register.
- JSON validated on both plugin.json files and both marketplace.json files.
- Both plugin.json versions = 1.7.0; all four tool-build-kit descriptions identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)