### PR TITLE
Fix session-tools marketplace sync (v1.10.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog and this project follows Semantic Versioning.
 
+## [1.10.1] - 2026-07-09
+
+### Fixed
+
+- `session-tools` was skipped during marketplace sync ("requires .claude-plugin/plugin.json or a top-level SKILL.md"). The plugin shipped only the top-level Antigravity `plugin.json` marker and was missing the Claude Code `.claude-plugin/plugin.json` manifest that every other plugin carries. Added the `.claude-plugin/plugin.json` manifest (identical contents); the Antigravity marker is unchanged, so both hosts now resolve the plugin.
+
 ## [1.10.0] - 2026-07-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TechWolf AI-First Toolkit
 
-![MIT License](https://img.shields.io/badge/license-MIT-blue.svg) ![v1.10.0](https://img.shields.io/badge/version-1.10.0-green.svg) ![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-blueviolet.svg) ![Codex](https://img.shields.io/badge/Codex-compatible-orange.svg) ![Antigravity](https://img.shields.io/badge/Antigravity-compatible-4285F4.svg) ![agentskills.io](https://img.shields.io/badge/agentskills.io-spec-lightgrey.svg)
+![MIT License](https://img.shields.io/badge/license-MIT-blue.svg) ![v1.10.1](https://img.shields.io/badge/version-1.10.1-green.svg) ![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-blueviolet.svg) ![Codex](https://img.shields.io/badge/Codex-compatible-orange.svg) ![Antigravity](https://img.shields.io/badge/Antigravity-compatible-4285F4.svg) ![agentskills.io](https://img.shields.io/badge/agentskills.io-spec-lightgrey.svg)
 
 Open-source agent skills from [TechWolf](https://techwolf.ai)'s [AI-First Bootcamp](https://ai-first.techwolf.ai), for Claude Code, Codex, and Google Antigravity.
 

--- a/plugins/session-tools/.claude-plugin/plugin.json
+++ b/plugins/session-tools/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "session-tools",
+  "version": "1.0.0",
+  "description": "Two skills for session continuity. session-search finds past Claude Code and Cowork sessions by title, cwd, time range, or full-text content. handoff writes a tight resume note so a fresh session picks up exactly where the last one stopped."
+}


### PR DESCRIPTION
## Problem

The marketplace sync skipped `session-tools`:

> Plugin 'session-tools' requires .claude-plugin/plugin.json or a top-level SKILL.md declaring plugin components

## Cause

`session-tools` shipped only the top-level Antigravity `plugin.json` marker and was missing the Claude Code `.claude-plugin/plugin.json` manifest that every other plugin in the repo carries.

## Fix

- Add `plugins/session-tools/.claude-plugin/plugin.json` (identical contents to the top-level marker). The Antigravity marker is unchanged, so both hosts resolve the plugin.
- Bump repo version to 1.10.1 (README badge + CHANGELOG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKb6n4gNX759fo1NCWzZLc