### PR TITLE
Add goal-prompt skill to session-tools (v1.11.0)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -54,7 +54,7 @@
       "source": { "source": "local", "path": "./plugins/session-tools" },
       "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" },
       "category": "Productivity",
-      "description": "Two skills for session continuity. session-search finds past Claude Code and Cowork sessions by title, cwd, time range, or full-text content. handoff writes a tight resume note so a fresh session picks up exactly where the last one stopped."
+      "description": "Three skills for session continuity and autonomous runs. session-search finds past Claude Code and Cowork sessions by title, cwd, time range, or full-text content. handoff writes a tight resume note so a fresh session picks up exactly where the last one stopped. goal-prompt turns a task into a ready-to-paste /goal command with a measurable end state, proof, and constraints."
     },
     {
       "name": "tool-build-kit",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -41,7 +41,7 @@
     {
       "name": "session-tools",
       "source": "./plugins/session-tools",
-      "description": "Two skills for session continuity. session-search finds past Claude Code and Cowork sessions by title, cwd, time range, or full-text content. handoff writes a tight resume note so a fresh session picks up exactly where the last one stopped."
+      "description": "Three skills for session continuity and autonomous runs. session-search finds past Claude Code and Cowork sessions by title, cwd, time range, or full-text content. handoff writes a tight resume note so a fresh session picks up exactly where the last one stopped. goal-prompt turns a task into a ready-to-paste /goal command with a measurable end state, proof, and constraints."
     },
     {
       "name": "tool-build-kit",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog and this project follows Semantic Versioning.
 
+## [1.11.0] - 2026-07-10
+
+### Added
+
+- `goal-prompt` skill in `session-tools`: turns a task, plan, or feature request into a ready-to-paste `/goal` command for an autonomous Claude Code run. Enforces the three-part shape the `/goal` evaluator needs: a measurable end state, a proof demonstrable in Claude's own output, and constraints that must not drift.
+
+### Changed
+
+- `session-tools` plugin bumped to v1.1.0; description updated in both `plugin.json` markers and both marketplace manifests.
+
 ## [1.10.1] - 2026-07-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TechWolf AI-First Toolkit
 
-![MIT License](https://img.shields.io/badge/license-MIT-blue.svg) ![v1.10.1](https://img.shields.io/badge/version-1.10.1-green.svg) ![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-blueviolet.svg) ![Codex](https://img.shields.io/badge/Codex-compatible-orange.svg) ![Antigravity](https://img.shields.io/badge/Antigravity-compatible-4285F4.svg) ![agentskills.io](https://img.shields.io/badge/agentskills.io-spec-lightgrey.svg)
+![MIT License](https://img.shields.io/badge/license-MIT-blue.svg) ![v1.11.0](https://img.shields.io/badge/version-1.11.0-green.svg) ![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-blueviolet.svg) ![Codex](https://img.shields.io/badge/Codex-compatible-orange.svg) ![Antigravity](https://img.shields.io/badge/Antigravity-compatible-4285F4.svg) ![agentskills.io](https://img.shields.io/badge/agentskills.io-spec-lightgrey.svg)
 
 Open-source agent skills from [TechWolf](https://techwolf.ai)'s [AI-First Bootcamp](https://ai-first.techwolf.ai), for Claude Code, Codex, and Google Antigravity.
 
@@ -14,7 +14,7 @@ claude plugin marketplace add techwolf-ai/ai-first-toolkit
 
 ## Plugins at a glance
 
-8 plugins, 27 skills. One install command each.
+8 plugins, 28 skills. One install command each.
 
 | Plugin | What it does | Install |
 |--------|--------------|---------|
@@ -23,14 +23,14 @@ claude plugin marketplace add techwolf-ai/ai-first-toolkit
 | **people-management** | AI-augmented management: 1:1 prep, meeting prep, triage, performance cycles | `claude plugin install people-management@techwolf-ai-first` |
 | **knowledge-base** | Evidence-backed KB; every answer cites literal quotes from your files | `claude plugin install knowledge-base@techwolf-ai-first` |
 | **ai-adoption** | Claude history analytics: token-doctor and task-profile | `claude plugin install ai-adoption@techwolf-ai-first` |
-| **session-tools** | Session continuity: find past sessions, write handoff notes | `claude plugin install session-tools@techwolf-ai-first` |
+| **session-tools** | Session continuity: find past sessions, write handoff notes, craft /goal prompts | `claude plugin install session-tools@techwolf-ai-first` |
 | **techwolf-brand-kit** | Official TechWolf logo assets (SVG + PNG) for AI-generated outputs | `claude plugin install techwolf-brand-kit@techwolf-ai-first` |
 | **tool-build-kit** | Build an MCP server and bundle your tools into a shareable plugin, end to end | `claude plugin install tool-build-kit@techwolf-ai-first` |
 
 <a name="not-using-claude-code"></a>
 Not using Claude Code? Every skill follows the [agentskills.io](https://agentskills.io) spec and installs into Codex or Google Antigravity via [`./install.sh`](#codex). One caveat on per-platform support:
 
-- **Cross-platform (all skills except below):** ai-firstify, content-studio, knowledge-base, people-management, techwolf-brand-kit, tool-build-kit, and the `handoff` skill in session-tools. These operate on your project files and prompts, so they work the same on Claude Code, Codex, and Antigravity.
+- **Cross-platform (all skills except below):** ai-firstify, content-studio, knowledge-base, people-management, techwolf-brand-kit, tool-build-kit, and the `handoff` and `goal-prompt` skills in session-tools. These operate on your project files and prompts, so they work the same on Claude Code, Codex, and Antigravity.
 - **Host-aware (ai-adoption and session-tools):** token-doctor, task-profile, and session-search read agent **session history** off disk, which is per-platform. Each script detects the host (via the `platform` field `install.sh` stamps into each installed skill; override with `AI_FIRST_PLATFORM=claude|codex|antigravity`) and routes or degrades rather than scanning the wrong path. Support today:
 
   | Skill | Plugin | Claude Code / Cowork | Codex (`~/.codex/sessions`) | Antigravity |
@@ -89,10 +89,11 @@ Two skills for analyzing your Claude Code + Cowork session history. Local-only, 
 
 ### session-tools: Session Continuity
 
-Two skills for finding past sessions and preserving the current one.
+Three skills for finding past sessions, preserving the current one, and launching autonomous runs.
 
 - **session-search**: finds a specific past session by title, working directory, time range, or free-text content across every transcript on disk. Works on Claude Code / Cowork and Codex; Antigravity degrades with a clear message.
 - **handoff**: writes a tight `HANDOFF.md` resume note at the current working directory so a fresh session can continue without replaying the conversation. No platform dependency; works on Claude Code, Cowork, and Codex.
+- **goal-prompt**: turns a task, plan, or feature request into a ready-to-paste `/goal` command: one measurable end state, a demonstrable proof, and the constraints that must not drift. Targets Claude Code's `/goal` autonomous mode.
 
 ### techwolf-brand-kit: Brand Assets
 
@@ -188,7 +189,7 @@ ai-first-toolkit/
 │   ├── people-management/      # Management tooling (8 skills, 5 reference docs)
 │   ├── knowledge-base/         # Evidence-backed KB (4 skills, templates, index + verify scripts)
 │   ├── ai-adoption/            # Claude history analytics (2 skills: token-doctor, task-profile)
-│   ├── session-tools/          # Session continuity (2 skills: session-search, handoff)
+│   ├── session-tools/          # Session continuity (3 skills: session-search, handoff, goal-prompt)
 │   ├── techwolf-brand-kit/     # Brand assets (logo variants in SVG + PNG)
 │   └── tool-build-kit/         # MCP + plugin builder (2 skills: build-mcp, build-plugin)
 ├── install.sh                  # Codex + Antigravity skill installer

--- a/plugins/session-tools/.claude-plugin/plugin.json
+++ b/plugins/session-tools/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "session-tools",
-  "version": "1.0.0",
-  "description": "Two skills for session continuity. session-search finds past Claude Code and Cowork sessions by title, cwd, time range, or full-text content. handoff writes a tight resume note so a fresh session picks up exactly where the last one stopped."
+  "version": "1.1.0",
+  "description": "Three skills for session continuity and autonomous runs. session-search finds past Claude Code and Cowork sessions by title, cwd, time range, or full-text content. handoff writes a tight resume note so a fresh session picks up exactly where the last one stopped. goal-prompt turns a task into a ready-to-paste /goal command with a measurable end state, proof, and constraints."
 }

--- a/plugins/session-tools/README.md
+++ b/plugins/session-tools/README.md
@@ -1,9 +1,10 @@
 # Session Tools
 
-Two skills for session continuity — finding past sessions and preserving the current one.
+Three skills for session continuity — finding past sessions, preserving the current one, and launching autonomous runs.
 
 - **`session-search`**, find a specific past session by title, working directory, time range, or free-text content across every transcript on disk.
 - **`handoff`**, write a tight resume note at the end of a session so the next session can pick up exactly where you left off, without replaying the conversation.
+- **`goal-prompt`**, turn a task, plan, or feature request into a ready-to-paste `/goal` command with a measurable end state, a demonstrable proof, and the constraints that must not drift.
 
 ## Getting Started
 
@@ -17,6 +18,7 @@ Two skills for session continuity — finding past sessions and preserving the c
 |-------|-------------|
 | `/session-search` | Find a past session by title, working directory, time range, or full-text content |
 | `/handoff` | Write a tight resume note so the next session starts from exactly where you stopped |
+| `/goal-prompt` | Turn a task into a ready-to-paste `/goal` command for an autonomous Claude Code run |
 
 ## `session-search`
 
@@ -100,12 +102,29 @@ Sample phrasings:
 
 If the directory is a git repo, the skill offers to add `HANDOFF.md` to `.gitignore` rather than staging it.
 
+## `goal-prompt`
+
+Turns whatever you are trying to accomplish into a single ready-to-paste `/goal` command for an autonomous Claude Code run. A good goal has three parts, and the skill enforces all of them:
+
+1. A measurable end state: one concrete finish line (a passing test, a file that must exist, a count, an empty queue).
+2. A stated proof: exactly how Claude demonstrates completion in its own output, since the `/goal` evaluator only reads the transcript.
+3. Constraints that must not drift: files not to touch, framing to keep, no network or prod.
+
+Output is one fenced `/goal ...` block plus 2-3 lines explaining why the end state is demonstrable.
+
+Sample phrasings:
+
+- `give me a goal`
+- `turn this into a goal`
+- `make this a /goal`
+- `/goal-prompt`
+
 ## Requirements
 
 - Claude Code ≥ 2.x
 - session-search: Python ≥ 3.10 (stdlib only; no pip install needed), macOS primary; Linux falls back to Code-only; Windows supported for Cowork path resolution
-- handoff: no additional requirements
+- handoff, goal-prompt: no additional requirements
 
 ## Attribution
 
-Skill sources: `skills/session-search/`, `skills/handoff/`.
+Skill sources: `skills/session-search/`, `skills/handoff/`, `skills/goal-prompt/`.

--- a/plugins/session-tools/plugin.json
+++ b/plugins/session-tools/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "session-tools",
-  "version": "1.0.0",
-  "description": "Two skills for session continuity. session-search finds past Claude Code and Cowork sessions by title, cwd, time range, or full-text content. handoff writes a tight resume note so a fresh session picks up exactly where the last one stopped."
+  "version": "1.1.0",
+  "description": "Three skills for session continuity and autonomous runs. session-search finds past Claude Code and Cowork sessions by title, cwd, time range, or full-text content. handoff writes a tight resume note so a fresh session picks up exactly where the last one stopped. goal-prompt turns a task into a ready-to-paste /goal command with a measurable end state, proof, and constraints."
 }

--- a/plugins/session-tools/skills/goal-prompt/SKILL.md
+++ b/plugins/session-tools/skills/goal-prompt/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: goal-prompt
+description: Turn a task, plan, or feature request into a ready-to-paste Claude Code /goal command — a single completion condition with a measurable end state, a demonstrable proof, and the constraints that must not drift. Use when the user says "give me a goal", "goal prompt", "make this a /goal", "turn this into a goal", or wants an autonomous long-running objective for Claude Code.
+---
+
+# goal-prompt
+
+Produce a ready-to-paste `/goal ...` command from whatever the user is trying to accomplish.
+
+## Why the shape matters
+`/goal` runs Claude autonomously until a separate fast-model evaluator decides, after a turn, that the condition is met. The evaluator does NOT run commands or read files itself — it only reads Claude's output. So the completion condition must be demonstrable by Claude's own output, never by hidden side effects.
+
+## A good goal has three parts
+1. **Measurable end state** — one concrete finish line: a test/exit code, a file that must exist, a count, an empty queue, named sections present.
+2. **Stated proof** — exactly how Claude demonstrates it: the command to run and its expected result, or the grep/check whose output shows done. Phrase it as "Prove it by showing X."
+3. **Constraints that must not drift** — what stays unchanged on the way there: files not to touch, framing to keep, no network/prod, don't modify tests.
+
+## How to write it
+- One sentence of objective, then `Done when: <end state + proof>`, then `Constraints that must not change: <list>`.
+- If the full spec is long, point to a plan/doc file (e.g. a path under `~/.claude/plans/` or `docs/`) and keep the goal itself scannable.
+- Make the proof something the transcript can show: prefer `command exits 0` + a summary line, or `grep` for markers, over vague "it works".
+- Translate conditions the evaluator can't see ("the UI looks good") into an observable check.
+- Keep constraints tight enough to stop scope creep, not so rigid they block the obvious path.
+
+## Output
+Give the user a single fenced block starting with `/goal`, then 2-3 lines explaining the end state, the proof, and why it's demonstrable. Nothing else.
+
+## Example
+```
+/goal Add a --json flag to the export CLI per docs/export-json.md. Done when: `pytest tests/test_export.py -q` exits 0 and `python -m app.export --json` prints valid JSON whose top-level keys include "rows" and "meta". Prove it by showing the pytest summary and the piped `... --json | jq keys` output. Constraints that must not change: only edit app/export.py and add tests/test_export.py; do not alter the existing CSV output path; no network.
+```
+Its finish line is a passing test plus a schema check, both visible in Claude's transcript; the constraints pin the blast radius so the autonomous run can't wander.


### PR DESCRIPTION
## Problem

The goal-prompt skill (turn any task into a ready-to-paste /goal command for autonomous Claude Code runs) only existed as a personal user-level skill, so nobody else could install it.

## Change

- Add `goal-prompt` to `session-tools`: enforces the three-part /goal shape the evaluator needs (measurable end state, proof demonstrable in Claude's own output, constraints that must not drift). Single SKILL.md, no scripts, no platform dependency.
- `session-tools` bumped to v1.1.0 in both plugin.json markers; description synced in both marketplace manifests.
- Docs synced: root README (28 skills, plugin table, cross-platform note, layout tree), plugin README (new section + skills table), CHANGELOG 1.11.0 entry, version badge.

Preflight (`.claude/skills` gate) passes: 8 plugins, both manifests agree, version in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wr2PthPCn8Tpar5wJeu55